### PR TITLE
fix: 16-KB ELF page alignment for Android 15+ devices

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,11 @@ kotlinx-serialization = "1.7.3"
 androidx-core-ktx = "1.15.0"
 androidx-lifecycle = "2.8.7"
 androidx-activity-compose = "1.9.3"
-androidx-compose-bom = "2024.12.01"
+# Compose BOM 2025.01.01 — first stable BOM that pulls in
+# `androidx.graphics:graphics-path:1.0.1`, the version with 16-KB
+# ELF page alignment for libandroidx.graphics.path.so. Earlier BOMs
+# trip the Android 15+ "App Compatibility" warning at first launch.
+androidx-compose-bom = "2025.01.01"
 androidx-security-crypto = "1.1.0-alpha06"
 androidx-biometric = "1.2.0-alpha05"
 androidx-fragment = "1.8.5"
@@ -19,7 +23,10 @@ androidx-lifecycle-viewmodel-compose = "2.8.7"
 
 # OnymSDK — published to the static Maven repo at
 # raw.githubusercontent.com/onymchat/onym-sdk-kotlin/releases/
-onym-sdk = "0.0.1"
+# v0.0.2: 16-KB ELF page-aligned libonym_sdk_jni.so for Android 15+
+# (linker `-Wl,-z,max-page-size=16384`). v0.0.1 trips the "App
+# Compatibility" warning + will be Play-Store-rejected from Nov 2025.
+onym-sdk = "0.0.2"
 
 # Crypto
 bouncycastle = "1.78.1"


### PR DESCRIPTION
Fixes the "App Compatibility" warning [you saw on a 16-KB-page Android device](https://github.com/onymchat/onym-android/pull/5#issuecomment-) — both flagged libraries now ship 16-KB-aligned LOAD segments.

## Two bumps

| Dep                                  | Before        | After          | Fixes                                |
|--------------------------------------|---------------|----------------|--------------------------------------|
| `chat.onym:onym-sdk`                 | `0.0.1`       | `0.0.2`        | `lib/<abi>/libonym_sdk_jni.so`       |
| `androidx.compose:compose-bom`       | `2024.12.01`  | `2025.01.01`   | `lib/<abi>/libandroidx.graphics.path.so` |

The SDK fix landed in [onym-sdk-kotlin#6](https://github.com/onymchat/onym-sdk-kotlin/pull/6) (linker `-Wl,-z,max-page-size=16384`). The Compose BOM bump pulls in `androidx.graphics:graphics-path:1.0.1` — the first version with 16-KB ELF alignment for that lib.

## Verified end-to-end

`./gradlew :app:assembleRelease`, then parse every `.so` in the APK:

```
lib/arm64-v8a/libandroidx.graphics.path.so       OK (16 KB)
lib/arm64-v8a/libonym_sdk_jni.so                 OK (16 KB)
lib/armeabi-v7a/libandroidx.graphics.path.so     OK (16 KB)
lib/armeabi-v7a/libonym_sdk_jni.so               OK (16 KB)
lib/x86/libandroidx.graphics.path.so             OK (16 KB)
lib/x86/libonym_sdk_jni.so                       OK (16 KB)
lib/x86_64/libandroidx.graphics.path.so          OK (16 KB)
lib/x86_64/libonym_sdk_jni.so                    OK (16 KB)
Result: ALL .so files 16-KB-aligned ✓
```

(Same Python ELF parser used in the SDK PR — handles both ELF32 and ELF64 program headers.)

## Background

The default ld.lld page-size for `-target *-android` is 4096 — the NDK was built when 4 KB was the only Android page size. Without an explicit `-Wl,-z,max-page-size=16384`, every produced `.so` ships at 4-KB alignment. Android 15+ on devices with 16-KB pages then runs the app in a "page size compatible mode" and pops the warning, AND **Play Store rejects 16-KB-misaligned APKs starting Nov 2025** per the [platform 16-KB requirement](https://developer.android.com/guide/practices/page-sizes).

zipalign at the APK level handles the OTHER half of the 16-KB story (positioning `.so` entries within the APK on a 16-KB boundary) — that's already correct because `release.yml` invokes the build-tools 35.0.0 zipalign which defaults to 16-KB page alignment when `-p` is set.

## Test plan

- [ ] CI green
- [ ] After merge, cut a v0.0.2 release: `gh workflow run Release -f tag=v0.0.2`
- [ ] Sideload the v0.0.2 APK on the same 16-KB-page device that showed the warning — the "App Compatibility" dialog should not appear

## Note on version

This PR doesn't bump `app/build.gradle.kts`'s `versionName` from `0.0.1` — leaving that to the user since the bug-fix-vs-version-policy call is a judgment thing. If you want a v0.0.2 release out of this, bump versionName to `0.0.2` (and `versionCode` to `2`) before triggering the release workflow.