### PR TITLE
Release pipeline: workflow_dispatch → signed APK → GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,205 @@
+name: Release
+
+# Cuts an onym-android release: lint → JVM unit tests → create
+# GitHub Release at the tag → assembleRelease → zipalign + apksigner
+# → upload signed universal APK to the GitHub Release.
+#
+# APK is the only artifact: no AAB, no Play Store, no F-Droid. Single
+# universal APK with all four ABIs (arm64-v8a, armeabi-v7a, x86_64,
+# x86) bundled, ~50-70 MB.
+#
+# Trigger:
+#   gh workflow run Release -f tag=v0.0.1
+#
+# Required repo secrets (see keystore/README.md for setup):
+#   ANDROID_KEYSTORE_BASE64    — base64-encoded JKS keystore
+#   ANDROID_KEYSTORE_PASSWORD  — keystore password
+#   ANDROID_KEY_ALIAS          — alias inside the keystore
+#   ANDROID_KEY_PASSWORD       — password for that alias
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.0.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write   # tag push + GitHub Release creation + asset upload
+
+jobs:
+  # ─── Hard gates ──────────────────────────────────────────────────
+  # Both run in parallel. `build` waits on both via `needs:` so a
+  # failure in either prevents an APK from ever being built or
+  # uploaded.
+
+  lint:
+    name: Lint (no off-repo secret reads)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Static check — identity secrets
+        run: python3 scripts/lint-secrets.py
+
+  test:
+    name: JVM unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+      - run: ./gradlew :app:testDebugUnitTest --no-daemon
+
+  # ─── GitHub Release creation ─────────────────────────────────────
+
+  create-release:
+    name: Create GitHub Release at tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0   # need full history for the release-notes commit range
+
+      - name: Validate tag input
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -eu
+          if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "tag must look like vX.Y.Z (got: $TAG)" >&2
+            exit 1
+          fi
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "tag $TAG already exists locally" >&2
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "tag $TAG already exists on origin" >&2
+            exit 1
+          fi
+
+      - name: Generate release notes
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -eu
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}\$" | head -1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          {
+            echo "## What's Changed"
+            echo ""
+            git log "$RANGE" --pretty=format:"- %s" --no-merges
+            echo ""
+            echo ""
+            if [ -n "$PREV_TAG" ]; then
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${TAG}"
+            fi
+          } > release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          target_commitish: ${{ github.sha }}
+          body_path: release_notes.md
+
+  # ─── APK build + sign + upload ───────────────────────────────────
+
+  build:
+    name: Build signed release APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [lint, test, create-release]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d  # v4
+
+      - name: assembleRelease
+        # Produces app/build/outputs/apk/release/app-release-unsigned.apk
+        # (no signingConfig is declared on the release buildType, so
+        # AGP emits an unsigned APK rather than failing the build).
+        run: ./gradlew :app:assembleRelease --no-daemon
+
+      - name: Locate + rename APK
+        id: apk
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -eu
+          UNSIGNED="app/build/outputs/apk/release/app-release-unsigned.apk"
+          [ -f "$UNSIGNED" ] || {
+            echo "expected unsigned APK at $UNSIGNED" >&2
+            ls -la app/build/outputs/apk/release/ 2>&1 >&2 || true
+            exit 1
+          }
+          VERSION="${TAG#v}"
+          OUT="onym-android-${VERSION}.apk"
+          mv "$UNSIGNED" "$OUT"
+          echo "path=$OUT" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Zipalign APK
+        # zipalign aligns uncompressed entries to 4-byte boundaries
+        # (the Android runtime mmap's resources directly off the APK).
+        # `-p` page-aligns shared libraries to 16 KB pages — required
+        # by Android 15+ on devices with 16 KB page sizes.
+        run: |
+          set -eu
+          ZIPALIGN=$(find "$ANDROID_HOME" -name zipalign 2>/dev/null | sort -V | tail -1)
+          [ -x "$ZIPALIGN" ] || { echo "zipalign not found in $ANDROID_HOME" >&2; exit 1; }
+          mv "${{ steps.apk.outputs.path }}" unaligned.apk
+          $ZIPALIGN -p -v 4 unaligned.apk "${{ steps.apk.outputs.path }}"
+          rm unaligned.apk
+
+      - name: Sign APK
+        env:
+          KEYSTORE_BASE64:   ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS:         ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD:      ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -eu
+          [ -n "$KEYSTORE_BASE64" ]   || { echo "secret ANDROID_KEYSTORE_BASE64 unset"   >&2; exit 1; }
+          [ -n "$KEYSTORE_PASSWORD" ] || { echo "secret ANDROID_KEYSTORE_PASSWORD unset" >&2; exit 1; }
+          [ -n "$KEY_ALIAS" ]         || { echo "secret ANDROID_KEY_ALIAS unset"         >&2; exit 1; }
+          [ -n "$KEY_PASSWORD" ]      || { echo "secret ANDROID_KEY_PASSWORD unset"      >&2; exit 1; }
+
+          echo "$KEYSTORE_BASE64" | base64 -d > /tmp/keystore.jks
+          APKSIGNER=$(find "$ANDROID_HOME" -name apksigner 2>/dev/null | sort -V | tail -1)
+          [ -x "$APKSIGNER" ] || { echo "apksigner not found in $ANDROID_HOME" >&2; exit 1; }
+
+          $APKSIGNER sign \
+            --ks /tmp/keystore.jks \
+            --ks-pass "pass:$KEYSTORE_PASSWORD" \
+            --ks-key-alias "$KEY_ALIAS" \
+            --key-pass "pass:$KEY_PASSWORD" \
+            "${{ steps.apk.outputs.path }}"
+          rm /tmp/keystore.jks
+
+          # Verify the produced signature so a misconfigured secret
+          # surfaces as a build failure rather than a silently-broken
+          # APK in the GitHub Release.
+          $APKSIGNER verify --verbose "${{ steps.apk.outputs.path }}"
+
+      - name: Upload APK to GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: ${{ steps.apk.outputs.path }}

