### PR TITLE
App shell: NavigationBar with Settings + Search; backup gated behind Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,12 +452,59 @@ adb shell am start -n chat.onym.android/.MainActivity \
   --es android.intent.extra.LOCALE ru-RU
 ```
 
+## App shell
+
+Sole entry point: [`MainActivity`](app/src/main/kotlin/chat/onym/android/MainActivity.kt)
+mounts [`RootScreen`](app/src/main/kotlin/chat/onym/android/RootScreen.kt) —
+a `Scaffold` with Material 3 [`NavigationBar`](https://developer.android.com/reference/kotlin/androidx/compose/material3/package-summary#NavigationBar(androidx.compose.ui.Modifier,androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color,androidx.compose.ui.unit.Dp,androidx.compose.foundation.layout.WindowInsets,kotlin.Function1))
+across the bottom and a [`NavHost`](https://developer.android.com/reference/kotlin/androidx/navigation/compose/package-summary)
+for the content slot.
+
+```
+MainActivity (FragmentActivity, FLAG_SECURE, enableEdgeToEdge)
+    │
+    ▼
+RootScreen
+    │  Scaffold(bottomBar = NavigationBar { Settings | Search })
+    │
+    ├─► SettingsScreen           (route "settings")
+    │     └── Backup row → navigate("recovery_backup")
+    │                          ▼
+    │                    RecoveryPhraseBackupScreen  (route "recovery_backup",
+    │                                                 bottom bar hidden)
+    │
+    └─► SearchScreen             (route "search", placeholder)
+```
+
+### Divergences from iOS PR #6
+
+- **No `.search` role / floating-bottom-right tab.** Material 3 has
+  no equivalent and faking it would make the app feel un-native on
+  Android. Both items live in the same nav bar with equal weight —
+  same as Gmail / Calendar / Drive / Files.
+- **Backup flow as a navigation destination, not a `ModalBottomSheet`.**
+  Android-idiomatic for a multi-step flow (Intro → Reveal → Verify
+  → Done); supports the system back gesture without ceremony. iOS
+  uses `.sheet` for the same role.
+- **Bottom bar hidden on the `recovery_backup` destination.** The
+  flow gets full vertical real-estate; the `TopAppBar` back arrow +
+  system back gesture are the way out.
+
+### Edge-to-edge
+
+`enableEdgeToEdge()` in `MainActivity.onCreate` opts in for Android
+14 and earlier; Android 15+ does this by default at
+`targetSdkVersion 35+`. `Scaffold` downstream applies the matching
+[`WindowInsets`](https://developer.android.com/develop/ui/views/layout/edge-to-edge)
+padding so content never sits under the status / navigation bars.
+
 ## Out of scope (future chunks)
 
 - `repo.stellarSign(_)` / `repo.decryptInvitation(_)` methods —
   no callers yet, lands when transport / invitation does.
-- Onboarding (this is just the backup flow; new-identity choice
-  vs restore-from-mnemonic UI is a future chunk).
+- Onboarding (new-identity choice vs restore-from-mnemonic UI).
+- Real Search screen (placeholder for now).
+- More Settings sections (preferences, advanced, about).
 - Promoting `Bip39` into `onym-sdk-kotlin` — wait for a third client
   to want the same derivation.
 - Emulator job in CI for instrumented tests.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
 
     // BiometricPrompt requires a FragmentActivity host. fragment-ktx
     // pulls in the FragmentActivity class; biometric pulls in the

--- a/app/src/main/kotlin/chat/onym/android/MainActivity.kt
+++ b/app/src/main/kotlin/chat/onym/android/MainActivity.kt
@@ -3,6 +3,7 @@ package chat.onym.android
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.material3.MaterialTheme
 import androidx.fragment.app.FragmentActivity
@@ -13,26 +14,27 @@ import chat.onym.android.identity.IdentitySecretStore
 import chat.onym.android.recovery.AndroidBiometricAuthenticator
 import chat.onym.android.recovery.AndroidClipboardWriter
 import chat.onym.android.recovery.AndroidStringProvider
-import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 
 /**
- * Sole entry point. Mounts [RecoveryPhraseBackupScreen] as the root —
- * for now the entire app IS the back-up flow; subsequent chunks add
- * a home screen and demote this to a nav destination.
+ * Sole entry point. Mounts [RootScreen] as the content; the recovery-
+ * phrase backup flow is reachable via the Settings tab → Backup row.
  *
  * Extends [FragmentActivity] (not [ComponentActivity][androidx.activity.ComponentActivity])
  * because [androidx.biometric.BiometricPrompt] attaches its dialog
  * fragment to a `FragmentActivity` host.
  *
  * Sets [WindowManager.LayoutParams.FLAG_SECURE] on the window before
- * `super.onCreate` so:
- *   - screenshots / screen recording are blocked across the whole app
- *   - the recents thumbnail is rendered as a blank surface
+ * `super.onCreate` so screenshots / screen recording are blocked
+ * across the whole app and the recents thumbnail is rendered as a
+ * blank surface — stronger than iOS's scene-phase obscure overlay
+ * (which only blanks the recents preview on backgrounding).
  *
- * That's a stronger guarantee than iOS's scene-phase obscure overlay
- * (which only blanks the recents preview on backgrounding) — covers
- * both screenshot suppression and recents-card redaction in one flag.
+ * Calls [enableEdgeToEdge] so the app draws under the system bars on
+ * Android 14 and earlier (Android 15+ does this by default at
+ * `targetSdkVersion 35+`). Compose [androidx.compose.material3.Scaffold]
+ * downstream applies the matching `WindowInsets` padding so content
+ * never sits under the status / navigation bars.
  */
 class MainActivity : FragmentActivity() {
 
@@ -42,7 +44,7 @@ class MainActivity : FragmentActivity() {
         )
     }
 
-    private val viewModel: RecoveryPhraseBackupViewModel by viewModels {
+    private val recoveryViewModel: RecoveryPhraseBackupViewModel by viewModels {
         object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 @Suppress("UNCHECKED_CAST")
@@ -63,6 +65,7 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         window.setFlags(
             WindowManager.LayoutParams.FLAG_SECURE,
             WindowManager.LayoutParams.FLAG_SECURE,
@@ -70,7 +73,7 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             MaterialTheme {
-                RecoveryPhraseBackupScreen(viewModel = viewModel)
+                RootScreen(recoveryViewModel = recoveryViewModel)
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -1,0 +1,121 @@
+package chat.onym.android
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import chat.onym.android.recovery.RecoveryPhraseBackupScreen
+import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
+import chat.onym.android.search.SearchScreen
+import chat.onym.android.settings.SettingsScreen
+
+/**
+ * App shell. `Scaffold` + Material 3 [NavigationBar] across the bottom,
+ * a [NavHost] for the content slot. Two tabs (Settings, Search) plus a
+ * full-screen `recovery_backup` destination pushed from the Settings
+ * row.
+ *
+ * Mirrors `RootView.swift` from onym-ios PR #6 in shape:
+ *
+ *   - Settings tab is the entry point for the recovery-phrase backup
+ *     flow (gated behind a Backup row tap).
+ *   - Search tab is a placeholder (real search lands later).
+ *
+ * **Diverges from iOS** in two ways the brief called out:
+ *
+ *   - No `.search` role / bottom-right floating tab (Material 3 has no
+ *     equivalent; would create cross-platform inconsistency without
+ *     buying anything Android users expect). Both items live in the
+ *     same nav bar with equal weight — same as Gmail / Calendar /
+ *     Drive / Files.
+ *   - Backup flow is a navigation destination (not a `ModalBottomSheet`).
+ *     Android-idiomatic for a multi-step flow; supports system back
+ *     gesture without ceremony.
+ */
+@Composable
+fun RootScreen(recoveryViewModel: RecoveryPhraseBackupViewModel) {
+    val navController = rememberNavController()
+    val currentEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentEntry?.destination?.route
+
+    Scaffold(
+        bottomBar = {
+            // Hide the bottom bar on the recovery-backup destination so
+            // the multi-step flow has full vertical real-estate (the
+            // back gesture / TopAppBar back arrow is the way out).
+            if (currentRoute in TAB_ROUTES) {
+                NavigationBar {
+                    Tab.entries.forEach { tab ->
+                        NavigationBarItem(
+                            icon = { Icon(tab.icon(), contentDescription = null) },
+                            label = { Text(stringResource(tab.labelRes)) },
+                            selected = currentRoute == tab.route,
+                            onClick = {
+                                navController.navigate(tab.route) {
+                                    // Keep a single instance of each tab destination
+                                    // and re-use the existing one when the user
+                                    // re-taps; pop intermediate destinations off
+                                    // the back stack so a tab tap is always a
+                                    // "go back to root of this tab" move.
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        },
+    ) { padding ->
+        NavHost(
+            navController = navController,
+            startDestination = Tab.Settings.route,
+            modifier = androidx.compose.ui.Modifier.padding(padding),
+        ) {
+            composable(Tab.Settings.route) {
+                SettingsScreen(
+                    onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
+                )
+            }
+            composable(Tab.Search.route) {
+                SearchScreen()
+            }
+            composable(ROUTE_RECOVERY_BACKUP) {
+                RecoveryPhraseBackupScreen(
+                    viewModel = recoveryViewModel,
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
+        }
+    }
+}
+
+private enum class Tab(val route: String, val labelRes: Int) {
+    Settings("settings", R.string.settings),
+    Search("search", R.string.search);
+
+    @Composable
+    fun icon() = when (this) {
+        Settings -> Icons.Filled.Settings
+        Search -> Icons.Filled.Search
+    }
+}
+
+private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
+private val TAB_ROUTES = setOf(Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Fingerprint
@@ -19,6 +20,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -74,6 +76,7 @@ import java.util.Date
 fun RecoveryPhraseBackupScreen(
     viewModel: RecoveryPhraseBackupViewModel,
     modifier: Modifier = Modifier,
+    onBackClick: (() -> Unit)? = null,
 ) {
     val step by viewModel.step.collectAsStateWithLifecycle()
     val isReady by viewModel.isReady.collectAsStateWithLifecycle()
@@ -94,7 +97,19 @@ fun RecoveryPhraseBackupScreen(
         modifier = modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
         topBar = {
-            CenterAlignedTopAppBar(title = { Text(title) })
+            CenterAlignedTopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    if (onBackClick != null) {
+                        IconButton(onClick = onBackClick) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(R.string.back),
+                            )
+                        }
+                    }
+                },
+            )
         },
     ) { padding ->
         Surface(

--- a/app/src/main/kotlin/chat/onym/android/search/SearchScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/search/SearchScreen.kt
@@ -1,0 +1,70 @@
+package chat.onym.android.search
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+
+/**
+ * Search tab placeholder. Real search lands in a future chunk; this
+ * screen exists so the bottom navigation has a destination for the
+ * Search tab.
+ *
+ * Material 3 has no direct equivalent of iOS's
+ * `ContentUnavailableView`, so we compose one — centred icon + title
+ * + body — with the same content shape as the iOS impl.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen() {
+    Scaffold(
+        topBar = {
+            LargeTopAppBar(title = { Text(stringResource(R.string.search)) })
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                Icons.Filled.Search,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                stringResource(R.string.search),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+            Text(
+                stringResource(R.string.search_placeholder_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp, start = 32.dp, end = 32.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -1,0 +1,146 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+
+/**
+ * Settings tab — entry point for the recovery-phrase backup flow.
+ * Minimal first cut: one Security section with the Backup row that
+ * navigates to [chat.onym.android.recovery.RecoveryPhraseBackupScreen].
+ *
+ * Mirrors `SettingsView.swift` from onym-ios PR #6 (PR #6 there, not
+ * the onym-android #6). More sections (preferences, advanced, about)
+ * land as the app grows.
+ *
+ * UX choices vs iOS:
+ *
+ *   - `LargeTopAppBar` = SwiftUI's `.navigationTitle("Settings")` in
+ *     iOS 16+ default (large title that collapses on scroll).
+ *   - `ListItem` + `headlineContent`/`leadingContent`/`trailingContent`
+ *     = the iOS Form row shape.
+ *   - The orange key-icon RoundedRect ([SettingsIconBox]) is the same
+ *     atom the recovery-flow Intro screen's rules list uses.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(onBackupClick: () -> Unit) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
+        rememberTopAppBarState()
+    )
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.settings)) },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(contentPadding = padding) {
+            item {
+                SectionHeader(stringResource(R.string.security))
+            }
+            item {
+                ListItem(
+                    headlineContent = {
+                        Text(stringResource(R.string.backup_recovery_phrase))
+                    },
+                    leadingContent = {
+                        SettingsIconBox(
+                            icon = Icons.Filled.Key,
+                            background = Color(0xFFFF9500),
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(onClick = onBackupClick),
+                )
+            }
+            item {
+                Text(
+                    stringResource(R.string.security_footer_view_recovery_phrase),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .padding(horizontal = 32.dp)
+            .padding(top = 16.dp, bottom = 6.dp),
+    )
+}
+
+/**
+ * 30dp coloured RoundedRect with a centred Icon inside. Matches the
+ * iOS `SettingsIconBox` and the recovery-flow `RoundedIcon` from the
+ * Intro screen.
+ */
+@Composable
+private fun SettingsIconBox(icon: ImageVector, background: Color) {
+    Box(
+        modifier = Modifier
+            .size(30.dp)
+            .clip(RoundedCornerShape(7.dp))
+            .background(background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(15.dp),
+        )
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -61,4 +61,13 @@
     <string name="authenticate_to_reveal_recovery_phrase">Подтвердите личность, чтобы увидеть фразу восстановления</string>
     <string name="recovery_phrase_unavailable">Фраза восстановления недоступна. Возможно, ваша личность не привязана к BIP-39.</string>
 
+    <!-- ─── App shell (RootScreen + tabs) ────────────────────────── -->
+    <string name="back">Назад</string>
+    <string name="settings">Настройки</string>
+    <string name="search">Поиск</string>
+    <string name="security">Безопасность</string>
+    <string name="backup_recovery_phrase">Резервная копия фразы восстановления</string>
+    <string name="security_footer_view_recovery_phrase">Просмотрите свою фразу восстановления из 12 слов. Она понадобится для восстановления личности на новом устройстве.</string>
+    <string name="search_placeholder_body">Поиск появится в одном из следующих обновлений.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,13 @@
     <string name="authenticate_to_reveal_recovery_phrase">Authenticate to reveal your recovery phrase</string>
     <string name="recovery_phrase_unavailable">Recovery phrase unavailable. Your identity may not be BIP39-backed.</string>
 
+    <!-- ─── App shell (RootScreen + tabs) ────────────────────────── -->
+    <string name="back">Back</string>
+    <string name="settings">Settings</string>
+    <string name="search">Search</string>
+    <string name="security">Security</string>
+    <string name="backup_recovery_phrase">Backup Recovery Phrase</string>
+    <string name="security_footer_view_recovery_phrase">View your 12-word recovery phrase. You will need it to restore your identity on a new device.</string>
+    <string name="search_placeholder_body">Search lands in a later chunk.</string>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidx-security-crypto = "1.1.0-alpha06"
 androidx-biometric = "1.2.0-alpha05"
 androidx-fragment = "1.8.5"
 androidx-lifecycle-viewmodel-compose = "2.8.7"
+androidx-navigation-compose = "2.8.5"
 
 # OnymSDK — published to the static Maven repo at
 # raw.githubusercontent.com/onymchat/onym-sdk-kotlin/releases/
@@ -53,6 +54,7 @@ androidx-security-crypto = { module = "androidx.security:security-crypto", versi
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "androidx-biometric" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-viewmodel-compose" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
 
 # Kotlin / coroutines / serialization
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
Android equivalent of [onym-ios PR #6](https://github.com/onymchat/onym-ios/pull/6). App boots into a Material 3 `NavigationBar` with two tabs (Settings, Search); the recovery-phrase backup flow is now reachable via Settings → Backup row.

## Architecture

```
MainActivity (FragmentActivity, FLAG_SECURE, enableEdgeToEdge)
    │
    ▼
