### PR TITLE
Recovery-phrase backup flow: Intro → Reveal → Verify → Done

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,12 +296,87 @@ See [`keystore/README.md`](keystore/README.md) for keystore management
 - `ANDROID_KEY_ALIAS`
 - `ANDROID_KEY_PASSWORD`
 
+## Recovery-phrase backup flow
+
+The app's only screen today is the
+[`RecoveryPhraseBackupScreen`](app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt)
+flow — Intro → Reveal → Verify → Done. Mirrors onym-ios PR #4 1:1
+in shape, ported to Compose + StateFlow + AndroidX BiometricPrompt.
+
+```
+.intro
+  │ tappedContinueFromIntro → authenticate()
+  ├─► .authFailed(reason) ── dismissedAuthError → .intro
+  └─► .reveal(phrase, revealed: false)
+        │ tappedReveal     → revealed: true
+        │ tappedCopyPhrase → clipboard write + 60s auto-clear
+        │ tappedContinueFromReveal
+        ▼
+      .verify(phrase, rounds: 3, index: 0, .idle)
+        │ picked(word):
+        │   correct → .correct, delay 450ms,
+        │             then advance index OR transition to .done
+        │   wrong   → .wrong(word), retry same round
+        ▼
+      .done
+        │ tappedDoneFromCompletion → .intro (single-screen app loop)
+```
+
+3 random verify rounds × 4 options each (one correct + three
+distractors from the same phrase). Wrong pick stays on the same
+round; second pick during the in-flight 450 ms advance is ignored.
+
+### Side-effect seams
+
+- **`BiometricAuthenticator`** — interface + `AndroidBiometricAuthenticator`
+  backed by [`BiometricPrompt`](https://developer.android.com/reference/androidx/biometric/BiometricPrompt).
+  Requires a [`FragmentActivity`](https://developer.android.com/reference/androidx/fragment/app/FragmentActivity)
+  host (so [`MainActivity`](app/src/main/kotlin/chat/onym/android/MainActivity.kt)
+  extends `FragmentActivity`, not `ComponentActivity`). Takes an
+  *activity provider thunk* rather than a captured Activity reference
+  so the long-lived [`RecoveryPhraseBackupViewModel`](app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt)
+  doesn't pin an Activity past configuration change. If the device has
+  no enrolled biometric and no device credential, returns success
+  without prompting (matches iOS `canEvaluatePolicy == false`
+  fail-open).
+- **`ClipboardWriter`** — interface + `AndroidClipboardWriter` over
+  [`ClipboardManager`](https://developer.android.com/reference/android/content/ClipboardManager).
+  Sets the [`IS_SENSITIVE`](https://developer.android.com/about/versions/13/features#copy-paste)
+  extra on Android 13+, so the system's clipboard preview shows a
+  redacted "Sensitive" placeholder instead of the actual phrase.
+
+### Screenshot / recents protection
+
+`MainActivity` sets [`WindowManager.LayoutParams.FLAG_SECURE`](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE)
+on the window before `super.onCreate`. This:
+
+- Blocks screenshots and screen recording across the entire app.
+- Renders the recents thumbnail as a blank surface.
+
+Stronger than iOS's scene-phase obscure overlay (which only blanks
+the recents preview on backgrounding) — Android's flag covers both.
+
+### Tests
+
+[`app/src/androidTest/.../RecoveryPhraseBackupViewModelTest.kt`](app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt)
+ports all 13 iOS XCTest cases against a real
+`IdentityRepository` (per-test unique prefs file), a fake
+`BiometricAuthenticator`, and a fake `ClipboardWriter`. Lives in
+`androidTest/` (not `test/`) because the real repository requires
+Android Keystore — Robolectric doesn't simulate it. Same rule as
+the identity-layer instrumented tests, same rationale as iOS's
+"real Keychain behaviour or it doesn't count".
+
+Inject short delays in the test fixture
+(`clipboardClearDelay = 50ms`, `verifyAdvanceDelay = 20ms`) so the
+suite runs in well under a second.
+
 ## Out of scope (future chunks)
 
 - `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods —
   no callers yet, lands when transport / invitation does.
-- Onboarding / recovery-reveal UI (the bootstrap screen exists only
-  to make the repo wiring exercisable end-to-end).
+- Onboarding (this is just the backup flow; new-identity choice
+  vs restore-from-mnemonic UI is a future chunk).
 - Promoting `Bip39` into `onym-sdk-kotlin` — wait for a third client
   to want the same derivation.
 - Emulator job in CI for instrumented tests.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,7 +72,16 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.compose.ui.tooling)
+
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+
+    // BiometricPrompt requires a FragmentActivity host. fragment-ktx
+    // pulls in the FragmentActivity class; biometric pulls in the
+    // prompt itself.
+    implementation(libs.androidx.fragment.ktx)
+    implementation(libs.androidx.biometric)
 
     implementation(libs.androidx.security.crypto)
 

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
@@ -1,0 +1,333 @@
+package chat.onym.android.recovery
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.identity.IdentityRepository
+import chat.onym.android.identity.IdentitySecretStore
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.Security
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Drives [RecoveryPhraseBackupViewModel] against:
+ *   - a real [IdentityRepository] (per-test unique
+ *     EncryptedSharedPreferences file so runs don't collide), seeded
+ *     by `restore(mnemonic)` so the recovery phrase is deterministic
+ *   - a fake [BiometricAuthenticator] whose outcome is set per test
+ *   - a fake [ClipboardWriter] so the system clipboard is never touched
+ *
+ * Lives in `androidTest/` (not `test/`) because the real
+ * `IdentityRepository` requires Android Keystore access, which
+ * Robolectric doesn't simulate. Mirrors iOS's "real Keychain behaviour
+ * or it doesn't count" rule.
+ *
+ * Verify-step rounds are random (3 of 12 with 3 distractors each), so
+ * tests work against [RecoveryPhraseBackupViewModel.step] *shape* and
+ * read the correct word from each round at runtime — reaching
+ * [RecoveryPhraseBackupViewModel.Step.Done] requires picking the
+ * correct word at every round.
+ */
+@RunWith(AndroidJUnit4::class)
+class RecoveryPhraseBackupViewModelTest {
+
+    /**
+     * Canonical BIP39 test vector with 12 distinct words so verify
+     * rounds have 4 truly distinct options to choose from. (The other
+     * canonical `abandon × 11 + about` mnemonic has 11 of 12 words
+     * collide on `abandon`.)
+     */
+    private val testMnemonic =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow"
+
+    private lateinit var store: IdentitySecretStore
+    private lateinit var repository: IdentityRepository
+    private lateinit var authenticator: FakeAuthenticator
+    private lateinit var clipboard: FakeClipboard
+    private lateinit var viewModel: RecoveryPhraseBackupViewModel
+
+    @Before
+    fun setUp() = runBlocking {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.insertProviderAt(BouncyCastleProvider(), 2)
+        }
+        val ctx = ApplicationProvider.getApplicationContext<android.content.Context>()
+        store = IdentitySecretStore(
+            ctx,
+            prefsFileName = "chat.onym.android.identity.recoverytests.${UUID.randomUUID()}",
+        )
+        repository = IdentityRepository(store)
+        repository.restore(testMnemonic)
+        authenticator = FakeAuthenticator()
+        clipboard = FakeClipboard()
+        viewModel = RecoveryPhraseBackupViewModel(
+            repository = repository,
+            authenticator = authenticator,
+            clipboard = clipboard,
+            // Short delays so the suite runs in well under a second.
+            // iOS runs in ~800 ms; matching that order of magnitude.
+            clipboardClearDelay = 50.milliseconds,
+            verifyAdvanceDelay = 20.milliseconds,
+        )
+        viewModel.start()
+        waitForReady()
+    }
+
+    @After
+    fun tearDown() {
+        viewModel.stop()
+        try { store.wipe() } catch (_: Throwable) {}
+    }
+
+    // ─── Auth ───────────────────────────────────────────────────────
+
+    @Test
+    fun initialStep_isIntro() {
+        assertEquals(RecoveryPhraseBackupViewModel.Step.Intro, viewModel.step.value)
+    }
+
+    @Test
+    fun isReady_flipsTrueAfterBootstrap() {
+        // setUp's waitForReady spun until this flipped — re-assert
+        // for the failure-mode visibility (the assertion message names
+        // the broken invariant).
+        assertTrue("flow should be ready after setUp's waitForReady", viewModel.isReady.value)
+    }
+
+    @Test
+    fun authSuccess_transitionsToReveal_unrevealed() = runBlocking {
+        authenticator.outcome = FakeAuthenticator.Outcome.Success
+        viewModel.authenticate()
+
+        val step = viewModel.step.value
+        if (step !is RecoveryPhraseBackupViewModel.Step.Reveal) {
+            fail("expected Reveal, got $step"); return@runBlocking
+        }
+        assertEquals(testMnemonic, step.phrase)
+        assertEquals(false, step.revealed)
+    }
+
+    @Test
+    fun authFailure_transitionsToAuthFailed_withMessage() = runBlocking {
+        authenticator.outcome =
+            FakeAuthenticator.Outcome.Failure(BiometricAuthException(13, "User cancelled"))
+        viewModel.authenticate()
+
+        val step = viewModel.step.value
+        if (step !is RecoveryPhraseBackupViewModel.Step.AuthFailed) {
+            fail("expected AuthFailed, got $step"); return@runBlocking
+        }
+        assertEquals("User cancelled", step.reason)
+    }
+
+    @Test
+    fun dismissedAuthError_resetsToIntro() = runBlocking {
+        authenticator.outcome =
+            FakeAuthenticator.Outcome.Failure(BiometricAuthException(13, "x"))
+        viewModel.authenticate()
+        assertNotEquals(RecoveryPhraseBackupViewModel.Step.Intro, viewModel.step.value)
+
+        viewModel.dismissedAuthError()
+        assertEquals(RecoveryPhraseBackupViewModel.Step.Intro, viewModel.step.value)
+    }
+
+    // ─── Reveal ─────────────────────────────────────────────────────
+
+    @Test
+    fun tappedReveal_flipsRevealedTrue() = runBlocking {
+        advanceToReveal()
+        viewModel.tappedReveal()
+
+        val step = viewModel.step.value
+        if (step !is RecoveryPhraseBackupViewModel.Step.Reveal) {
+            fail("expected Reveal, got $step"); return@runBlocking
+        }
+        assertTrue(step.revealed)
+    }
+
+    @Test
+    fun tappedCopyPhrase_writesToClipboard_thenClearsAfterDelay() = runBlocking {
+        advanceToReveal()
+        viewModel.tappedReveal()
+
+        viewModel.tappedCopyPhrase()
+        assertEquals(testMnemonic, clipboard.lastWritten)
+
+        // clipboardClearDelay is 50 ms in tests — wait a comfortable
+        // multiple to let the auto-clear run.
+        delay(150)
+        assertTrue("clipboard auto-clear didn't run", clipboard.didClear)
+    }
+
+    @Test
+    fun tappedCopyPhrase_isNoop_beforeReveal() = runBlocking {
+        advanceToReveal()
+        // Don't tap reveal — phrase still hidden.
+        viewModel.tappedCopyPhrase()
+        assertNull(clipboard.lastWritten)
+    }
+
+    @Test
+    fun tappedContinueFromReveal_movesToVerify_withThreeRounds() = runBlocking {
+        advanceToReveal()
+        viewModel.tappedReveal()
+        viewModel.tappedContinueFromReveal()
+
+        val step = viewModel.step.value
+        if (step !is RecoveryPhraseBackupViewModel.Step.Verify) {
+            fail("expected Verify, got $step"); return@runBlocking
+        }
+        assertEquals(testMnemonic, step.phrase)
+        assertEquals("three verify rounds, picked at random from 12 positions",
+            3, step.rounds.size)
+        assertEquals(0, step.index)
+        assertEquals(RecoveryPhraseBackupViewModel.VerifyState.Idle, step.state)
+        for (round in step.rounds) {
+            assertEquals("four options per round", 4, round.options.size)
+            assertTrue("correct word must be in options",
+                round.options.contains(round.correct))
+            assertTrue(round.wordPosition in 1..12)
+        }
+    }
+
+    // ─── Verify ─────────────────────────────────────────────────────
+
+    @Test
+    fun pickedCorrect_advancesAfterDelay_andEventuallyHitsDone() = runBlocking {
+        advanceToVerify()
+
+        repeat(3) {
+            val step = viewModel.step.value
+            if (step !is RecoveryPhraseBackupViewModel.Step.Verify) {
+                fail("expected Verify mid-loop, got $step"); return@runBlocking
+            }
+            viewModel.picked(step.rounds[step.index].correct)
+            // verifyAdvanceDelay is 20 ms — wait 60 ms to let the advance fire.
+            delay(60)
+        }
+
+        assertEquals(RecoveryPhraseBackupViewModel.Step.Done, viewModel.step.value)
+    }
+
+    @Test
+    fun pickedWrong_marksWrong_andStaysOnSameRound() = runBlocking {
+        advanceToVerify()
+
+        val step = viewModel.step.value as RecoveryPhraseBackupViewModel.Step.Verify
+        val round = step.rounds[step.index]
+        val wrong = round.options.first { it != round.correct }
+        viewModel.picked(wrong)
+
+        val after = viewModel.step.value
+        if (after !is RecoveryPhraseBackupViewModel.Step.Verify) {
+            fail("expected to stay on Verify after wrong pick, got $after"); return@runBlocking
+        }
+        assertEquals("wrong pick must NOT advance the round", step.index, after.index)
+        assertEquals(RecoveryPhraseBackupViewModel.VerifyState.Wrong(wrong), after.state)
+    }
+
+    @Test
+    fun pickedCorrect_thenWrongPickIgnored_inflightAdvance() = runBlocking {
+        advanceToVerify()
+
+        val step = viewModel.step.value as RecoveryPhraseBackupViewModel.Step.Verify
+        val round = step.rounds[step.index]
+        val correct = round.correct
+        val wrong = round.options.first { it != correct }
+
+        viewModel.picked(correct)
+        // Immediately try a wrong pick — should be ignored because state == Correct
+        viewModel.picked(wrong)
+
+        val after = viewModel.step.value
+        if (after !is RecoveryPhraseBackupViewModel.Step.Verify) {
+            fail("expected Verify after correct, got $after"); return@runBlocking
+        }
+        assertEquals(step.index, after.index)
+        assertEquals(
+            "second pick during in-flight advance must be ignored",
+            RecoveryPhraseBackupViewModel.VerifyState.Correct,
+            after.state,
+        )
+    }
+
+    // ─── Done ──────────────────────────────────────────────────────
+
+    @Test
+    fun tappedDoneFromCompletion_loopsBackToIntro() = runBlocking {
+        runEntireFlow()
+        assertEquals(RecoveryPhraseBackupViewModel.Step.Done, viewModel.step.value)
+
+        viewModel.tappedDoneFromCompletion()
+        assertEquals(RecoveryPhraseBackupViewModel.Step.Intro, viewModel.step.value)
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────
+
+    private suspend fun waitForReady() {
+        repeat(50) {
+            if (viewModel.isReady.value) return
+            delay(10)
+        }
+        fail("viewModel.isReady never flipped true within 500 ms")
+    }
+
+    private suspend fun advanceToReveal() {
+        authenticator.outcome = FakeAuthenticator.Outcome.Success
+        viewModel.authenticate()
+        if (viewModel.step.value !is RecoveryPhraseBackupViewModel.Step.Reveal) {
+            fail("expected Reveal, got ${viewModel.step.value}")
+        }
+    }
+
+    private suspend fun advanceToVerify() {
+        advanceToReveal()
+        viewModel.tappedReveal()
+        viewModel.tappedContinueFromReveal()
+    }
+
+    private suspend fun runEntireFlow() {
+        advanceToVerify()
+        repeat(3) {
+            val step = viewModel.step.value as RecoveryPhraseBackupViewModel.Step.Verify
+            viewModel.picked(step.rounds[step.index].correct)
+            delay(60)
+        }
+    }
+
+    // ─── Fakes ─────────────────────────────────────────────────────
+
+    private class FakeAuthenticator : BiometricAuthenticator {
+        sealed class Outcome {
+            data object Success : Outcome()
+            data class Failure(val cause: Throwable) : Outcome()
+        }
+        var outcome: Outcome = Outcome.Success
+        override suspend fun authenticate(title: String, subtitle: String?) {
+            when (val o = outcome) {
+                is Outcome.Success -> Unit
+                is Outcome.Failure -> throw o.cause
+            }
+        }
+    }
+
+    private class FakeClipboard : ClipboardWriter {
+        var lastWritten: String? = null
+        var didClear: Boolean = false
+        override fun write(value: String) { lastWritten = value }
+        override fun clearIfStill(value: String) {
+            if (lastWritten == value) didClear = true
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/MainActivity.kt
+++ b/app/src/main/kotlin/chat/onym/android/MainActivity.kt
@@ -1,30 +1,74 @@
 package chat.onym.android
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import android.view.WindowManager
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
-import chat.onym.android.identity.IdentityBootstrapScreen
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.identity.IdentitySecretStore
+import chat.onym.android.recovery.AndroidBiometricAuthenticator
+import chat.onym.android.recovery.AndroidClipboardWriter
+import chat.onym.android.recovery.RecoveryPhraseBackupScreen
+import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 
-class MainActivity : ComponentActivity() {
+/**
+ * Sole entry point. Mounts [RecoveryPhraseBackupScreen] as the root —
+ * for now the entire app IS the back-up flow; subsequent chunks add
+ * a home screen and demote this to a nav destination.
+ *
+ * Extends [FragmentActivity] (not [ComponentActivity][androidx.activity.ComponentActivity])
+ * because [androidx.biometric.BiometricPrompt] attaches its dialog
+ * fragment to a `FragmentActivity` host.
+ *
+ * Sets [WindowManager.LayoutParams.FLAG_SECURE] on the window before
+ * `super.onCreate` so:
+ *   - screenshots / screen recording are blocked across the whole app
+ *   - the recents thumbnail is rendered as a blank surface
+ *
+ * That's a stronger guarantee than iOS's scene-phase obscure overlay
+ * (which only blanks the recents preview on backgrounding) — covers
+ * both screenshot suppression and recents-card redaction in one flag.
+ */
+class MainActivity : FragmentActivity() {
+
     private val repository: IdentityRepository by lazy {
         IdentityRepository(
             store = IdentitySecretStore(applicationContext)
         )
     }
 
+    private val viewModel: RecoveryPhraseBackupViewModel by viewModels {
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                @Suppress("UNCHECKED_CAST")
+                return RecoveryPhraseBackupViewModel(
+                    repository = repository,
+                    authenticator = AndroidBiometricAuthenticator(
+                        // Activity provider thunk — re-evaluated on
+                        // each call so configuration-change recreation
+                        // hands the prompt the new Activity instance
+                        // rather than the captured-at-construction one.
+                        activityProvider = { this@MainActivity },
+                    ),
+                    clipboard = AndroidClipboardWriter(applicationContext),
+                ) as T
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE,
+        )
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
-                Surface(modifier = Modifier.fillMaxSize()) {
-                    IdentityBootstrapScreen(repository = repository)
-                }
+                RecoveryPhraseBackupScreen(viewModel = viewModel)
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/recovery/BiometricAuthenticator.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/BiometricAuthenticator.kt
@@ -1,0 +1,135 @@
+package chat.onym.android.recovery
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.biometric.BiometricPrompt
+import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Async biometric / device-credential prompt. Wrapped behind an
+ * interface so [RecoveryPhraseBackupViewModel] can be unit-tested
+ * without standing up a real [BiometricPrompt] (which requires a
+ * `FragmentActivity` and user interaction).
+ *
+ * Mirrors the iOS [`BiometricAuthenticator` protocol
+ * ](https://github.com/onymchat/onym-ios/blob/main/Sources/OnymIOS/Recovery/BiometricAuthenticator.kt)
+ * 1:1: success → return; cancel/failure → throw; no enrolled
+ * biometric AND no device credential → return success without
+ * prompting (matches iOS's `canEvaluatePolicy == false → fail open`).
+ */
+interface BiometricAuthenticator {
+    /**
+     * Prompts the user. Returns on success; throws on cancel/failure.
+     *
+     * @param title shown at the top of the system prompt
+     *        (e.g. `"Authenticate to reveal your recovery phrase"`).
+     */
+    suspend fun authenticate(title: String, subtitle: String? = null)
+}
+
+/** Failure surface for [AndroidBiometricAuthenticator]. The message
+ *  comes from `BiometricPrompt`'s `errString` and is already
+ *  user-facing (e.g. `"Authentication cancelled"`,
+ *  `"Too many attempts. Try again later."`). */
+class BiometricAuthException(
+    val errorCode: Int,
+    message: String,
+) : Exception(message)
+
+/**
+ * Production [BiometricAuthenticator] backed by AndroidX
+ * [BiometricPrompt].
+ *
+ * `BiometricPrompt` requires a [FragmentActivity] host to attach its
+ * dialog fragment to. We take an [activityProvider] thunk rather than
+ * a captured `Activity` reference so the long-lived
+ * [RecoveryPhraseBackupViewModel] doesn't pin an `Activity` past
+ * configuration change (which would leak the entire view hierarchy).
+ *
+ * When called, the provider is invoked on the main thread and is
+ * expected to return the currently-foregrounded activity. The Compose
+ * entry point (`MainActivity`) supplies `{ this@MainActivity }`.
+ */
+class AndroidBiometricAuthenticator(
+    private val activityProvider: () -> FragmentActivity,
+) : BiometricAuthenticator {
+
+    /** `BIOMETRIC_WEAK` lets users with face-only auth (e.g. older
+     *  Pixels) past the gate too. `DEVICE_CREDENTIAL` is the PIN /
+     *  pattern / password fallback. The combination matches iOS's
+     *  `.deviceOwnerAuthentication` policy. */
+    private val authenticators = BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+
+    override suspend fun authenticate(title: String, subtitle: String?) {
+        // Switch to main for the BiometricManager probe + prompt
+        // attachment — the prompt fragment must be added on the main
+        // thread, and BiometricManager itself is main-only by contract.
+        withContext(Dispatchers.Main) {
+            val activity = activityProvider()
+            val manager = BiometricManager.from(activity)
+
+            when (manager.canAuthenticate(authenticators)) {
+                BiometricManager.BIOMETRIC_SUCCESS -> {
+                    suspendCancellableCoroutine { continuation ->
+                        val callback = object : BiometricPrompt.AuthenticationCallback() {
+                            override fun onAuthenticationSucceeded(
+                                result: BiometricPrompt.AuthenticationResult,
+                            ) {
+                                if (continuation.isActive) continuation.resume(Unit)
+                            }
+
+                            override fun onAuthenticationError(
+                                errorCode: Int,
+                                errString: CharSequence,
+                            ) {
+                                if (continuation.isActive) {
+                                    continuation.resumeWithException(
+                                        BiometricAuthException(errorCode, errString.toString())
+                                    )
+                                }
+                            }
+
+                            // onAuthenticationFailed (single attempt rejection)
+                            // is a UI-only signal — the system prompt re-asks
+                            // automatically. We only resume on terminal events
+                            // (success / error), which matches iOS's
+                            // single-resume continuation behaviour.
+                        }
+
+                        val prompt = BiometricPrompt(
+                            activity,
+                            ContextCompat_getMainExecutor(activity),
+                            callback,
+                        )
+                        val info = BiometricPrompt.PromptInfo.Builder()
+                            .setTitle(title)
+                            .apply { if (subtitle != null) setSubtitle(subtitle) }
+                            .setAllowedAuthenticators(authenticators)
+                            .build()
+                        prompt.authenticate(info)
+                    }
+                }
+
+                else -> {
+                    // No enrolled biometric AND no device credential. Match
+                    // the iOS "fail open in dev" behaviour — return success
+                    // without prompting. Production devices in this state
+                    // are extremely rare and the user has explicitly opted
+                    // out of device security.
+                }
+            }
+        }
+    }
+}
+
+/** Spelled funny so it doesn't shadow [androidx.core.content.ContextCompat]
+ *  (the ContextCompat reference is only needed for the executor and
+ *  bringing in the full `androidx.core` import is overkill here). */
+private fun ContextCompat_getMainExecutor(activity: FragmentActivity) =
+    androidx.core.content.ContextCompat.getMainExecutor(activity)

--- a/app/src/main/kotlin/chat/onym/android/recovery/ClipboardWriter.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/ClipboardWriter.kt
@@ -1,0 +1,77 @@
+package chat.onym.android.recovery
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import android.os.PersistableBundle
+
+/**
+ * Minimal seam over [ClipboardManager] so the flow's clipboard
+ * side effect can be observed in tests without writing to the real
+ * system clipboard.
+ *
+ * Mirrors the iOS [`PasteboardWriter` protocol
+ * ](https://github.com/onymchat/onym-ios/blob/main/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift)
+ * 1:1.
+ */
+interface ClipboardWriter {
+    /** Write the value to the system clipboard. */
+    fun write(value: String)
+
+    /**
+     * Clear the clipboard ONLY if its current content is still [value].
+     * No-op if the user has since copied something else — we don't
+     * want to wipe an unrelated value the user is mid-paste.
+     */
+    fun clearIfStill(value: String)
+}
+
+class AndroidClipboardWriter(private val context: Context) : ClipboardWriter {
+
+    /** Lazy so test code in modules without an Android context can
+     *  type-check against this class without crashing. */
+    private val clipboard: ClipboardManager by lazy {
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    }
+
+    override fun write(value: String) {
+        val clip = ClipData.newPlainText(LABEL, value)
+        // Android 13+ honours the IS_SENSITIVE flag — the system
+        // clipboard preview that pops up after a paste-able copy
+        // shows a redacted "Sensitive" placeholder instead of the
+        // actual recovery phrase. Older Androids ignore the flag,
+        // which is OK — the surface is the same as iOS pre-15
+        // (no in-OS preview at all).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            clip.description.extras = PersistableBundle().apply {
+                putBoolean("android.content.extra.IS_SENSITIVE", true)
+            }
+        }
+        clipboard.setPrimaryClip(clip)
+    }
+
+    override fun clearIfStill(value: String) {
+        val current = clipboard.primaryClip
+            ?.takeIf { it.itemCount > 0 }
+            ?.getItemAt(0)
+            ?.text
+            ?.toString()
+        if (current == value) {
+            // setPrimaryClip(null) isn't allowed; the official "clear"
+            // path is `clearPrimaryClip()` on API 28+, otherwise
+            // overwrite with an empty plaintext entry.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                clipboard.clearPrimaryClip()
+            } else {
+                clipboard.setPrimaryClip(ClipData.newPlainText(LABEL, ""))
+            }
+        }
+    }
+
+    companion object {
+        /** The clipboard label is user-visible in some launchers'
+         *  paste UI — keep it generic. */
+        private const val LABEL = "recovery_phrase"
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
@@ -1,0 +1,737 @@
+package chat.onym.android.recovery
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import java.text.DateFormat
+import java.util.Date
+
+/**
+ * Top-level Compose root for the Back-up-keys flow. Stateless w.r.t.
+ * domain data — collects [RecoveryPhraseBackupViewModel.step] and
+ * renders the matching sub-composable, wires button taps to intent
+ * methods.
+ *
+ * Mirrors `onym-ios/Sources/OnymIOS/Recovery/RecoveryPhraseBackupView.swift`.
+ * Layout numbers (paddings, corner radii, font sizes) translated 1:1 from
+ * the SwiftUI source; the visual design was tuned in the reference impl
+ * and is the user-facing contract.
+ *
+ * Screenshot/recents protection is set on the Activity window via
+ * `WindowManager.LayoutParams.FLAG_SECURE` in `MainActivity` — equivalent
+ * to (and stronger than) iOS's scene-phase obscure overlay.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecoveryPhraseBackupScreen(
+    viewModel: RecoveryPhraseBackupViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val step by viewModel.step.collectAsStateWithLifecycle()
+    val isReady by viewModel.isReady.collectAsStateWithLifecycle()
+
+    LaunchedEffect(viewModel) {
+        viewModel.start()
+    }
+
+    val title = when (step) {
+        is RecoveryPhraseBackupViewModel.Step.Intro,
+        is RecoveryPhraseBackupViewModel.Step.AuthFailed -> "Back up keys"
+        is RecoveryPhraseBackupViewModel.Step.Reveal    -> "Recovery phrase"
+        is RecoveryPhraseBackupViewModel.Step.Verify    -> "Verify"
+        is RecoveryPhraseBackupViewModel.Step.Done      -> ""
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        topBar = {
+            CenterAlignedTopAppBar(title = { Text(title) })
+        },
+    ) { padding ->
+        Surface(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            color = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ) {
+            when (val s = step) {
+                is RecoveryPhraseBackupViewModel.Step.Intro,
+                is RecoveryPhraseBackupViewModel.Step.AuthFailed -> {
+                    IntroScreen(
+                        isReady = isReady,
+                        onContinue = viewModel::tappedContinueFromIntro,
+                    )
+                }
+                is RecoveryPhraseBackupViewModel.Step.Reveal -> {
+                    RevealScreen(
+                        phrase = s.phrase,
+                        revealed = s.revealed,
+                        onReveal = viewModel::tappedReveal,
+                        onCopy = viewModel::tappedCopyPhrase,
+                        onContinue = viewModel::tappedContinueFromReveal,
+                    )
+                }
+                is RecoveryPhraseBackupViewModel.Step.Verify -> {
+                    VerifyScreen(
+                        round = s.rounds[s.index],
+                        progressIndex = s.index,
+                        progressTotal = s.rounds.size,
+                        state = s.state,
+                        onPick = viewModel::picked,
+                    )
+                }
+                is RecoveryPhraseBackupViewModel.Step.Done -> {
+                    DoneScreen(onDone = viewModel::tappedDoneFromCompletion)
+                }
+            }
+        }
+    }
+
+    val authFailed = step as? RecoveryPhraseBackupViewModel.Step.AuthFailed
+    if (authFailed != null) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissedAuthError,
+            title = { Text("Authentication Failed") },
+            text = { Text(authFailed.reason) },
+            confirmButton = {
+                TextButton(onClick = viewModel::tappedContinueFromIntro) { Text("Try Again") }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissedAuthError) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+// ─── Intro ───────────────────────────────────────────────────────────
+
+@Composable
+private fun IntroScreen(isReady: Boolean, onContinue: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 28.dp),
+    ) {
+        HeroCard(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(top = 4.dp, bottom = 18.dp),
+        )
+
+        SectionHeader("Before you start")
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            IntroRow(
+                icon = Icons.Filled.Warning,
+                iconBg = Color(0xFFFF9800),
+                title = "Never share or photograph",
+                separator = true,
+            )
+            IntroRow(
+                icon = Icons.Filled.Shield,
+                iconBg = Color(0xFF4CAF50),
+                title = "Store offline (paper or metal)",
+                separator = true,
+            )
+            IntroRow(
+                icon = Icons.Filled.Lock,
+                iconBg = Color(0xFF8E8E93),
+                title = "Anyone with it can read your chats",
+                separator = false,
+            )
+        }
+
+        Button(
+            onClick = onContinue,
+            enabled = isReady,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(top = 22.dp),
+            shape = RoundedCornerShape(14.dp),
+            contentPadding = PaddingValues(vertical = 14.dp),
+        ) {
+            Icon(Icons.Filled.Fingerprint, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("Continue with biometrics", fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun HeroCard(modifier: Modifier = Modifier) {
+    val accent = MaterialTheme.colorScheme.primary
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(vertical = 22.dp, horizontal = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(RoundedCornerShape(22.dp))
+                .background(
+                    Brush.linearGradient(listOf(accent, Color(0xFFAB47BC)))
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.Key,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(30.dp),
+            )
+        }
+        Text(
+            "Your identity, in 12 words",
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            "Write them down. Keep them offline. This phrase restores your Nostr, " +
+                    "Stellar, and BLS keys on any device.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp)
+            .padding(bottom = 6.dp),
+    )
+}
+
+@Composable
+private fun IntroRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    iconBg: Color,
+    title: String,
+    separator: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 44.dp)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(30.dp)
+                .clip(RoundedCornerShape(7.dp))
+                .background(iconBg),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(15.dp))
+        }
+        Text(title, style = MaterialTheme.typography.bodyLarge)
+    }
+    if (separator) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 58.dp)
+                .height(0.5.dp)
+                .background(MaterialTheme.colorScheme.outlineVariant),
+        )
+    }
+}
+
+// ─── Reveal ──────────────────────────────────────────────────────────
+
+@Composable
+private fun RevealScreen(
+    phrase: String,
+    revealed: Boolean,
+    onReveal: () -> Unit,
+    onCopy: () -> Unit,
+    onContinue: () -> Unit,
+) {
+    var copyConfirmShown by remember { mutableStateOf(false) }
+    val words = remember(phrase) { phrase.split(" ").filter { it.isNotEmpty() } }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 28.dp),
+    ) {
+        Text(
+            "Write down these ${words.size} words in order. You'll confirm three of them on the next screen.",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp)
+                .padding(top = 12.dp, bottom = 8.dp),
+        )
+
+        PhraseCard(
+            words = words,
+            revealed = revealed,
+            onReveal = onReveal,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 12.dp),
+        )
+
+        // Copy button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Button(
+                onClick = {
+                    onCopy()
+                    copyConfirmShown = true
+                },
+                enabled = revealed,
+                modifier = Modifier.weight(1f),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                    contentColor = MaterialTheme.colorScheme.primary,
+                ),
+                contentPadding = PaddingValues(vertical = 12.dp),
+            ) {
+                Icon(Icons.Filled.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("Copy", fontWeight = FontWeight.SemiBold)
+            }
+        }
+
+        Button(
+            onClick = onContinue,
+            enabled = revealed,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(top = 14.dp),
+            shape = RoundedCornerShape(14.dp),
+            contentPadding = PaddingValues(vertical = 14.dp),
+        ) {
+            Text("I've written it down", fontWeight = FontWeight.SemiBold)
+        }
+
+        Text(
+            "The phrase is generated on-device and never sent off the device. " +
+                "Screenshots are blocked on this screen.",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp)
+                .padding(top = 18.dp),
+        )
+    }
+
+    if (copyConfirmShown) {
+        AlertDialog(
+            onDismissRequest = { copyConfirmShown = false },
+            title = { Text("Copied") },
+            text = { Text("Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now.") },
+            confirmButton = {
+                TextButton(onClick = { copyConfirmShown = false }) { Text("OK") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun PhraseCard(
+    words: List<String>,
+    revealed: Boolean,
+    onReveal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        // 2-column grid of indexed words. Slight blur when hidden.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .blur(if (revealed) 0.dp else 10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            words.chunked(2).forEachIndexed { rowIdx, pair ->
+                Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                    pair.forEachIndexed { colIdx, word ->
+                        val displayIndex = rowIdx * 2 + colIdx + 1
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.03f))
+                                .padding(horizontal = 10.dp, vertical = 7.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                "%2d".format(displayIndex),
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontFamily = FontFamily.Monospace,
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            )
+                            Text(
+                                word,
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.Medium,
+                                ),
+                            )
+                        }
+                    }
+                    // Pad-cell when chunked left an odd word out
+                    if (pair.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+
+        if (!revealed) {
+            // Tap target overlaying the blurred phrase
+            Column(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable { onReveal() },
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Filled.VisibilityOff,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    "Tap to reveal",
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                )
+            }
+        }
+    }
+}
+
+// ─── Verify ──────────────────────────────────────────────────────────
+
+@Composable
+private fun VerifyScreen(
+    round: RecoveryPhraseBackupViewModel.VerifyRound,
+    progressIndex: Int,
+    progressTotal: Int,
+    state: RecoveryPhraseBackupViewModel.VerifyState,
+    onPick: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 28.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp, bottom = 22.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            ProgressDots(current = progressIndex, total = progressTotal)
+        }
+
+        // Hero "Select word number N"
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .clip(RoundedCornerShape(18.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .padding(vertical = 20.dp, horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                "Select word number",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "${round.wordPosition}",
+                style = MaterialTheme.typography.displayLarge.copy(
+                    fontSize = 64.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace,
+                ),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // 4 option rows
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            for (option in round.options) {
+                val isCorrect = state is RecoveryPhraseBackupViewModel.VerifyState.Correct &&
+                        option == round.correct
+                val isWrong = state is RecoveryPhraseBackupViewModel.VerifyState.Wrong &&
+                        state.word == option
+                VerifyOption(
+                    word = option,
+                    isCorrect = isCorrect,
+                    isWrong = isWrong,
+                    onTap = { onPick(option) },
+                )
+            }
+        }
+
+        if (state is RecoveryPhraseBackupViewModel.VerifyState.Wrong) {
+            Text(
+                "Not the right word. Check your phrase and try again.",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp)
+                    .padding(top = 18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VerifyOption(
+    word: String,
+    isCorrect: Boolean,
+    isWrong: Boolean,
+    onTap: () -> Unit,
+) {
+    val (bg, border, fg) = when {
+        isCorrect -> Triple(
+            Color(0xFF4CAF50).copy(alpha = 0.14f),
+            Color(0xFF4CAF50),
+            Color(0xFF2E7D32),
+        )
+        isWrong -> Triple(
+            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f),
+            MaterialTheme.colorScheme.error,
+            MaterialTheme.colorScheme.error,
+        )
+        else -> Triple(
+            MaterialTheme.colorScheme.surfaceContainerHigh,
+            Color.Transparent,
+            MaterialTheme.colorScheme.onSurface,
+        )
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(bg)
+            .border(1.5.dp, border, RoundedCornerShape(14.dp))
+            .clickable { onTap() }
+            .padding(horizontal = 18.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            word,
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+            color = fg,
+            modifier = Modifier.weight(1f),
+        )
+        if (isCorrect) {
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFF4CAF50)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(12.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressDots(current: Int, total: Int) {
+    val accent = MaterialTheme.colorScheme.primary
+    val inactive = MaterialTheme.colorScheme.outlineVariant
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (i in 0 until total) {
+            val width by animateDpAsState(
+                targetValue = if (i == current) 24.dp else 8.dp,
+                animationSpec = tween(200),
+                label = "dotWidth",
+            )
+            Box(
+                modifier = Modifier
+                    .height(8.dp)
+                    .width(width)
+                    .clip(CircleShape)
+                    .background(if (i == current) accent else inactive),
+            )
+        }
+    }
+}
+
+// ─── Done ────────────────────────────────────────────────────────────
+
+@Composable
+private fun DoneScreen(onDone: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(Modifier.weight(1f))
+
+        Box(
+            modifier = Modifier
+                .size(96.dp)
+                .clip(CircleShape)
+                .background(
+                    Brush.linearGradient(listOf(Color(0xFF4CAF50), Color(0xFF33C759)))
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.Check,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(44.dp),
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            "Backup verified",
+            style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Text(
+            "Your recovery phrase is confirmed. Store it somewhere safe — " +
+                    "you'll only need it if you lose this device.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 28.dp),
+        )
+
+        Spacer(Modifier.height(36.dp))
+
+        Button(
+            onClick = onDone,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            shape = RoundedCornerShape(14.dp),
+            contentPadding = PaddingValues(vertical = 14.dp),
+        ) {
+            Text("Done", fontWeight = FontWeight.SemiBold)
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        Text(
+            "Backed up ${dateString()} · BIP-39 English",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp, vertical = 32.dp),
+        )
+    }
+}
+
+private fun dateString(): String =
+    DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date())
+

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
@@ -1,0 +1,264 @@
+package chat.onym.android.recovery
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.identity.Identity
+import chat.onym.android.identity.IdentityRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Single source of truth for the "Back up keys" flow.
+ *
+ * State flows down ([step]); intents flow up (the `tapped*` / `picked` /
+ * `dismissed*` methods). The UI never mutates state directly — it
+ * collects [step], renders the matching screen, and calls intents on
+ * user actions. All side effects (storage via [IdentityRepository],
+ * [BiometricAuthenticator], [ClipboardWriter], randomness, [delay])
+ * live here.
+ *
+ * Mirrors `onym-ios/Sources/OnymIOS/Recovery/RecoveryPhraseBackupFlow.swift`
+ * 1:1, with iOS primitives mapped to their Android equivalents:
+ *
+ *   - `@Observable` → `StateFlow`
+ *   - actor / `nonisolated AsyncStream` → `StateFlow` (snapshot drain)
+ *   - `Task { … }` / `Task.sleep` → `viewModelScope.launch { … }` /
+ *     [delay]
+ *   - `LAContext` → AndroidX BiometricPrompt (behind
+ *     [BiometricAuthenticator])
+ *   - `UIPasteboard` → [android.content.ClipboardManager] (behind
+ *     [ClipboardWriter])
+ */
+class RecoveryPhraseBackupViewModel(
+    private val repository: IdentityRepository,
+    private val authenticator: BiometricAuthenticator,
+    private val clipboard: ClipboardWriter,
+    private val clipboardClearDelay: Duration = 60.seconds,
+    private val verifyAdvanceDelay: Duration = 450.milliseconds,
+) : ViewModel() {
+
+    sealed class Step {
+        data object Intro : Step()
+        data class AuthFailed(val reason: String) : Step()
+        data class Reveal(val phrase: String, val revealed: Boolean) : Step()
+        data class Verify(
+            val phrase: String,
+            val rounds: List<VerifyRound>,
+            val index: Int,
+            val state: VerifyState,
+        ) : Step()
+        data object Done : Step()
+    }
+
+    sealed class VerifyState {
+        data object Idle : VerifyState()
+        data object Correct : VerifyState()
+        data class Wrong(val word: String) : VerifyState()
+    }
+
+    data class VerifyRound(
+        /** 1-based position in the phrase (so the prompt can say
+         *  "word #4"). */
+        val wordPosition: Int,
+        val correct: String,
+        val options: List<String>,
+    )
+
+    // ─── Public state ────────────────────────────────────────────────
+
+    private val _step = MutableStateFlow<Step>(Step.Intro)
+    val step: StateFlow<Step> = _step.asStateFlow()
+
+    /**
+     * `true` once [IdentityRepository.bootstrap] has resolved and
+     * produced a snapshot. The view disables the Continue button until
+     * this flips so a too-eager tap on first launch can't race the
+     * bootstrap write.
+     */
+    private val _isReady = MutableStateFlow(false)
+    val isReady: StateFlow<Boolean> = _isReady.asStateFlow()
+
+    // ─── Internal ───────────────────────────────────────────────────
+
+    private var snapshotJob: Job? = null
+    private var verifyAdvanceJob: Job? = null
+    private var clipboardClearJob: Job? = null
+
+    /**
+     * Cached identity — read once at authenticate-time so the reveal
+     * step doesn't have to suspend on the repo. The view never sees
+     * this; only the recovery phrase escapes via [Step.Reveal.phrase],
+     * gated behind the auth + tap-to-reveal flow.
+     */
+    private var currentIdentity: Identity? = null
+
+    /**
+     * Begin draining the repository's snapshots into the cached
+     * [currentIdentity]. Idempotent — safe to call from
+     * [androidx.compose.runtime.LaunchedEffect] on every entry.
+     */
+    fun start() {
+        if (snapshotJob != null) return
+        snapshotJob = viewModelScope.launch {
+            try { repository.bootstrap() } catch (_: Throwable) { /* surfaced in authenticate() */ }
+            repository.snapshots.collect { snapshot ->
+                currentIdentity = snapshot
+                if (snapshot != null && !_isReady.value) _isReady.value = true
+            }
+        }
+    }
+
+    /**
+     * Cancel any in-flight jobs. Called automatically by
+     * [androidx.lifecycle.ViewModel.onCleared] via [viewModelScope];
+     * exposed so tests + `LifecycleEventObserver`-style callers can
+     * tear down deterministically.
+     */
+    fun stop() {
+        snapshotJob?.cancel(); snapshotJob = null
+        verifyAdvanceJob?.cancel(); verifyAdvanceJob = null
+        clipboardClearJob?.cancel(); clipboardClearJob = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stop()
+    }
+
+    // ─── Intents (called from the view) ─────────────────────────────
+
+    fun tappedContinueFromIntro() {
+        viewModelScope.launch { authenticate() }
+    }
+
+    fun dismissedAuthError() {
+        if (_step.value is Step.AuthFailed) _step.value = Step.Intro
+    }
+
+    fun tappedReveal() {
+        val current = _step.value
+        if (current is Step.Reveal) {
+            _step.value = current.copy(revealed = true)
+        }
+    }
+
+    fun tappedCopyPhrase() {
+        val current = _step.value
+        if (current !is Step.Reveal || !current.revealed) return
+        // onym:allow-secret-read: copy is the explicit user intent on the
+        // reveal screen; auto-clears after `clipboardClearDelay` so the
+        // value doesn't sit on the system clipboard indefinitely.
+        val phrase = current.phrase
+        clipboard.write(phrase)
+        clipboardClearJob?.cancel()
+        clipboardClearJob = viewModelScope.launch {
+            delay(clipboardClearDelay)
+            clipboard.clearIfStill(phrase)
+        }
+    }
+
+    fun tappedContinueFromReveal() {
+        val current = _step.value
+        if (current is Step.Reveal && current.revealed) {
+            _step.value = Step.Verify(
+                phrase = current.phrase,
+                rounds = makeRounds(current.phrase),
+                index = 0,
+                state = VerifyState.Idle,
+            )
+        }
+    }
+
+    fun picked(word: String) {
+        val current = _step.value as? Step.Verify ?: return
+        // Second pick during the in-flight 450ms advance is ignored.
+        if (current.state is VerifyState.Correct) return
+        val round = current.rounds[current.index]
+        if (word == round.correct) {
+            _step.value = current.copy(state = VerifyState.Correct)
+            verifyAdvanceJob?.cancel()
+            verifyAdvanceJob = viewModelScope.launch {
+                delay(verifyAdvanceDelay)
+                // Re-check that we're still in the same verify step
+                // we left — a wipe / restart could have moved the
+                // ground out from under us mid-delay.
+                val now = _step.value as? Step.Verify ?: return@launch
+                if (now.index != current.index || now.state !is VerifyState.Correct) return@launch
+                _step.value = if (now.index + 1 >= now.rounds.size) {
+                    Step.Done
+                } else {
+                    now.copy(index = now.index + 1, state = VerifyState.Idle)
+                }
+            }
+        } else {
+            _step.value = current.copy(state = VerifyState.Wrong(word))
+        }
+    }
+
+    fun tappedDoneFromCompletion() {
+        // Single-screen app: loop back to intro so the user can re-verify.
+        // Once a settings/home screen exists, this becomes a navigation pop.
+        _step.value = Step.Intro
+    }
+
+    // ─── Internal (also reachable from tests) ───────────────────────
+
+    /**
+     * Drives the auth + reveal handoff. Public-by-package so tests can
+     * exercise it without going through [tappedContinueFromIntro]
+     * (which buries the call inside [viewModelScope.launch]).
+     */
+    internal suspend fun authenticate() {
+        try {
+            authenticator.authenticate(
+                title = "Authenticate to reveal your recovery phrase",
+            )
+        } catch (t: Throwable) {
+            _step.value = Step.AuthFailed(reason = t.message ?: t::class.qualifiedName ?: "Authentication failed")
+            return
+        }
+        // onym:allow-secret-read: revealing the recovery phrase to the user
+        // is the entire purpose of this flow. The reveal screen gates the
+        // text behind a tap-to-reveal, FLAG_SECURE on the window, and the
+        // (biometric / device-credential)-gated authenticator above.
+        val phrase = currentIdentity?.recoveryPhrase
+        if (phrase == null) {
+            _step.value = Step.AuthFailed(
+                reason = "Recovery phrase unavailable. Your identity may not be BIP39-backed.",
+            )
+            return
+        }
+        _step.value = Step.Reveal(phrase = phrase, revealed = false)
+    }
+
+    companion object {
+        /**
+         * Pick three random word positions, present each as a 4-way
+         * multiple choice with one correct + three random distractors
+         * from the same phrase. Matches the iOS reference impl.
+         */
+        internal fun makeRounds(phrase: String): List<VerifyRound> {
+            val words = phrase.split(" ").filter { it.isNotEmpty() }
+            val positions = (0 until words.size).shuffled().take(3).sorted()
+            return positions.map { pos ->
+                val opts = mutableSetOf(words[pos])
+                while (opts.size < 4) {
+                    val candidate = words.random()
+                    if (candidate != words[pos]) opts.add(candidate)
+                }
+                VerifyRound(
+                    wordPosition = pos + 1,
+                    correct = words[pos],
+                    options = opts.toList().shuffled(),
+                )
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ androidx-lifecycle = "2.8.7"
 androidx-activity-compose = "1.9.3"
 androidx-compose-bom = "2024.12.01"
 androidx-security-crypto = "1.1.0-alpha06"
+androidx-biometric = "1.2.0-alpha05"
+androidx-fragment = "1.8.5"
+androidx-lifecycle-viewmodel-compose = "2.8.7"
 
 # OnymSDK — published to the static Maven repo at
 # raw.githubusercontent.com/onymchat/onym-sdk-kotlin/releases/
@@ -38,7 +41,11 @@ androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidx-biometric" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-viewmodel-compose" }
 
 # Kotlin / coroutines / serialization
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Android equivalent of [onym-ios PR #4](https://github.com/onymchat/onym-ios/pull/4). Same screens, same unidirectional shape, same testability seams. App boots straight into the flow.

## State machine

```
.intro
  │ tappedContinueFromIntro → authenticate()
  ├─► .authFailed(reason) ── dismissedAuthError → .intro
  └─► .reveal(phrase, revealed: false)
        │ tappedReveal     → revealed: true
        │ tappedCopyPhrase → clipboard write + 60s auto-clear
        │ tappedContinueFromReveal
        ▼
      .verify(phrase, rounds: 3, index: 0, .idle)
        │ picked(word):
        │   correct → .correct, delay 450ms,
        │             then advance index OR transition to .done
        │   wrong   → .wrong(word), retry same round
        ▼
      .done
        │ tappedDoneFromCompletion → .intro (single-screen app loop)
```

Preserved verbatim from iOS.

## What's in

- `RecoveryPhraseBackupViewModel` — sealed `Step` + `VerifyState` + `VerifyRound`; `StateFlow`-backed; `viewModelScope` for delays / clipboard auto-clear / verify-step advance; intent methods 1:1 with iOS; `authenticate()` exposed `internal` for tests.
- `RecoveryPhraseBackupScreen` — Compose root + Intro/Reveal/Verify/Done sub-composables; `AlertDialog` for auth failure; 2-column phrase grid with `Modifier.blur()` when hidden; `ProgressDots` with `animateDpAsState` for the active-dot capsule expand. **Layout numbers (paddings, corner radii, font sizes) translated 1:1 from the SwiftUI source.**
- `BiometricAuthenticator` — interface + `AndroidBiometricAuthenticator` backed by AndroidX `BiometricPrompt`. **Activity provider thunk** (not captured Activity) avoids leaking the host past configuration change. `BIOMETRIC_WEAK or DEVICE_CREDENTIAL` matches iOS's `.deviceOwnerAuthentication`. `canAuthenticate == false` → success without prompting (iOS fail-open parity).
- `ClipboardWriter` — interface + `AndroidClipboardWriter`. Sets `IS_SENSITIVE` on Android 13+ for redacted system clipboard preview. `clearIfStill()` only clears if the user hasn't copied something else in the meantime.
- `MainActivity` — switched `ComponentActivity` → `FragmentActivity` (req'd by `BiometricPrompt`). `FLAG_SECURE` on the window before `super.onCreate` blocks screenshots + recents thumbnail.
- 13-case instrumented test class — real `IdentityRepository` (per-test unique prefs file), fake authenticator + clipboard, short delays (50ms / 20ms) for sub-second wall time. Mirrors iOS's 13 XCTest cases 1:1 in name + behaviour.

## Architectural calls vs the brief

- **Activity provider thunk** for `BiometricPrompt`'s `FragmentActivity` requirement, exactly as the brief recommended. The Compose entry passes `{ this@MainActivity }` so each invocation re-resolves the current foregrounded activity rather than capturing an obsolete reference.
- **Recovery-phrase footer copy says "Screenshots are blocked on this screen"** — accurate on Android (`FLAG_SECURE`) where the iOS version was technically inaccurate (only obscured on background). Brief flagged this as a carry-over to choose; opted for Android-honest wording rather than verbatim-from-iOS.
- **`FLAG_SECURE` instead of an in-Compose obscure overlay**. The OS-level flag covers both screenshot suppression and recents-card redaction in one go — no need for a `LifecycleEventObserver`-driven Compose blanker.
- **Linter handled the one legitimate `.recoveryPhrase` read** in `authenticate()` with an inline `// onym:allow-secret-read` comment + 3-line justification. ViewModel didn't need to be added to the allowlist — the suppression marker is enough. Lint check exits 0.
- **Tests are instrumented (not JVM unit + fake repo)**. Mirrors iOS's "real Keychain behaviour or it doesn't count" rule — Android Keystore + EncryptedSharedPreferences only work under instrumentation; Robolectric doesn't simulate them. Same path as the existing `IdentityRepositoryTest`.

## Test results (local, in worktree)

```
./gradlew :app:testDebugUnitTest              → BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin  → BUILD SUCCESSFUL
python3 scripts/lint-secrets.py               → exit 0
```

The 13 instrumented cases are designed to run via `./gradlew :app:connectedDebugAndroidTest` against an emulator or attached device — not run locally yet (no emulator wired up).

## Test plan

- [ ] CI green on this PR (lint + JVM unit + compile gates)
- [ ] Manual: install on emulator/device, run through Intro → biometric prompt → Reveal → tap-to-reveal → Copy (verify clipboard preview shows "Sensitive" on Android 13+) → Continue → 3 verify rounds → Done → loop back to Intro
- [ ] Manual: take a screenshot from inside the flow → confirm system blocks it (`FLAG_SECURE`)
- [ ] Manual: `./gradlew :app:connectedDebugAndroidTest` against an emulator → all 13 instrumented cases pass

## Out of scope (future chunks)

- `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods — no callers yet.
- Onboarding (new-identity vs restore-from-mnemonic choice UI).
- Promoting `Bip39` into `onym-sdk-kotlin`.
- Emulator job in CI for instrumented tests.