--- a/README.md
+++ b/README.md
@@ -256,6 +256,46 @@ based reads are a known hole; flag in code review if you see one.
 To run locally: `python3 scripts/lint-secrets.py`. Exits 0 on
 success, 1 on any unsuppressed violation.
 
+## Release pipeline
+
+`.github/workflows/release.yml` — manual `workflow_dispatch`, builds a
+signed universal APK and attaches it to a fresh GitHub Release.
+
+```sh
+gh workflow run Release -f tag=v0.0.1
+```
+
+Job graph:
+
+```
+       ┌─── lint ──────────────┐
+       │                       │
+       ├─── test ──────────────┤
+       │                       ▼
+trigger┤                     build  →  GitHub Release
+       │                       ▲       (signed APK attached)
+       └─── create-release ────┘
+            (notes + Release at the tag)
+```
+
+The build job runs `assembleRelease` (no `signingConfig` declared on
+the release buildType, so AGP emits an unsigned APK), `zipalign`s
+the result with `-p 4` for 16 KB page-aligned native libs (Android
+15+ requirement), then signs with `apksigner` using a keystore
+decoded from the `ANDROID_KEYSTORE_BASE64` repo secret. APK is then
+uploaded to the Release the previous job created.
+
+APK is the only artifact: no AAB, no Play Store, no F-Droid. Single
+universal APK, all four ABIs bundled (~29 MB at v0.0.1).
+
+See [`keystore/README.md`](keystore/README.md) for keystore management
++ secret rotation. Required repo secrets:
+
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
 ## Out of scope (future chunks)
 
 - `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods —

--- a/keystore/README.md
+++ b/keystore/README.md
@@ -1,0 +1,64 @@
+# Keystore
+
+This directory holds the **release-signing keystore**. The `*.jks` glob
+in the repo `.gitignore` keeps any actual keystore file out of git —
+this README is the only thing tracked.
+
+## Local setup (one-time, per developer)
+
+The CI release pipeline signs release APKs with the canonical Onym
+upload key. To sign a release locally (e.g. to reproduce CI's APK or
+to build a one-off ad-hoc APK), drop the keystore into this directory
+as `release.jks`:
+
+```sh
+cp ~/Downloads/onym-release.jks keystore/release.jks
+# Verify gitignore is doing its job — git should NOT see this file:
+git status keystore/release.jks   # → no output
+git check-ignore -v keystore/release.jks
+```
+
+The keystore is a credentialed asset — share it via the same channel
+the team uses for other secrets (1Password, Bitwarden, encrypted
+Slack DM with rotation), never via plain email or unencrypted
+storage.
+
+## CI
+
+CI doesn't read `keystore/release.jks` from disk — the keystore is
+stored as a base64-encoded GitHub repository secret named
+`ANDROID_KEYSTORE_BASE64`. The `Sign APK` step in
+`.github/workflows/release.yml` decodes it into `/tmp/keystore.jks`
+just before invoking `apksigner`, then deletes it.
+
+To rotate the CI keystore (or set it up for the first time):
+
+```sh
+# 1. Inspect the keystore so you know what alias / passwords to set.
+keytool -list -v -keystore keystore/release.jks
+# Note the "Alias name:" line — that's $ANDROID_KEY_ALIAS.
+
+# 2. Base64-encode the JKS and copy to clipboard.
+base64 -i keystore/release.jks | pbcopy   # macOS
+# or
+base64 -w 0 keystore/release.jks | xclip  # Linux
+
+# 3. Set the four secrets on the repo (you'll be prompted for each).
+gh secret set ANDROID_KEYSTORE_BASE64    --repo onymchat/onym-android   # paste from clipboard
+gh secret set ANDROID_KEYSTORE_PASSWORD  --repo onymchat/onym-android
+gh secret set ANDROID_KEY_ALIAS          --repo onymchat/onym-android
+gh secret set ANDROID_KEY_PASSWORD       --repo onymchat/onym-android
+```
+
+## Why a single fixed upload key matters
+
+Sideloaded APK installs require **the same signing key** for in-place
+updates. A user who installs `onym-v0.0.1.apk` signed by key X then
+tries to install `onym-v0.0.2.apk` signed by key Y will see a
+`INSTALL_FAILED_UPDATE_INCOMPATIBLE` error and have to uninstall +
+reinstall (losing all app data, including the encrypted identity
+secrets stored in `EncryptedSharedPreferences`).
+
+So: do not rotate the CI keystore once a release has shipped to real
+users. If the keystore is compromised, rotation requires a coordinated
+"reinstall to upgrade" announcement.


### PR DESCRIPTION
Steals shape from `stellar-mls/.github/workflows/release.yml`, trimmed to just what's needed: lint → JVM unit tests → create GitHub Release at the tag → `assembleRelease` → zipalign → apksigner → upload signed universal APK to the Release.

**APK is the only artifact.** No AAB, no Play Store, no F-Droid. Single universal APK with all four ABIs bundled (~29 MB at v0.0.1, verified locally via `./gradlew :app:assembleRelease`).

## Job graph

```
        ┌── lint ─────────────┐
        │                     │
