### PR TITLE
Localization: strings.xml (en + ru) for the recovery-phrase flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,87 @@ Inject short delays in the test fixture
 (`clipboardClearDelay = 50ms`, `verifyAdvanceDelay = 20ms`) so the
 suite runs in well under a second.
 
+## Localization
+
+Strings live in [`app/src/main/res/values/strings.xml`](app/src/main/res/values/strings.xml)
+(English source) and [`app/src/main/res/values-ru/strings.xml`](app/src/main/res/values-ru/strings.xml)
+(Russian). Mirrors `Resources/Localizable.xcstrings` from onym-ios PR #5
+1:1 — same 27 strings + 1 plural, same wording, same Russian translations.
+
+### Compose access
+
+```kotlin
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
+
+Text(stringResource(R.string.your_identity_in_12_words))
+Text(pluralStringResource(R.plurals.write_down_words_in_order, count = words.size, words.size))
+```
+
+### Outside Composables: `StringProvider`
+
+[`RecoveryPhraseBackupViewModel`](app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt)
+holds no `Context` reference. The two strings it needs to resolve at
+runtime — the [`BiometricPrompt`](https://developer.android.com/reference/androidx/biometric/BiometricPrompt)
+title shown deep inside `authenticate()`, and the localized "recovery
+phrase unavailable" error — go through a small
+[`StringProvider`](app/src/main/kotlin/chat/onym/android/recovery/StringProvider.kt)
+seam:
+
+```kotlin
+interface StringProvider { operator fun get(@StringRes resId: Int): String }
+class AndroidStringProvider(context: Context) : StringProvider { … }
+```
+
+`MainActivity` injects the production impl backed by the application
+context. Tests provide `FakeStringProvider` returning
+`"string:$resId"` — assertions stay locale-independent.
+
+### Plurals
+
+Russian CLDR has four cardinal quantities: `one` (1, 21, 31; not 11),
+`few` (2-4, 22-24; not 12-14), `many` (0, 5-20, 25-30; the form `12`
+maps to → "12 слов"), and `other` (fractions like "1.5 слова").
+English has just `one` and `other`. The `MissingQuantity` lint check
+catches a translator who omits a CLDR-required form.
+
+### Lint gate
+
+[`lint { abortOnError = true }`](app/build.gradle.kts) +
+`MissingTranslation` (default-on) means a string added to
+`values/strings.xml` without a parallel `values-ru/` entry fails the
+build at `./gradlew :app:lintDebug`. Equivalent to iOS String Catalog's
+`state: new` warnings, but a hard gate.
+
+`app_name` is marked `translatable="false"` because "Onym" is a proper
+noun — keeps translators from inventing transliterations.
+
+### Adding a new language
+
+```sh
+mkdir -p app/src/main/res/values-fr
+cp app/src/main/res/values-ru/strings.xml app/src/main/res/values-fr/
+# … translate every <string> + <plurals> body
+./gradlew :app:lintDebug    # asserts complete coverage
+```
+
+Common BCP-47 region tags: `values-fr`, `values-de`, `values-es`,
+`values-zh-rCN`, `values-pt-rBR`.
+
+### Per-app language preference
+
+Android 13+ supports per-app language settings (Settings → System →
+Languages). When an in-app picker lands, wire it via
+[`AppCompatDelegate.setApplicationLocales`](https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setApplicationLocales(androidx.core.os.LocaleListCompat)).
+For now the app honours the device language.
+
+To smoke-test Russian without changing the device language:
+
+```sh
+adb shell am start -n chat.onym.android/.MainActivity \
+  --es android.intent.extra.LOCALE ru-RU
+```
+
 ## Out of scope (future chunks)
 
 - `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods —

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,19 @@ android {
         compose = true
     }
 
+    // Lint hard-gates the build on missing localizations: every string
+    // added to `res/values/strings.xml` must have a parallel entry in
+    // every `res/values-<lang>/strings.xml`, otherwise the lint
+    // `MissingTranslation` check fails. Equivalent to iOS String
+    // Catalog's `state: new` warnings, but enforced as a hard gate.
+    lint {
+        checkReleaseBuilds = true
+        abortOnError = true
+        // MissingTranslation is enabled by default; explicit re-enable
+        // below in case it gets suppressed in a future config sweep.
+        disable.remove("MissingTranslation")
+    }
+
     packaging {
         resources {
             // BouncyCastle ships duplicate META-INF entries that AGP

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
@@ -75,6 +75,9 @@ class RecoveryPhraseBackupViewModelTest {
             repository = repository,
             authenticator = authenticator,
             clipboard = clipboard,
+            // FakeStringProvider returns the resource id stringified —
+            // tests assert on Step shape + behaviour, not on locale.
+            strings = FakeStringProvider,
             // Short delays so the suite runs in well under a second.
             // iOS runs in ~800 ms; matching that order of magnitude.
             clipboardClearDelay = 50.milliseconds,
@@ -329,5 +332,11 @@ class RecoveryPhraseBackupViewModelTest {
         override fun clearIfStill(value: String) {
             if (lastWritten == value) didClear = true
         }
+    }
+
+    /** Returns the resource id stringified, so tests assert on
+     *  Step shape + behaviour rather than locale-specific copy. */
+    private object FakeStringProvider : StringProvider {
+        override fun get(resId: Int): String = "string:$resId"
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/MainActivity.kt
+++ b/app/src/main/kotlin/chat/onym/android/MainActivity.kt
@@ -12,6 +12,7 @@ import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.identity.IdentitySecretStore
 import chat.onym.android.recovery.AndroidBiometricAuthenticator
 import chat.onym.android.recovery.AndroidClipboardWriter
+import chat.onym.android.recovery.AndroidStringProvider
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 
@@ -55,6 +56,7 @@ class MainActivity : FragmentActivity() {
                         activityProvider = { this@MainActivity },
                     ),
                     clipboard = AndroidClipboardWriter(applicationContext),
+                    strings = AndroidStringProvider(applicationContext),
                 ) as T
             }
         }

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
@@ -42,12 +42,15 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
 import java.text.DateFormat
 import java.util.Date
 
@@ -81,9 +84,9 @@ fun RecoveryPhraseBackupScreen(
 
     val title = when (step) {
         is RecoveryPhraseBackupViewModel.Step.Intro,
-        is RecoveryPhraseBackupViewModel.Step.AuthFailed -> "Back up keys"
-        is RecoveryPhraseBackupViewModel.Step.Reveal    -> "Recovery phrase"
-        is RecoveryPhraseBackupViewModel.Step.Verify    -> "Verify"
+        is RecoveryPhraseBackupViewModel.Step.AuthFailed -> stringResource(R.string.back_up_keys)
+        is RecoveryPhraseBackupViewModel.Step.Reveal    -> stringResource(R.string.recovery_phrase_title)
+        is RecoveryPhraseBackupViewModel.Step.Verify    -> stringResource(R.string.verify)
         is RecoveryPhraseBackupViewModel.Step.Done      -> ""
     }
 
@@ -137,13 +140,17 @@ fun RecoveryPhraseBackupScreen(
     if (authFailed != null) {
         AlertDialog(
             onDismissRequest = viewModel::dismissedAuthError,
-            title = { Text("Authentication Failed") },
+            title = { Text(stringResource(R.string.authentication_failed)) },
             text = { Text(authFailed.reason) },
             confirmButton = {
-                TextButton(onClick = viewModel::tappedContinueFromIntro) { Text("Try Again") }
+                TextButton(onClick = viewModel::tappedContinueFromIntro) {
+                    Text(stringResource(R.string.try_again))
+                }
             },
             dismissButton = {
-                TextButton(onClick = viewModel::dismissedAuthError) { Text("Cancel") }
+                TextButton(onClick = viewModel::dismissedAuthError) {
+                    Text(stringResource(R.string.cancel))
+                }
             },
         )
     }
@@ -165,7 +172,7 @@ private fun IntroScreen(isReady: Boolean, onContinue: () -> Unit) {
                 .padding(top = 4.dp, bottom = 18.dp),
         )
 
-        SectionHeader("Before you start")
+        SectionHeader(stringResource(R.string.before_you_start))
         Column(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
@@ -175,19 +182,19 @@ private fun IntroScreen(isReady: Boolean, onContinue: () -> Unit) {
             IntroRow(
                 icon = Icons.Filled.Warning,
                 iconBg = Color(0xFFFF9800),
-                title = "Never share or photograph",
+                title = stringResource(R.string.rule_never_share),
                 separator = true,
             )
             IntroRow(
                 icon = Icons.Filled.Shield,
                 iconBg = Color(0xFF4CAF50),
-                title = "Store offline (paper or metal)",
+                title = stringResource(R.string.rule_store_offline),
                 separator = true,
             )
             IntroRow(
                 icon = Icons.Filled.Lock,
                 iconBg = Color(0xFF8E8E93),
-                title = "Anyone with it can read your chats",
+                title = stringResource(R.string.rule_anyone_can_read),
                 separator = false,
             )
         }
@@ -204,7 +211,10 @@ private fun IntroScreen(isReady: Boolean, onContinue: () -> Unit) {
         ) {
             Icon(Icons.Filled.Fingerprint, contentDescription = null)
             Spacer(Modifier.width(8.dp))
-            Text("Continue with biometrics", fontWeight = FontWeight.SemiBold)
+            Text(
+                stringResource(R.string.continue_with_biometrics),
+                fontWeight = FontWeight.SemiBold,
+            )
         }
     }
 }
@@ -238,13 +248,12 @@ private fun HeroCard(modifier: Modifier = Modifier) {
             )
         }
         Text(
-            "Your identity, in 12 words",
+            stringResource(R.string.your_identity_in_12_words),
             style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
             textAlign = TextAlign.Center,
         )
         Text(
-            "Write them down. Keep them offline. This phrase restores your Nostr, " +
-                    "Stellar, and BLS keys on any device.",
+            stringResource(R.string.recovery_phrase_intro_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -322,7 +331,11 @@ private fun RevealScreen(
             .padding(bottom = 28.dp),
     ) {
         Text(
-            "Write down these ${words.size} words in order. You'll confirm three of them on the next screen.",
+            pluralStringResource(
+                R.plurals.write_down_words_in_order,
+                count = words.size,
+                words.size,
+            ),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
@@ -363,7 +376,7 @@ private fun RevealScreen(
             ) {
                 Icon(Icons.Filled.ContentCopy, contentDescription = null, modifier = Modifier.size(18.dp))
                 Spacer(Modifier.width(6.dp))
-                Text("Copy", fontWeight = FontWeight.SemiBold)
+                Text(stringResource(R.string.copy), fontWeight = FontWeight.SemiBold)
             }
         }
 
@@ -377,12 +390,11 @@ private fun RevealScreen(
             shape = RoundedCornerShape(14.dp),
             contentPadding = PaddingValues(vertical = 14.dp),
         ) {
-            Text("I've written it down", fontWeight = FontWeight.SemiBold)
+            Text(stringResource(R.string.ive_written_it_down), fontWeight = FontWeight.SemiBold)
         }
 
         Text(
-            "The phrase is generated on-device and never sent off the device. " +
-                "Screenshots are blocked on this screen.",
+            stringResource(R.string.phrase_local_disclaimer),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier
@@ -395,10 +407,12 @@ private fun RevealScreen(
     if (copyConfirmShown) {
         AlertDialog(
             onDismissRequest = { copyConfirmShown = false },
-            title = { Text("Copied") },
-            text = { Text("Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now.") },
+            title = { Text(stringResource(R.string.copied)) },
+            text = { Text(stringResource(R.string.recovery_phrase_copied_message)) },
             confirmButton = {
-                TextButton(onClick = { copyConfirmShown = false }) { Text("OK") }
+                TextButton(onClick = { copyConfirmShown = false }) {
+                    Text(stringResource(R.string.ok))
+                }
             },
         )
     }
@@ -484,7 +498,7 @@ private fun PhraseCard(
                 }
                 Spacer(Modifier.height(10.dp))
                 Text(
-                    "Tap to reveal",
+                    stringResource(R.string.tap_to_reveal),
                     style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
                 )
             }
@@ -529,7 +543,7 @@ private fun VerifyScreen(
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Text(
-                "Select word number",
+                stringResource(R.string.select_word_number),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -567,7 +581,7 @@ private fun VerifyScreen(
 
         if (state is RecoveryPhraseBackupViewModel.VerifyState.Wrong) {
             Text(
-                "Not the right word. Check your phrase and try again.",
+                stringResource(R.string.not_the_right_word),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.error,
                 textAlign = TextAlign.Center,
@@ -692,15 +706,14 @@ private fun DoneScreen(onDone: () -> Unit) {
         Spacer(Modifier.height(24.dp))
 
         Text(
-            "Backup verified",
+            stringResource(R.string.backup_verified),
             style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
         )
 
         Spacer(Modifier.height(10.dp))
 
         Text(
-            "Your recovery phrase is confirmed. Store it somewhere safe — " +
-                    "you'll only need it if you lose this device.",
+            stringResource(R.string.backup_verified_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -717,13 +730,13 @@ private fun DoneScreen(onDone: () -> Unit) {
             shape = RoundedCornerShape(14.dp),
             contentPadding = PaddingValues(vertical = 14.dp),
         ) {
-            Text("Done", fontWeight = FontWeight.SemiBold)
+            Text(stringResource(R.string.done), fontWeight = FontWeight.SemiBold)
         }
 
         Spacer(Modifier.weight(1f))
 
         Text(
-            "Backed up ${dateString()} · BIP-39 English",
+            stringResource(R.string.backed_up_footer, dateString()),
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
@@ -2,6 +2,7 @@ package chat.onym.android.recovery
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import chat.onym.android.R
 import chat.onym.android.identity.Identity
 import chat.onym.android.identity.IdentityRepository
 import kotlinx.coroutines.Job
@@ -40,6 +41,7 @@ class RecoveryPhraseBackupViewModel(
     private val repository: IdentityRepository,
     private val authenticator: BiometricAuthenticator,
     private val clipboard: ClipboardWriter,
+    private val strings: StringProvider,
     private val clipboardClearDelay: Duration = 60.seconds,
     private val verifyAdvanceDelay: Duration = 450.milliseconds,
 ) : ViewModel() {
@@ -218,10 +220,14 @@ class RecoveryPhraseBackupViewModel(
     internal suspend fun authenticate() {
         try {
             authenticator.authenticate(
-                title = "Authenticate to reveal your recovery phrase",
+                title = strings[R.string.authenticate_to_reveal_recovery_phrase],
             )
         } catch (t: Throwable) {
-            _step.value = Step.AuthFailed(reason = t.message ?: t::class.qualifiedName ?: "Authentication failed")
+            _step.value = Step.AuthFailed(
+                reason = t.message
+                    ?: t::class.qualifiedName
+                    ?: strings[R.string.authentication_failed],
+            )
             return
         }
         // onym:allow-secret-read: revealing the recovery phrase to the user
@@ -231,7 +237,7 @@ class RecoveryPhraseBackupViewModel(
         val phrase = currentIdentity?.recoveryPhrase
         if (phrase == null) {
             _step.value = Step.AuthFailed(
-                reason = "Recovery phrase unavailable. Your identity may not be BIP39-backed.",
+                reason = strings[R.string.recovery_phrase_unavailable],
             )
             return
         }

--- a/app/src/main/kotlin/chat/onym/android/recovery/StringProvider.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/StringProvider.kt
@@ -1,0 +1,35 @@
+package chat.onym.android.recovery
+
+import android.content.Context
+import androidx.annotation.StringRes
+
+/**
+ * Minimal seam over [Context.getString] so the [RecoveryPhraseBackupViewModel]
+ * can resolve localized strings without holding a [Context].
+ *
+ * The ViewModel needs two strings that the view layer can't supply:
+ *
+ *   - the prompt title shown by `BiometricPrompt` (must be passed at
+ *     the moment the prompt is invoked, deep inside an `authenticate()`
+ *     coroutine)
+ *   - the localized error message when no recovery phrase is available
+ *     (resolved at the moment of failure, no Composable around)
+ *
+ * Symmetric with iOS's `String(localized:)` wrapper. Tests provide a
+ * fake that returns the resource name itself, so assertions stay
+ * locale-independent.
+ */
+interface StringProvider {
+    /** Resolve a plain string resource. */
+    operator fun get(@StringRes resId: Int): String
+}
+
+/**
+ * Production [StringProvider] backed by an Android [Context]. Use the
+ * application context (not an Activity) so we don't pin an Activity
+ * past configuration change — the localized resource set is the same
+ * either way.
+ */
+class AndroidStringProvider(private val context: Context) : StringProvider {
+    override fun get(resId: Int): String = context.getString(resId)
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Russian translations. Match en-source strings in `values/strings.xml`
+    1:1 by key. Pre-translated and verified against
+    `Resources/Localizable.xcstrings` `ru` localizations on iOS.
+
+    Russian plural quantities: `one` (e.g. 1, 21, 31; not 11),
+    `few` (e.g. 2-4, 22-24; not 12-14), `other` (everything else).
+-->
+<resources>
+
+    <!-- ─── Top-bar / nav titles ─────────────────────────────────── -->
+    <string name="back_up_keys">Резервная копия ключей</string>
+    <string name="recovery_phrase_title">Фраза восстановления</string>
+    <string name="verify">Проверка</string>
+
+    <!-- ─── Auth failure dialog ──────────────────────────────────── -->
+    <string name="authentication_failed">Не удалось аутентифицироваться</string>
+    <string name="try_again">Повторить</string>
+    <string name="cancel">Отмена</string>
+
+    <!-- ─── Intro screen ─────────────────────────────────────────── -->
+    <string name="your_identity_in_12_words">Ваша личность в 12 словах</string>
+    <string name="recovery_phrase_intro_subtitle">Запишите их. Храните офлайн. Эта фраза восстанавливает ваши ключи Nostr, Stellar и BLS на любом устройстве.</string>
+    <string name="before_you_start">Перед началом</string>
+    <string name="rule_never_share">Никому не показывайте и не фотографируйте</string>
+    <string name="rule_store_offline">Храните офлайн (бумага или металл)</string>
+    <string name="rule_anyone_can_read">Любой обладатель сможет читать ваши чаты</string>
+    <string name="continue_with_biometrics">Продолжить с биометрией</string>
+
+    <!-- ─── Reveal screen ────────────────────────────────────────── -->
+    <!-- Russian CLDR plurals: `one` for 1/21/31/… (not 11), `few` for
+         2-4/22-24/… (not 12-14), `many` for 0/5-20/25-30/… (this is
+         the form 12 maps to → "12 слов"), `other` for fractions
+         like "1.5 слова". -->
+    <plurals name="write_down_words_in_order">
+        <item quantity="one">Запишите %1$d слово по порядку. На следующем экране нужно будет подтвердить три из них.</item>
+        <item quantity="few">Запишите %1$d слова по порядку. На следующем экране нужно будет подтвердить три из них.</item>
+        <item quantity="many">Запишите %1$d слов по порядку. На следующем экране нужно будет подтвердить три из них.</item>
+        <item quantity="other">Запишите %1$d слова по порядку. На следующем экране нужно будет подтвердить три из них.</item>
+    </plurals>
+    <string name="copy">Копировать</string>
+    <string name="ive_written_it_down">Я записал(а)</string>
+    <string name="phrase_local_disclaimer">Фраза создаётся на устройстве и никогда его не покидает.</string>
+    <string name="copied">Скопировано</string>
+    <string name="ok">ОК</string>
+    <string name="recovery_phrase_copied_message">Фраза восстановления скопирована. Через 60 секунд она будет удалена из буфера обмена. Сохраните её сейчас в надёжном месте.</string>
+    <string name="tap_to_reveal">Нажмите, чтобы показать</string>
+
+    <!-- ─── Verify screen ────────────────────────────────────────── -->
+    <string name="select_word_number">Выберите слово номер</string>
+    <string name="not_the_right_word">Это не то слово. Проверьте фразу и повторите попытку.</string>
+
+    <!-- ─── Done screen ──────────────────────────────────────────── -->
+    <string name="backup_verified">Резервная копия подтверждена</string>
+    <string name="backup_verified_subtitle">Ваша фраза восстановления подтверждена. Храните её в безопасном месте — она понадобится только при потере устройства.</string>
+    <string name="done">Готово</string>
+    <string name="backed_up_footer">Резервное копирование: %1$s · BIP-39 (англ.)</string>
+
+    <!-- ─── ViewModel-resolved strings (no Composable available) ── -->
+    <string name="authenticate_to_reveal_recovery_phrase">Подтвердите личность, чтобы увидеть фразу восстановления</string>
+    <string name="recovery_phrase_unavailable">Фраза восстановления недоступна. Возможно, ваша личность не привязана к BIP-39.</string>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    English source strings for the recovery-phrase backup flow.
+    Mirror of `Resources/Localizable.xcstrings` in onym-ios PR #5
+    (commit 36bd1c4) — same 27 strings + 1 plural, same wording.
+
+    See `values-ru/strings.xml` for the Russian translations. The
+    `MissingTranslation` lint check (enabled in app/build.gradle.kts)
+    fails the build if a string lands here without a parallel
+    `values-<lang>/strings.xml` entry.
+
+    Keys are snake_case per Android convention. Apostrophes inside
+    `<string>` and `<item>` content are escaped as `\'`.
+-->
 <resources>
-    <string name="app_name">Onym</string>
+
+    <!-- App identity. Proper noun — `translatable="false"` so per-locale
+         strings.xml files don't have to (and shouldn't) translate it. -->
+    <string name="app_name" translatable="false">Onym</string>
+
+    <!-- ─── Top-bar / nav titles ─────────────────────────────────── -->
+    <string name="back_up_keys">Back up keys</string>
+    <string name="recovery_phrase_title">Recovery phrase</string>
+    <string name="verify">Verify</string>
+
+    <!-- ─── Auth failure dialog ──────────────────────────────────── -->
+    <string name="authentication_failed">Authentication Failed</string>
+    <string name="try_again">Try Again</string>
+    <string name="cancel">Cancel</string>
+
+    <!-- ─── Intro screen ─────────────────────────────────────────── -->
+    <string name="your_identity_in_12_words">Your identity, in 12 words</string>
+    <string name="recovery_phrase_intro_subtitle">Write them down. Keep them offline. This phrase restores your Nostr, Stellar, and BLS keys on any device.</string>
+    <string name="before_you_start">Before you start</string>
+    <string name="rule_never_share">Never share or photograph</string>
+    <string name="rule_store_offline">Store offline (paper or metal)</string>
+    <string name="rule_anyone_can_read">Anyone with it can read your chats</string>
+    <string name="continue_with_biometrics">Continue with biometrics</string>
+
+    <!-- ─── Reveal screen ────────────────────────────────────────── -->
+    <plurals name="write_down_words_in_order">
+        <item quantity="one">Write down this %1$d word in order. You\'ll confirm three of them on the next screen.</item>
+        <item quantity="other">Write down these %1$d words in order. You\'ll confirm three of them on the next screen.</item>
+    </plurals>
+    <string name="copy">Copy</string>
+    <string name="ive_written_it_down">I\'ve written it down</string>
+    <string name="phrase_local_disclaimer">The phrase is generated on-device and never sent off the device. Screenshots are blocked on this screen.</string>
+    <string name="copied">Copied</string>
+    <string name="ok">OK</string>
+    <string name="recovery_phrase_copied_message">Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now.</string>
+    <string name="tap_to_reveal">Tap to reveal</string>
+
+    <!-- ─── Verify screen ────────────────────────────────────────── -->
+    <string name="select_word_number">Select word number</string>
+    <string name="not_the_right_word">Not the right word. Check your phrase and try again.</string>
+
+    <!-- ─── Done screen ──────────────────────────────────────────── -->
+    <string name="backup_verified">Backup verified</string>
+    <string name="backup_verified_subtitle">Your recovery phrase is confirmed. Store it somewhere safe — you\'ll only need it if you lose this device.</string>
+    <string name="done">Done</string>
+    <string name="backed_up_footer">Backed up %1$s · BIP-39 English</string>
+
+    <!-- ─── ViewModel-resolved strings (no Composable available) ── -->
+    <string name="authenticate_to_reveal_recovery_phrase">Authenticate to reveal your recovery phrase</string>
+    <string name="recovery_phrase_unavailable">Recovery phrase unavailable. Your identity may not be BIP39-backed.</string>
+
 </resources>


