### PR TITLE
Static lint: forbid off-repo reads of mnemonic / private keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 # Runs on every PR / push to main:
+#   - lint: forbid off-repo reads of identity secrets (~5 sec, hard gate).
 #   - JVM unit tests (~3-5 min): Bip39, StellarStrKey, the cross-platform
 #     fixture for Bip39+HKDF+Curve25519+inbox-tag derivation. No emulator
 #     required.
@@ -19,9 +20,20 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint (no off-repo secret reads)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Static check — identity secrets
+        run: python3 scripts/lint-secrets.py
+
   jvm-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [lint]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -220,6 +220,42 @@ If any constant in the derivation chain drifts, one of these tests
 breaks loudly. **Do not change a salt / info / algorithm without
 coordinating with iOS and stellar-mls.**
 
+## Static lint — no off-repo secret reads
+
+`scripts/lint-secrets.py` is a default-deny check that any field-access
+read of `.nostrSecretKey`, `.blsSecretKey`, `.recoveryPhrase`, or
+`.entropy` outside an explicit allowlist fails the build. Wired into
+`.github/workflows/ci.yml` as the first hard gate — JVM unit tests
+won't even run if the linter trips.
+
+The allowlist (in the script itself; adding to it requires
+justification in code review):
+
+```
+app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+app/src/main/kotlin/chat/onym/android/identity/StoredSnapshot.kt
+app/src/main/kotlin/chat/onym/android/identity/Identity.kt
+app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
+```
+
+Note `IdentitySecretStore.kt` is **not** allowlisted — kotlinx.serialization
+generates the field-access code into `build/generated/`, which the
+linter skips, so the source file itself never reads these fields with
+`.fieldName` syntax.
+
+To allow a specific read, annotate the line itself or any `//`
+comment line in the contiguous block directly above with
+`// onym:allow-secret-read`. The one current suppression
+(`IdentityBootstrapScreen.kt`) cites the surrounding context.
+
+The linter also catches Kotlin destructuring with secret-named
+bindings (`val (entropy, …) = snapshot`) — the only way besides
+`.fieldName` to read the secrets in idiomatic Kotlin. Reflection-
+based reads are a known hole; flag in code review if you see one.
+
+To run locally: `python3 scripts/lint-secrets.py`. Exits 0 on
+success, 1 on any unsuppressed violation.
+
 ## Out of scope (future chunks)
 
 - `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods —

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityBootstrapScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityBootstrapScreen.kt
@@ -92,6 +92,13 @@ private fun IdentitySection(identity: Identity) {
     Labelled("Inbox tag (Nostr filter)") {
         Text(identity.inboxTag, style = monospace())
     }
+    // First-launch reveal of the freshly-generated mnemonic so the user
+    // can write it down before doing anything else with the app. Real
+    // onboarding / settings UI in a later chunk will gate this behind
+    // BiometricPrompt + an explicit "show recovery phrase" action; for
+    // now it shows on every app launch because there's nothing else for
+    // this scaffold screen to do.
+    // onym:allow-secret-read
     identity.recoveryPhrase?.let { phrase ->
         Labelled("Recovery phrase (BIP39, 12 words)") {
             Text(phrase, style = monospace())

--- a/scripts/lint-secrets.py
+++ b/scripts/lint-secrets.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Static check: forbid reads of identity secrets outside IdentityRepository.
+
+The mnemonic (BIP39 recovery phrase) and the persisted private key
+bytes (nostr secp256k1, BLS12-381) are owned by `IdentityRepository`.
+Any code outside the repository that reads them — even in passing —
+invites the secret to leak through logs, crash reports, screenshots,
+third-party SDK call sites, or accidental serialization.
+
+Default-deny. To allow a specific read, annotate the line itself or
+any `//` comment line in the contiguous block directly above with
+`// onym:allow-secret-read`. Each suppression should justify itself
+in code review and ideally name a reason inline:
+
+    // Rendered behind biometric on backup screen — production reveal
+    // UI owns the gating, this view just renders.
+    // onym:allow-secret-read
+    val phrase = identity.recoveryPhrase
+
+Usage:
+    python3 scripts/lint-secrets.py
+Exits 0 on success, 1 on any unsuppressed violation.
+
+Ported 1:1 from `onym-ios/scripts/lint-secrets.py`. Differences:
+
+- File globs are `**/*.kt` and `**/*.kts` (skipping `build/`,
+  `.gradle/`, and `**/generated/`).
+- Allowlist paths follow the Android module layout
+  (`app/src/{main,androidTest}/kotlin/...`).
+- Adds a destructuring check: `val (entropy, …) = thing` binds the
+  destructured value to a variable named `entropy` (or any other
+  secret-field name), which is the only Kotlin-specific way to read
+  these fields without going through `.fieldName` syntax. iOS
+  doesn't have this hole because Swift doesn't destructure structs
+  the same way.
+
+Known holes (deliberate gaps, flag in code review):
+
+- Reflection: `identity::class.memberProperties.forEach { println(it.get(identity)) }`
+  bypasses both regexes. Not worth catching with a static linter.
+- Renamed destructuring: `val (a, b, c) = storedSnapshot` with no
+  secret-named binding bypasses the destructuring regex but still
+  reads the fields. Caller intent is the same as `.entropy` etc.,
+  but the linter only flags the obvious case.
+- IDE-generated code (e.g. data class `copy()` overrides) that the
+  developer hand-edits to read fields. Out of scope.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Files allowed to construct / inspect secrets. Adding to this list
+# requires a justification in code review — these are the only files
+# that legitimately need to touch raw secret material.
+ALLOWED: set[str] = {
+    "app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt",
+    "app/src/main/kotlin/chat/onym/android/identity/StoredSnapshot.kt",
+    "app/src/main/kotlin/chat/onym/android/identity/Identity.kt",
+    "app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt",
+}
+
+# Field-access patterns that read identity secrets. The `.` prefix
+# means we only catch member access (not declarations or unrelated
+# local variables that happen to share a name).
+PATTERNS: list[tuple[str, str]] = [
+    (r"\.nostrSecretKey\b", "nostr secp256k1 secret key"),
+    (r"\.blsSecretKey\b",   "BLS12-381 secret key"),
+    (r"\.recoveryPhrase\b", "BIP39 recovery phrase (mnemonic)"),
+    (r"\.entropy\b",        "BIP39 entropy bytes"),
+]
+
+# Destructuring with one of our secret field names as a binding —
+# `val (entropy, nostrSk, blsSk) = snapshot` reads all three fields
+# without touching `.fieldName` syntax. We catch the case where the
+# binding is named like the field (intent is clear); a developer
+# renaming `(entropy, …)` to `(a, …)` to dodge the linter is in
+# bad faith and out of scope.
+DESTRUCTURING = re.compile(
+    r"\bval\s*\([^)]*\b(?:nostrSecretKey|blsSecretKey|recoveryPhrase|entropy)\b[^)]*\)\s*="
+)
+
+SUPPRESSION = "onym:allow-secret-read"
+COMMENT_LINE = re.compile(r"^\s*//")
+
+
+def is_suppressed(lines: list[str], index: int) -> bool:
+    """True if the violation on `lines[index]` (1-based) is suppressed.
+
+    A suppression is honoured if `SUPPRESSION` appears on the violating
+    line itself, or anywhere in the contiguous block of `//`-prefixed
+    comment lines directly above it.
+    """
+    line = lines[index - 1]
+    if SUPPRESSION in line:
+        return True
+    j = index - 2
+    while j >= 0 and COMMENT_LINE.match(lines[j]):
+        if SUPPRESSION in lines[j]:
+            return True
+        j -= 1
+    return False
+
+
+# Path components anywhere in the relative path that should be skipped:
+# Gradle build outputs, Gradle daemon scratch, kotlinx.serialization /
+# AGP-generated sources.
+SKIP_DIR_COMPONENTS = {"build", ".gradle", "generated"}
+
+
+def is_skipped(path: Path, root: Path) -> bool:
+    rel = path.relative_to(root).parts
+    return any(part in SKIP_DIR_COMPONENTS for part in rel)
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    sources = sorted(
+        list(root.glob("**/*.kt")) + list(root.glob("**/*.kts"))
+    )
+
+    violations: list[tuple[str, int, str, str]] = []
+    for file in sources:
+        if is_skipped(file, root):
+            continue
+
+        rel = file.relative_to(root).as_posix()
+        if rel in ALLOWED:
+            continue
+
+        lines = file.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines, start=1):
+            for pattern, desc in PATTERNS:
+                if not re.search(pattern, line):
+                    continue
+                if is_suppressed(lines, i):
+                    continue
+                violations.append((rel, i, desc, line.rstrip()))
+            if DESTRUCTURING.search(line):
+                if not is_suppressed(lines, i):
+                    violations.append(
+                        (rel, i, "destructuring binds a secret field name", line.rstrip())
+                    )
+
+    if violations:
+        for rel, i, desc, line in violations:
+            print(f"{rel}:{i}: forbidden secret read ({desc})")
+            print(f"    {line}")
+        print()
+        print(f"Found {len(violations)} secret-read violation(s).")
+        print(f"Allow with `// {SUPPRESSION}` on the line or directly above.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Kotlin port of the iOS [`lint-secrets.py`](https://github.com/onymchat/onym-ios/blob/main/scripts/lint-secrets.py) (commit ff69bc9, [PR #2](https://github.com/onymchat/onym-ios/pull/2)). Default-deny check that any field-access read of `.nostrSecretKey`, `.blsSecretKey`, `.recoveryPhrase`, or `.entropy` outside an explicit allowlist fails the build.

## Allowlist (Android module layout)

```
app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
app/src/main/kotlin/chat/onym/android/identity/StoredSnapshot.kt
app/src/main/kotlin/chat/onym/android/identity/Identity.kt
app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
```

`IdentitySecretStore.kt` is **not** allowlisted — kotlinx.serialization generates the field-access code into `build/generated/` (which the linter skips), so the source file itself never references these fields via `.fieldName` syntax. The store is the only off-repo file with a legitimate need to serialize secret material, and the kotlinx-serialization design keeps it out of the linter's scope as a happy accident. Verified by running the linter against the post-Chunk-2 tree.

One suppressed read: `IdentityBootstrapScreen.kt`'s recovery-phrase display — comment cites the surrounding scaffold context (real reveal UI in a later chunk will gate behind `BiometricPrompt`).

## Architectural calls (vs the brief)

- **Kotlin-specific destructuring check.** `val (entropy, nostrSk, blsSk) = snapshot` reads three secret fields without touching `.fieldName` syntax. The linter catches the case where the destructured binding name is one of {`nostrSecretKey`, `blsSecretKey`, `recoveryPhrase`, `entropy`} — i.e. the binding name reveals intent. Renaming to `val (a, b, c) = snapshot` evades the regex but is in bad faith and out of scope, per the brief.
- **Path skip list** `{build, .gradle, generated}` covers Gradle build outputs, daemon scratch, and AGP / kotlinx-serialization generated sources.
- **Suppression syntax** is `// onym:allow-secret-read` (matches iOS). Block comments (`/* … */`) are NOT honoured — to keep parity with iOS and because Kotlin codebases overwhelmingly use `//` line comments. If a future contributor needs block-comment suppression we can add it.
- **Reflection holes** (`identity::class.memberProperties.forEach { it.get(identity) }`) are out of scope per the brief — flag in code review.

## Pipeline wiring

⚠ **`onym-android` does not yet have a release pipeline.** No `.github/workflows/release.yml`, no AAB build, no Play Store upload. The brief said: *"If onym-android has no release pipeline at all yet, that's a larger task — flag it back to the user as 'Chunk 3 needs a release pipeline first' rather than scoping in the whole pipeline build."* — flagging.

This PR therefore wires the linter into the only workflow that exists: `.github/workflows/ci.yml`, as a separate `lint` job that `jvm-unit-tests` lists in its `needs:`. Same hard-gate semantics (a lint failure prevents the JVM unit tests from running), just attached to PR/push events instead of release dispatch. When the release pipeline lands, adding the linter as its first gate is a one-line change.

## Sanity check (all passing locally)

```
1. clean tree                      → exit 0
2. plant `.nostrSecretKey` read    → exit 1 (caught)
3. plant secret-named destructure  → exit 1 (caught)
4. plant suppression marker        → exit 0
5. cleanup                         → exit 0
```

## Test plan

- [ ] CI green on this PR (the new `lint` job runs and passes; `jvm-unit-tests` runs after `lint` succeeds)
- [ ] After merge, plant a `.nostrSecretKey` read in any non-allowlisted file and confirm CI fails on the `lint` job before `jvm-unit-tests` is invoked

## Future follow-ups

- A release pipeline for `onym-android` (AAB + Play Store upload + GitHub Release attachment). Wire the linter as the first gate, same one-liner.
- Reflection check (`memberProperties` / `Field.get(...)`) if it ever appears in the codebase.