### PR TITLE
ui: launcher icon ported from stellar-mls/clients/android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <application
         android:name=".OnymApplication"
         android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@android:style/Theme.Material.Light.NoActionBar"
         android:supportsRtl="true"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/res/drawable-nodpi/ic_launcher_foreground.png
+++ b/app/src/main/res/drawable-nodpi/ic_launcher_foreground.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0dcc78b6fda15ccf9b1c037c774aed1070c44eacd90e5eed7a38b234cc8fd5
+size 17674

--- a/app/src/main/res/drawable-nodpi/ic_launcher_monochrome.png
+++ b/app/src/main/res/drawable-nodpi/ic_launcher_monochrome.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cc70551aef911273460ac4a887d1c416b2db46e936ef7e12bb673ab8f9dd2a9
+size 10705

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#FFFFFF" />
+</shape>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>


### PR DESCRIPTION
Borrows the StellarChat launcher icon assets verbatim. Same shape as stellar-mls — adaptive icon with foreground + monochrome PNGs + solid-white background, so Android 8+ launchers do the right thing and Android 13+ themed icons work out of the box.

## Files

Copied 1:1 from `stellar-mls/clients/android/StellarChat/app/src/main/res/`:

| Path                                          | What it is                          |
|-----------------------------------------------|-------------------------------------|
| `mipmap-anydpi-v26/ic_launcher.xml`           | Adaptive-icon definition            |
| `mipmap-anydpi-v26/ic_launcher_round.xml`     | Circular variant (same content)     |
| `drawable/ic_launcher_background.xml`         | Solid `#FFFFFF`                     |
| `drawable-nodpi/ic_launcher_foreground.png`   | 432×432 logo                        |
| `drawable-nodpi/ic_launcher_monochrome.png`   | 432×432 themed-icon variant         |

`AndroidManifest.xml` wires them via `android:icon="@mipmap/ic_launcher"` + `android:roundIcon="@mipmap/ic_launcher_round"`. Previously the manifest had no icon attribute → AGP shipped its default green-Android placeholder (visible in the v0.0.1 APK on the home screen + recents strip).

## No custom splash / launch image

Android 12+'s `windowSplashScreen` synthesises a launcher-icon-derived splash automatically — same approach stellar-mls uses; nothing custom to port. If you want a richer splash later (animated logo, brand color background) it's a `Theme.SplashScreen` parent + an `androidx.core:core-splashscreen` dep.

## Local checks

```
./gradlew :app:lintDebug          → BUILD SUCCESSFUL
./gradlew :app:assembleRelease    → BUILD SUCCESSFUL  (29 MB APK)
```

## Test plan

- [ ] CI green
- [ ] Sideload the v0.0.X-built APK on a device, confirm:
  - Launcher icon shows the StellarChat logo (not the green AGP placeholder)
  - Recents thumbnail uses the icon (per `FLAG_SECURE`, the recents preview is blanked but the icon still shows)
  - Android 13+ themed-icon mode picks up the monochrome variant