RootScreen
    │  Scaffold(bottomBar = NavigationBar { Settings | Search })
    │
    ├─► SettingsScreen           (route "settings")
    │     └── Backup row → navigate("recovery_backup")
    │                          ▼
    │                    RecoveryPhraseBackupScreen  (route "recovery_backup",
    │                                                 bottom bar hidden)
    │
    └─► SearchScreen             (route "search", placeholder)
```

## Architectural calls vs the brief

- **Backup as a navigation destination, not a `ModalBottomSheet`**. Brief recommended this; Android-idiomatic for a multi-step flow (Intro → Reveal → Verify → Done); supports the system back gesture without ceremony.
- **No `.search` role / floating-bottom-right tab**. Material 3 has no equivalent and faking it would make the app feel un-native on Android. Both items live in the same NavigationBar with equal weight — same as Gmail / Calendar / Drive / Files.
- **Bottom bar hidden on the `recovery_backup` destination** so the multi-step flow has full vertical real-estate. The TopAppBar back arrow + system back gesture are the way out.
- **Single `NavHost` with all routes** (top-level routes for both tabs + the recovery destination), rather than a nested NavController per tab. Simpler; the bottom bar conditionally renders based on `currentBackStackEntryAsState`.
- **`RecoveryPhraseBackupScreen` got an optional `onBackClick` parameter**. When non-null (= invoked as a NavHost destination rather than as the app root), renders a back arrow in the TopAppBar. Backward-compatible default of `null` preserves the existing call sites.

## What's new

- `RootScreen.kt` — Scaffold + NavigationBar + NavHost
- `settings/SettingsScreen.kt` — LargeTopAppBar + LazyColumn + Backup row with the orange RoundedRect key icon (same atom as the recovery flow's Intro screen rules)
- `search/SearchScreen.kt` — placeholder; centred icon + title + body
- `MainActivity` — switched root to `RootScreen`; added `enableEdgeToEdge()`; preserves `FLAG_SECURE`
- 7 new strings (`back`, `settings`, `search`, `security`, `backup_recovery_phrase`, `security_footer_view_recovery_phrase`, `search_placeholder_body`) added to en + ru. Lint `MissingTranslation` clean.
- `androidx.navigation:navigation-compose 2.8.5` added

## Local checks (in worktree)

```
./gradlew :app:lintDebug                       → BUILD SUCCESSFUL
./gradlew :app:testDebugUnitTest               → BUILD SUCCESSFUL
./gradlew :app:compileDebugAndroidTestKotlin   → BUILD SUCCESSFUL
./gradlew :app:assembleRelease                 → BUILD SUCCESSFUL
16-KB ELF alignment check (all 8 .so files)    → All 16 KB ✓
python3 scripts/lint-secrets.py                → exit 0
```

## Test plan

- [ ] CI green
- [ ] Manual on Android 14 emulator: install → Settings tab opens with Backup row → tap Backup → recovery flow → back arrow → returns to Settings → tap Search tab → placeholder renders
- [ ] Manual on Android 15+ emulator: same flow; verify no system-bar overlap (edge-to-edge defaults differ between API 34 and API 35)
- [ ] Manual: `adb shell setprop persist.sys.locale ru-RU; adb reboot` (or per-app language picker) → screens render in Russian

## Out of scope

- Real Search screen
- More Settings sections (preferences, advanced, about)
- Per-app language picker (`LocaleManager`)