trigger ├── test ─────────────┤
        │                     ▼
        │                   build  →  GitHub Release
        │                     ▲       (signed APK attached)
        └── create-release ───┘
            (notes + Release at tag)
```

`build` lists all three in `needs:` so a lint, test, or release-creation failure prevents the APK from ever being signed or uploaded. `apksigner verify --verbose` runs after signing so a misconfigured secret surfaces as a build failure rather than a silently broken APK in the Release.

## Trigger

```sh
gh workflow run Release -f tag=v0.0.1
```

## ⚠ ACTION REQUIRED before triggering: set 4 repo secrets

```sh
# Inspect the keystore to find the alias name (`Alias name:` in output):
keytool -list -v -keystore keystore/release.jks
# (will prompt for the keystore password)

# Then set the four secrets:
base64 -i keystore/release.jks | pbcopy
gh secret set ANDROID_KEYSTORE_BASE64    --repo onymchat/onym-android   # paste from clipboard
gh secret set ANDROID_KEYSTORE_PASSWORD  --repo onymchat/onym-android
gh secret set ANDROID_KEY_ALIAS          --repo onymchat/onym-android
gh secret set ANDROID_KEY_PASSWORD       --repo onymchat/onym-android
```

The `Sign APK` step explicitly checks each secret is non-empty and fails loudly if any of the four is unset, so the first dry-run will tell you which one is missing.

## Architectural notes

- **Apksigner pattern** matches stellar-mls — `build.gradle.kts` is unchanged. No `signingConfig` on the release buildType means AGP emits `app-release-unsigned.apk` rather than failing the build. CI signs externally. Keeps build-time dependencies and signing-time dependencies separate; lets local `./gradlew :app:assembleRelease` work without a keystore.
- **`zipalign -p 4`** for 16 KB-page-aligned native libs. Android 15+ on devices with 16 KB page sizes requires this; onym-sdk-jni ships `.so` files in `jniLibs/<abi>/`, so it's load-bearing.
- **Tag validation**: rejects malformed tags (`vX.Y.Z` only) and tags that already exist locally or on origin. Surfaces a typo before any side effects.
- **Release-notes generation** auto-generates from `git log $PREV_TAG..HEAD --no-merges` (same pattern as stellar-mls and onym-ios PR #3). For the first release with no `$PREV_TAG`, falls back to the full HEAD log.
- **Keystore copied to `keystore/release.jks`** for local release reproduction. `*.jks` is gitignored repo-wide; verified `git check-ignore` matches and the staged file list is empty for any `.jks`. `keystore/README.md` documents the local-setup + secret-rotation flow.
- **All third-party actions pinned to commit SHA**: `actions/checkout` v4, `actions/setup-java` v4, `gradle/actions/setup-gradle` v4, `softprops/action-gh-release` v2.

## Test plan

- [ ] CI green on this PR (the `lint` and `test` jobs from this workflow run as the existing `ci.yml` flow; the new `release.yml` doesn't fire on PRs)
- [ ] After merge, set the 4 secrets per the snippet above
- [ ] `gh workflow run Release -f tag=v0.0.1` — should produce a v0.0.1 GitHub Release with one signed `onym-android-0.0.1.apk` attachment
- [ ] Sideload the APK on an Android device, confirm it installs and `IdentityBootstrapScreen` renders the 6 derived fields + a 12-word recovery phrase