### PR DESCRIPTION
Android equivalent of [onym-ios PR #5](https://github.com/onymchat/onym-ios/pull/5). Same 27 strings + 1 plural, same Russian translations, expressed in Android's native resource model.

Stacked on PR #4 originally; rebased onto squash-merged main once #4 landed.

## What's in

- **`res/values/strings.xml`** — English source, 27 strings + 1 plural. `app_name` marked `translatable="false"` (proper noun).
- **`res/values-ru/strings.xml`** — Russian translations.
- **`StringProvider` interface + `AndroidStringProvider`** — injected into [`RecoveryPhraseBackupViewModel`](app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt) for the BiometricPrompt title + the "recovery phrase unavailable" error message that need to resolve outside a Composable. Symmetric with iOS's `String(localized:)` wrapper. Tests use `FakeStringProvider` returning `"string:$resId"` so assertions stay locale-independent.
- **All Composables in the recovery-phrase flow** use `stringResource()` / `pluralStringResource()` / `stringResource(..., vararg)`. No hardcoded user-facing literals remain.
- **Lint config** — `abortOnError = true`; `MissingTranslation` explicitly re-enabled. Build fails on any en string without a parallel ru entry.

## Architectural calls vs the brief

- **`StringProvider` injection over Composable-passing** for the auth-failure paths. Brief listed both options; injection wins because the auth-fail message is constructed deep inside an `authenticate()` coroutine — no Composable around to resolve at the moment of failure.
- **"Continue with biometrics" copy (generic)** instead of querying `BiometricManager` for "fingerprint" / "face unlock" variants. System BiometricPrompt renders the device-specific UI on top of generic copy; brief recommended this.
- **"Backed up Y · BIP-39 English" → "Резервное копирование: Y · BIP-39 (англ.)"** — Russian translates BIP-39 with a parenthetical language note rather than translating the technical name.

## Lint surfaced two issues the brief didn't anticipate

1. **`MissingQuantity`** — Russian needs `many` quantity per CLDR (the form `12` maps to → "12 слов"). Brief said `one` / `few` / `other`; corrected to `one` / `few` / `many` / `other`.
2. **`MissingTranslation` on `app_name`** — marked `translatable="false"` since "Onym" is a proper noun. Keeps translators from inventing transliterations.

## Local checks (in the worktree)

```
./gradlew :app:lintDebug                       → BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest               → BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin   → BUILD SUCCESSFUL
python3 scripts/lint-secrets.py                → exit 0
```

## Test plan

- [ ] CI green (lint, JVM unit tests both gate on this change)
- [ ] Manual: install on emulator with system locale = Russian, navigate the recovery flow, confirm Russian copy renders end-to-end
- [ ] Manual: `adb shell am start -n chat.onym.android/.MainActivity --es android.intent.extra.LOCALE ru-RU` to force Russian without changing the system language
- [ ] Manual: run with 1 word → "Запишите 1 слово…" (`one`); 2 words → "слова" (`few`); 12 words (default) → "слов" (`many`); 24 words → "слова" (`few`). Plural quantity selection rule verification.

## Out of scope (future chunks)

- Per-app language picker UI (`AppCompatDelegate.setApplicationLocales`)
- Additional locales beyond en + ru