### PR TITLE
transport: abstract MessageTransport / InboxTransport with Nostr adapter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,11 @@ dependencies {
 
     implementation(libs.androidx.security.crypto)
 
+    // OkHttp WebSocket — NostrRelayConnection uses it for the relay
+    // connection. Built-in pingInterval handles heartbeat; no need
+    // for the iOS CFNetwork-pong workaround.
+    implementation(libs.okhttp)
+
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 

--- a/app/src/main/kotlin/chat/onym/android/transport/Transport.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/Transport.kt
@@ -1,0 +1,178 @@
+package chat.onym.android.transport
+
+import kotlinx.coroutines.flow.Flow
+import java.net.URI
+import java.time.Instant
+
+/**
+ * Transport-agnostic message-passing surface. Mirrors `Transport.swift`
+ * from onym-ios PR #12 1:1 — same value types, same operation shapes,
+ * same name conventions translated to Kotlin / coroutines / Flow.
+ *
+ * The abstract layer is what the chat repository (landing in a
+ * subsequent chunk) talks to. Concrete adapters under `transport/nostr/`
+ * (today) and a future `transport/tor/` implement these interfaces;
+ * no `NostrEvent`, kind, tag, or relay concept may leak across the
+ * boundary.
+ */
+
+/**
+ * A reachable transport endpoint. The URI scheme is interpreted by
+ * the concrete transport: `wss://` for Nostr relays, `onion://` for
+ * a future Tor hidden-service transport, etc.
+ */
+data class TransportEndpoint(val url: URI)
+
+/**
+ * Opaque broadcast topic identifier. The transport is free to map
+ * this onto its own routing primitive (a Nostr `["t", topic]` tag,
+ * a Tor pubsub channel name, …); callers must treat it as a stable
+ * string that identifies a many-to-many channel.
+ */
+@JvmInline
+value class TransportTopic(val rawValue: String)
+
+/**
+ * Opaque inbox identifier — a recipient-derived handle that lets a
+ * sender reach exactly one receiver without learning their long-term
+ * identity. Derivation is the application's job (e.g.
+ * [chat.onym.android.identity.Identity.inboxTag]); the transport
+ * only routes by it.
+ */
+@JvmInline
+value class TransportInboxId(val rawValue: String)
+
+/**
+ * One inbound payload as observed by a topic subscriber. The
+ * transport has already validated whatever framing it was
+ * responsible for (Nostr event-ID integrity, signature, …); [payload]
+ * is the opaque bytes the sender called [MessageTransport.publish]
+ * with.
+ */
+data class InboundMessage(
+    val topic: TransportTopic,
+    val payload: ByteArray,
+    /** Wall-clock timestamp the transport reports for this message. */
+    val receivedAt: Instant,
+    /**
+     * Transport-assigned unique identifier (e.g. NIP-01 event id) that
+     * callers can use to dedupe across redundant endpoints.
+     */
+    val messageId: String,
+) {
+    // Default data-class equals/hashCode use reference equality for
+    // ByteArray. Override with content-based comparison so two
+    // InboundMessage instances with the same bytes compare equal.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InboundMessage) return false
+        return topic == other.topic &&
+                payload.contentEquals(other.payload) &&
+                receivedAt == other.receivedAt &&
+                messageId == other.messageId
+    }
+
+    override fun hashCode(): Int {
+        var result = topic.hashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + receivedAt.hashCode()
+        result = 31 * result + messageId.hashCode()
+        return result
+    }
+}
+
+/** Inbox variant of [InboundMessage]. */
+data class InboundInbox(
+    val inbox: TransportInboxId,
+    val payload: ByteArray,
+    val receivedAt: Instant,
+    val messageId: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is InboundInbox) return false
+        return inbox == other.inbox &&
+                payload.contentEquals(other.payload) &&
+                receivedAt == other.receivedAt &&
+                messageId == other.messageId
+    }
+
+    override fun hashCode(): Int {
+        var result = inbox.hashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + receivedAt.hashCode()
+        result = 31 * result + messageId.hashCode()
+        return result
+    }
+}
+
+/**
+ * Acknowledgement returned by [MessageTransport.publish] /
+ * [InboxTransport.send]. [acceptedBy] is the number of endpoints
+ * that confirmed acceptance — for Nostr that's the count of relays
+ * that returned `OK true`. Concrete transports may treat
+ * "no response within timeout" as acceptance to avoid blocking.
+ */
+data class PublishReceipt(
+    val messageId: String,
+    val acceptedBy: Int,
+)
+
+/**
+ * Transport-layer failure. Sealed so `when` exhaustiveness checks
+ * downstream don't need an `else` branch.
+ */
+sealed class TransportError(message: String) : Exception(message) {
+    object NotConnected : TransportError("transport is not connected to any endpoint") {
+        private fun readResolve(): Any = NotConnected
+    }
+    object PublishRejected : TransportError("no endpoint accepted the publish") {
+        private fun readResolve(): Any = PublishRejected
+    }
+    class InvalidPayload(reason: String) : TransportError("invalid payload: $reason")
+}
+
+/**
+ * Many-to-many topic-addressed transport. A [MessageTransport]
+ * carries opaque [ByteArray] payloads between any number of
+ * publishers and subscribers that share a topic. Senders are not
+ * authenticated by the transport — that's the application layer's
+ * responsibility.
+ *
+ * The iOS twin uses `AsyncStream`; the Kotlin equivalent is
+ * [Flow]. The returned Flow is cold — the transport opens its
+ * subscription on first collection and tears it down on cancellation.
+ */
+interface MessageTransport {
+    suspend fun connect(endpoints: List<TransportEndpoint>)
+    suspend fun disconnect()
+
+    suspend fun publish(payload: ByteArray, topic: TransportTopic): PublishReceipt
+
+    /**
+     * Subscribe to a topic. [since] lets the caller request a
+     * catch-up window; if `null`, the transport picks a sensible
+     * recent default. The Flow cancels its underlying subscription
+     * when the consumer stops collecting or the scope is cancelled.
+     */
+    fun subscribe(topic: TransportTopic, since: Instant? = null): Flow<InboundMessage>
+
+    suspend fun unsubscribe(topic: TransportTopic)
+}
+
+/**
+ * Recipient-addressed transport. Unlike [MessageTransport], each
+ * payload targets exactly one inbox. A receiver subscribes by their
+ * own inbox identifier; senders address them by the same
+ * identifier. The transport makes no claim about who the sender is.
+ */
+interface InboxTransport {
+    suspend fun connect(endpoints: List<TransportEndpoint>)
+    suspend fun disconnect()
+
+    suspend fun send(payload: ByteArray, inbox: TransportInboxId): PublishReceipt
+
+    fun subscribe(inbox: TransportInboxId): Flow<InboundInbox>
+
+    suspend fun unsubscribe(inbox: TransportInboxId)
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrEvent.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrEvent.kt
@@ -1,0 +1,169 @@
+package chat.onym.android.transport.nostr
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.security.MessageDigest
+
+/**
+ * NIP-01 Nostr event. Wire-encoded via [toJson] / [fromJson],
+ * integrity-checked via [verifyEventId], and constructable through
+ * [build] which computes the canonical id and asks a [NostrSigner]
+ * to produce the BIP340 Schnorr signature.
+ *
+ * Mirrors `NostrEvent.swift` from onym-ios PR #12. Canonical JSON
+ * format is part of the protocol contract — `[0, pubkey, created_at,
+ * kind, tags, content]` serialised by `JSONArray.toString()` (Android's
+ * `org.json` keeps the array ordered + emits no whitespace, matching
+ * iOS's `JSONSerialization`).
+ */
+data class NostrEvent(
+    val id: String,
+    val pubkey: String,
+    val createdAt: Long,
+    val kind: Int,
+    val tags: List<List<String>>,
+    val content: String,
+    val sig: String,
+) {
+    /** Wire JSON object — the inner part of an `["EVENT", {…}]` frame. */
+    fun toJson(): JSONObject =
+        JSONObject().apply {
+            put("id", id)
+            put("pubkey", pubkey)
+            put("created_at", createdAt)
+            put("kind", kind)
+            put("tags", JSONArray().also { outer ->
+                for (tag in tags) {
+                    outer.put(JSONArray().also { inner ->
+                        for (s in tag) inner.put(s)
+                    })
+                }
+            })
+            put("content", content)
+            put("sig", sig)
+        }
+
+    /**
+     * Recompute the event id from canonical JSON and compare. Catches
+     * relay-level tampering of `content`, `pubkey`, or `tags`. Full
+     * Schnorr signature verification is a separate concern (handled
+     * upstream when the SDK exposes a public-key verifier).
+     */
+    fun verifyEventId(): Boolean = try {
+        val canonical = canonicalSerialization(pubkey, createdAt, kind, tags, content)
+        val computed = sha256(canonical.toByteArray(Charsets.UTF_8)).toHex()
+        computed == id
+    } catch (_: Throwable) {
+        false
+    }
+
+    /**
+     * App-local millisecond timestamp from `["ms", "..."]`. NIP-01's
+     * `created_at` is second-resolution; the extra tag is a private
+     * convention added by [build] so we can order messages within a
+     * second. Other clients ignore it.
+     */
+    val displayMilliseconds: Long
+        get() = tags.firstOrNull { it.size >= 2 && it[0] == "ms" }
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+            ?.takeIf { it >= 0 }
+            ?: (createdAt * 1000)
+
+    companion object {
+        /**
+         * Build a NIP-01 event: append the `["ms", ...]` ordering
+         * tag, compute the canonical id, sign it with [signer]. The
+         * signer's [NostrSigner.publicKey] becomes the event
+         * `pubkey` — pass an ephemeral signer (see
+         * [OnymNostrSigner.ephemeral]) for metadata-hiding (kinds
+         * 44114 / 34113 in this codebase) so the outer pubkey can't
+         * be used to cluster related events.
+         */
+        fun build(
+            kind: Int,
+            tags: List<List<String>>,
+            content: String,
+            signer: NostrSigner,
+        ): NostrEvent {
+            val pubkeyHex = signer.publicKey().toHex()
+            val unixMs = System.currentTimeMillis()
+            val createdAt = unixMs / 1000
+            val allTags = tags + listOf(listOf("ms", unixMs.toString()))
+
+            val canonical = canonicalSerialization(pubkeyHex, createdAt, kind, allTags, content)
+            val eventIdBytes = sha256(canonical.toByteArray(Charsets.UTF_8))
+            val eventIdHex = eventIdBytes.toHex()
+
+            val sig = signer.signEventId(eventIdBytes).toHex()
+
+            return NostrEvent(
+                id = eventIdHex,
+                pubkey = pubkeyHex,
+                createdAt = createdAt,
+                kind = kind,
+                tags = allTags,
+                content = content,
+                sig = sig,
+            )
+        }
+
+        /** Parse a wire JSON object into a [NostrEvent]. Returns
+         *  `null` if any required field is missing or the wrong
+         *  type — let the caller decide whether to log + drop. */
+        fun fromJson(json: JSONObject): NostrEvent? = try {
+            val tagsArray = json.getJSONArray("tags")
+            val tags = (0 until tagsArray.length()).map { i ->
+                val inner = tagsArray.getJSONArray(i)
+                (0 until inner.length()).map { j -> inner.getString(j) }
+            }
+            NostrEvent(
+                id = json.getString("id"),
+                pubkey = json.getString("pubkey"),
+                createdAt = json.getLong("created_at"),
+                kind = json.getInt("kind"),
+                tags = tags,
+                content = json.getString("content"),
+                sig = json.getString("sig"),
+            )
+        } catch (_: Throwable) {
+            null
+        }
+
+        /** Build the canonical-JSON string `[0, pubkey, created_at,
+         *  kind, tags, content]`. Used by both [build] and
+         *  [verifyEventId]. */
+        private fun canonicalSerialization(
+            pubkey: String,
+            createdAt: Long,
+            kind: Int,
+            tags: List<List<String>>,
+            content: String,
+        ): String {
+            val arr = JSONArray().apply {
+                put(0)
+                put(pubkey)
+                put(createdAt)
+                put(kind)
+                put(JSONArray().also { outer ->
+                    for (tag in tags) {
+                        outer.put(JSONArray().also { inner ->
+                            for (s in tag) inner.put(s)
+                        })
+                    }
+                })
+                put(content)
+            }
+            return arr.toString()
+        }
+
+        private fun sha256(data: ByteArray): ByteArray =
+            MessageDigest.getInstance("SHA-256").digest(data)
+
+        private fun ByteArray.toHex(): String {
+            val sb = StringBuilder(size * 2)
+            for (b in this) sb.append("%02x".format(b.toInt() and 0xFF))
+            return sb.toString()
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrInboxTransport.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrInboxTransport.kt
@@ -1,0 +1,203 @@
+package chat.onym.android.transport.nostr
+
+import chat.onym.android.transport.InboundInbox
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.PublishReceipt
+import chat.onym.android.transport.TransportEndpoint
+import chat.onym.android.transport.TransportError
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.URI
+import java.time.Instant
+import java.util.Base64
+
+/**
+ * Nostr-relay-backed [InboxTransport]. Each [send] builds a
+ * kind-34113 parameterised-replaceable event with the recipient
+ * inbox encoded as a `["d", "sep-inbox:" + inbox]` tag (so relays
+ * can serve it across reconnects), plus a `["t", inbox]` tag that
+ * lets clients filter by kind-24113 / legacy paths. The payload
+ * goes into `content` as base64. Subscribers receive every event
+ * whose `d` or `t` tag matches their inbox identifier across the
+ * three filter shapes.
+ *
+ * Mirrors `NostrInboxTransport.swift` from onym-ios PR #12.
+ * `PendingInvitation` / `SEPRekeyEnvelope` decoding is stripped —
+ * the adapter does exactly: ship opaque bytes in/out.
+ */
+class NostrInboxTransport(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) : InboxTransport {
+
+    private val state = State(scope)
+
+    override suspend fun connect(endpoints: List<TransportEndpoint>) {
+        state.connect(endpoints)
+    }
+
+    override suspend fun disconnect() {
+        state.disconnect()
+    }
+
+    override suspend fun send(payload: ByteArray, inbox: TransportInboxId): PublishReceipt {
+        val signer = OnymNostrSigner.ephemeral()
+        // Outbound tag set preserved verbatim from iOS / stellar-mls.
+        // Each tag carries the inbox under a different key so a
+        // subscriber on any of the three filter shapes catches it.
+        val tags = listOf(
+            listOf("d", INBOX_TAG_PREFIX + inbox.rawValue),
+            listOf("t", inbox.rawValue),
+            listOf("sep_inbox", inbox.rawValue),
+            listOf("sep_version", "1"),
+        )
+        val event = NostrEvent.build(
+            kind = PRIMARY_KIND,
+            tags = tags,
+            content = Base64.getEncoder().encodeToString(payload),
+            signer = signer,
+        )
+        val accepted = state.send(event)
+        return PublishReceipt(messageId = event.id, acceptedBy = accepted)
+    }
+
+    override fun subscribe(inbox: TransportInboxId): Flow<InboundInbox> = callbackFlow {
+        val job = scope.launch {
+            state.subscribe(inbox = inbox, onEvent = { trySend(it) })
+        }
+        awaitClose {
+            job.cancel()
+            scope.launch { state.unsubscribe(inbox) }
+        }
+    }
+
+    override suspend fun unsubscribe(inbox: TransportInboxId) {
+        state.unsubscribe(inbox)
+    }
+
+    /**
+     * Triple filter shape preserved verbatim — `#d` primary with the
+     * `sep-inbox:` prefix is the canonical addressing scheme;
+     * `#t` secondary catches clients that drop `d`; the legacy kind
+     * 24113 keeps backward-compat with older senders.
+     */
+    private fun subscriptionFilters(inbox: String): List<JSONObject> = listOf(
+        JSONObject().apply {
+            put("kinds", JSONArray().put(PRIMARY_KIND))
+            put("#d", JSONArray().put(INBOX_TAG_PREFIX + inbox))
+        },
+        JSONObject().apply {
+            put("kinds", JSONArray().put(PRIMARY_KIND))
+            put("#t", JSONArray().put(inbox))
+        },
+        JSONObject().apply {
+            put("kinds", JSONArray().put(LEGACY_KIND))
+            put("#t", JSONArray().put(inbox))
+        },
+    )
+
+    private inner class State(private val scope: CoroutineScope) {
+        private val mutex = Mutex()
+        private val connections = mutableMapOf<URI, NostrRelayConnection>()
+        private val activeSubscriptions = mutableMapOf<TransportInboxId, Job>()
+
+        suspend fun connect(endpoints: List<TransportEndpoint>) = mutex.withLock {
+            for (endpoint in endpoints) {
+                if (connections[endpoint.url] == null) {
+                    val conn = NostrRelayConnection(url = endpoint.url.toString(), scope = scope)
+                    connections[endpoint.url] = conn
+                    conn.connect()
+                }
+            }
+        }
+
+        suspend fun disconnect() = mutex.withLock {
+            for (job in activeSubscriptions.values) job.cancel()
+            activeSubscriptions.clear()
+            for (conn in connections.values) conn.disconnect()
+            connections.clear()
+        }
+
+        suspend fun send(event: NostrEvent): Int {
+            val conns = mutex.withLock { connections.values.toList() }
+            if (conns.isEmpty()) throw TransportError.NotConnected
+            val accepted = coroutineScope {
+                conns.map { conn ->
+                    async {
+                        try {
+                            conn.publishAndAwaitOK(event)
+                        } catch (_: Throwable) {
+                            false
+                        }
+                    }
+                }.awaitAll().count { it }
+            }
+            if (accepted == 0) throw TransportError.PublishRejected
+            return accepted
+        }
+
+        suspend fun subscribe(
+            inbox: TransportInboxId,
+            onEvent: (InboundInbox) -> Unit,
+        ) {
+            val (subBase, conns) = mutex.withLock {
+                activeSubscriptions[inbox]?.cancel()
+                "inbox-${inbox.rawValue}" to connections.values.toList()
+            }
+            val filters = subscriptionFilters(inbox.rawValue)
+            val job = scope.launch {
+                for (conn in conns) {
+                    filters.forEachIndexed { index, filter ->
+                        val filterSubId = "$subBase-$index"
+                        conn.subscribe(filterSubId, filter)
+                            .onEach { event ->
+                                try {
+                                    val payload = Base64.getDecoder().decode(event.content)
+                                    onEvent(
+                                        InboundInbox(
+                                            inbox = inbox,
+                                            payload = payload,
+                                            receivedAt = Instant.ofEpochMilli(event.displayMilliseconds),
+                                            messageId = event.id,
+                                        )
+                                    )
+                                } catch (_: IllegalArgumentException) {
+                                    // Bad base64 — drop.
+                                }
+                            }
+                            .launchIn(this)
+                    }
+                }
+            }
+            mutex.withLock {
+                activeSubscriptions[inbox] = job
+            }
+        }
+
+        suspend fun unsubscribe(inbox: TransportInboxId) = mutex.withLock {
+            activeSubscriptions[inbox]?.cancel()
+            activeSubscriptions.remove(inbox)
+        }
+    }
+
+    companion object {
+        private const val PRIMARY_KIND = 34113
+        private const val LEGACY_KIND = 24113
+        private const val INBOX_TAG_PREFIX = "sep-inbox:"
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrMessageTransport.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrMessageTransport.kt
@@ -1,0 +1,209 @@
+package chat.onym.android.transport.nostr
+
+import chat.onym.android.transport.InboundMessage
+import chat.onym.android.transport.MessageTransport
+import chat.onym.android.transport.PublishReceipt
+import chat.onym.android.transport.TransportEndpoint
+import chat.onym.android.transport.TransportError
+import chat.onym.android.transport.TransportTopic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.URI
+import java.time.Instant
+import java.util.Base64
+
+/**
+ * Nostr-relay-backed [MessageTransport]. Each call to [publish]
+ * builds a kind-44114 event with the topic in a `["t", topic]` tag,
+ * the payload base64-encoded as `content`, and an ephemeral signer
+ * for the outer pubkey so co-membership can't be inferred from the
+ * relay's view. Subscribers receive every kind-44114 / kind-24114
+ * event whose `t` tag matches the topic.
+ *
+ * Mirrors `NostrMessageTransport.swift` from onym-ios PR #12. All
+ * chat-specific concerns (GroupCrypto encrypt/decrypt, SealedEnvelope,
+ * BLS sender wrapper, member tracking, image / protocol message
+ * routing, key resolver / epoch tag handling) are stripped — the
+ * adapter does exactly: ship opaque bytes in/out.
+ */
+class NostrMessageTransport(
+    /** Scope for relay reconnect loops + per-subscription fan-out. */
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) : MessageTransport {
+
+    private val state = State(scope)
+
+    override suspend fun connect(endpoints: List<TransportEndpoint>) {
+        state.connect(endpoints)
+    }
+
+    override suspend fun disconnect() {
+        state.disconnect()
+    }
+
+    override suspend fun publish(payload: ByteArray, topic: TransportTopic): PublishReceipt {
+        val signer = OnymNostrSigner.ephemeral()
+        val event = NostrEvent.build(
+            kind = PRIMARY_KIND,
+            tags = listOf(listOf("t", topic.rawValue)),
+            content = Base64.getEncoder().encodeToString(payload),
+            signer = signer,
+        )
+        val accepted = state.publish(event)
+        return PublishReceipt(messageId = event.id, acceptedBy = accepted)
+    }
+
+    override fun subscribe(topic: TransportTopic, since: Instant?): Flow<InboundMessage> {
+        // Slack on `since` for clock skew across relays; default
+        // catch-up window when caller passes nothing. Same numbers
+        // as iOS — preserved verbatim.
+        val sinceUnix = if (since != null) {
+            maxOf(0L, since.epochSecond - SINCE_SLACK_SECONDS)
+        } else {
+            (System.currentTimeMillis() / 1000) - DEFAULT_CATCH_UP_SECONDS
+        }
+        return callbackFlow {
+            val job = scope.launch {
+                state.subscribe(
+                    topic = topic,
+                    sinceUnix = sinceUnix,
+                    kinds = intArrayOf(PRIMARY_KIND, LEGACY_KIND),
+                    onEvent = { msg -> trySend(msg) },
+                )
+            }
+            awaitClose {
+                job.cancel()
+                scope.launch { state.unsubscribe(topic) }
+            }
+        }
+    }
+
+    override suspend fun unsubscribe(topic: TransportTopic) {
+        state.unsubscribe(topic)
+    }
+
+    /**
+     * Owns the relay connections + per-topic subscription jobs.
+     * Mutex-serialised mutation; reads (`connections.values`) are
+     * fine because [java.util.concurrent.ConcurrentHashMap] is
+     * thread-safe and the iteration order doesn't matter here.
+     */
+    private class State(private val scope: CoroutineScope) {
+        private val mutex = Mutex()
+        private val connections = mutableMapOf<URI, NostrRelayConnection>()
+        private val activeSubscriptions = mutableMapOf<TransportTopic, Job>()
+        // Monotonic counter for relay subscription ids. Each new
+        // subscribe gets a unique id so an old stream's awaitClose
+        // CLOSE can't kill a freshly opened REQ for the same topic.
+        private var subscriptionGeneration: ULong = 0u
+
+        suspend fun connect(endpoints: List<TransportEndpoint>) = mutex.withLock {
+            for (endpoint in endpoints) {
+                if (connections[endpoint.url] == null) {
+                    val conn = NostrRelayConnection(url = endpoint.url.toString(), scope = scope)
+                    connections[endpoint.url] = conn
+                    conn.connect()
+                }
+            }
+        }
+
+        suspend fun disconnect() = mutex.withLock {
+            for (job in activeSubscriptions.values) job.cancel()
+            activeSubscriptions.clear()
+            for (conn in connections.values) conn.disconnect()
+            connections.clear()
+        }
+
+        suspend fun publish(event: NostrEvent): Int {
+            val conns = mutex.withLock { connections.values.toList() }
+            if (conns.isEmpty()) throw TransportError.NotConnected
+            val accepted = coroutineScope {
+                conns.map { conn ->
+                    async {
+                        try {
+                            conn.publish(event)
+                            true
+                        } catch (_: Throwable) {
+                            false
+                        }
+                    }
+                }.awaitAll().count { it }
+            }
+            if (accepted == 0) throw TransportError.PublishRejected
+            return accepted
+        }
+
+        suspend fun subscribe(
+            topic: TransportTopic,
+            sinceUnix: Long,
+            kinds: IntArray,
+            onEvent: (InboundMessage) -> Unit,
+        ) {
+            val (subId, conns) = mutex.withLock {
+                activeSubscriptions[topic]?.cancel()
+                subscriptionGeneration += 1u
+                val id = "msg-${topic.rawValue}-$subscriptionGeneration"
+                id to connections.values.toList()
+            }
+            val job = scope.launch {
+                for (conn in conns) {
+                    val filter = JSONObject().apply {
+                        put("kinds", JSONArray().also { for (k in kinds) it.put(k) })
+                        put("#t", JSONArray().put(topic.rawValue))
+                        put("since", sinceUnix)
+                    }
+                    conn.subscribe(subId, filter)
+                        .onEach { event ->
+                            try {
+                                val payload = Base64.getDecoder().decode(event.content)
+                                onEvent(
+                                    InboundMessage(
+                                        topic = topic,
+                                        payload = payload,
+                                        receivedAt = Instant.ofEpochMilli(event.displayMilliseconds),
+                                        messageId = event.id,
+                                    )
+                                )
+                            } catch (_: IllegalArgumentException) {
+                                // Bad base64 — drop. Don't crash the
+                                // subscription on a single bad event.
+                            }
+                        }
+                        .launchIn(this)
+                }
+            }
+            mutex.withLock {
+                activeSubscriptions[topic] = job
+            }
+        }
+
+        suspend fun unsubscribe(topic: TransportTopic) = mutex.withLock {
+            activeSubscriptions[topic]?.cancel()
+            activeSubscriptions.remove(topic)
+        }
+    }
+
+    companion object {
+        private const val PRIMARY_KIND = 44114
+        private const val LEGACY_KIND = 24114
+        /** Default catch-up window when the caller doesn't pass `since`. */
+        private const val DEFAULT_CATCH_UP_SECONDS = 300L
+        /** Tolerance applied to `since` to handle clock skew across relays. */
+        private const val SINCE_SLACK_SECONDS = 60L
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelayConnection.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelayConnection.kt
@@ -1,0 +1,260 @@
+package chat.onym.android.transport.nostr
+
+import android.util.Log
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+/**
+ * Persistent WebSocket connection to a single Nostr relay. Owns the
+ * REQ/EVENT/EOSE/OK/CLOSE framing and is the only place in the
+ * transport layer that touches OkHttp's [WebSocket] API. Reconnect
+ * with exponential backoff + heartbeat (via OkHttp's `pingInterval`)
+ * + per-publish OK await are all internal — the surface for callers
+ * is [connect], [disconnect], [publish], [publishAndAwaitOK],
+ * [subscribe], [unsubscribe].
+ *
+ * Ported from `stellar-mls/clients/android/StellarChat/.../nostr/
+ * NostrRelayConnection.kt` (the Android impl) with three changes:
+ *
+ *   - References to `SecurityLog` and `BuildConfig` (live in the
+ *     stellar-mls app module) replaced with [Log.w] tags.
+ *   - Reconnect's `Thread.sleep` replaced with coroutine [delay] on
+ *     an injected [scope] — the OkHttp listener thread is a worker
+ *     dispatcher, blocking it for up to 2 minutes is rude.
+ *   - `disconnect()` no longer wipes the subscriptions map. Matches
+ *     the iOS twin (`NostrRelayConnection.swift` in onym-ios PR #12)
+ *     so subscriptions survive an explicit disconnect+reconnect
+ *     cycle and only the per-subscription unsubscribe clears state.
+ *
+ * Heartbeat: OkHttp's built-in `pingInterval(30s)` sends WebSocket
+ * ping frames; relays that respect NIP-01 reply with pong. iOS
+ * needs the `["CLOSE","__hb"]` workaround because `URLSession`'s
+ * pong handler has a known CFNetwork crash; Android doesn't.
+ */
+class NostrRelayConnection(
+    private val url: String,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        // 0 read-timeout — WebSocket is long-lived; never let OkHttp
+        // tear it down because no message arrived in N seconds.
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .pingInterval(PING_INTERVAL_SECONDS, TimeUnit.SECONDS)
+        .build(),
+) {
+    private var webSocket: WebSocket? = null
+    private val subscriptions = ConcurrentHashMap<String, Pair<JSONObject, (NostrEvent) -> Unit>>()
+
+    @Volatile private var reconnectAttempts = 0
+    @Volatile var isConnected: Boolean = false
+        private set
+
+    /** Callback for relay OK responses: `(eventId, accepted)`. */
+    var onOK: ((String, Boolean) -> Unit)? = null
+
+    /** Notifies callers when the connection state flips, so a higher
+     *  layer can react (e.g. show a "reconnecting…" indicator). */
+    var onConnectionStateChange: ((Boolean) -> Unit)? = null
+
+    private val pendingOKs = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
+
+    fun connect() {
+        val request = Request.Builder().url(url).build()
+        webSocket = client.newWebSocket(
+            request,
+            object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    reconnectAttempts = 0
+                    isConnected = true
+                    onConnectionStateChange?.invoke(true)
+                    // Replay subscriptions through the new connection.
+                    // ConcurrentHashMap iteration is safe under
+                    // concurrent mutation; we may miss a subscription
+                    // added between the loop start and end, but the
+                    // caller's `subscribe` always re-sends the REQ
+                    // immediately so nothing is lost.
+                    for ((subId, pair) in subscriptions) {
+                        sendReq(subId, pair.first)
+                    }
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    handleMessage(text)
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    val wasConnected = isConnected
+                    isConnected = false
+                    if (wasConnected) onConnectionStateChange?.invoke(false)
+
+                    // Exponential backoff. Reconnect runs on the
+                    // injected scope so we don't block OkHttp's
+                    // listener dispatcher.
+                    reconnectAttempts++
+                    val delayMs = minOf(
+                        MAX_RECONNECT_DELAY_MS,
+                        BASE_RECONNECT_DELAY_MS * (1L shl minOf(reconnectAttempts - 1, 6)),
+                    )
+                    scope.launch {
+                        delay(delayMs)
+                        connect()
+                    }
+                }
+            },
+        )
+    }
+
+    fun disconnect() {
+        webSocket?.close(NORMAL_CLOSURE_CODE, "Bye")
+        webSocket = null
+        isConnected = false
+        reconnectAttempts = 0
+        // Subscriptions intentionally preserved — see class doc. An
+        // explicit disconnect does not wipe the per-subscription
+        // continuations; only `unsubscribe(id)` does.
+    }
+
+    /** Best-effort send. Returns immediately; the relay's ACK (if
+     *  any) arrives later via [onOK]. Callers that need the ACK
+     *  should use [publishAndAwaitOK]. */
+    fun publish(event: NostrEvent) {
+        val frame = JSONArray().apply {
+            put("EVENT")
+            put(event.toJson())
+        }
+        webSocket?.send(frame.toString())
+    }
+
+    /**
+     * Publish and wait for the relay's OK for this event id. Returns
+     * `true` on `OK true`. Treats a [PUBLISH_TIMEOUT_MS] silence as
+     * acceptance to avoid hanging on relays that drop OK frames —
+     * matches iOS's twin behaviour.
+     *
+     * The pending-OK entry is registered BEFORE the send so a fast
+     * OK can never be missed.
+     */
+    suspend fun publishAndAwaitOK(event: NostrEvent): Boolean {
+        val deferred = CompletableDeferred<Boolean>()
+        pendingOKs[event.id] = deferred
+
+        val frame = JSONArray().apply {
+            put("EVENT")
+            put(event.toJson())
+        }
+        val sent = webSocket?.send(frame.toString()) ?: false
+        if (!sent) {
+            pendingOKs.remove(event.id)
+            return false
+        }
+        return withTimeoutOrNull(PUBLISH_TIMEOUT_MS) {
+            deferred.await()
+        } ?: run {
+            pendingOKs.remove(event.id)
+            // Treat timeout as success — event was sent, relay just
+            // didn't ACK. Better than blocking the chat layer
+            // indefinitely on a flaky relay.
+            true
+        }
+    }
+
+    /** Subscribe via callbackFlow. The flow's awaitClose CLOSEs the
+     *  subscription on the relay when the consumer cancels. */
+    fun subscribe(subscriptionId: String, filter: JSONObject): Flow<NostrEvent> = callbackFlow {
+        subscriptions[subscriptionId] = filter to { event -> trySend(event) }
+        sendReq(subscriptionId, filter)
+
+        awaitClose {
+            subscriptions.remove(subscriptionId)
+            val close = JSONArray().apply {
+                put("CLOSE")
+                put(subscriptionId)
+            }
+            webSocket?.send(close.toString())
+        }
+    }
+
+    // ─── Private ────────────────────────────────────────────────────
+
+    private fun sendReq(subscriptionId: String, filter: JSONObject) {
+        val frame = JSONArray().apply {
+            put("REQ")
+            put(subscriptionId)
+            put(filter)
+        }
+        webSocket?.send(frame.toString())
+    }
+
+    private fun handleMessage(text: String) {
+        // Reject oversized inbound frames — a malicious relay should
+        // not be able to OOM the app by streaming megabytes per
+        // message. 1 MB is the same cap the stellar-mls / iOS twin
+        // applies.
+        if (text.length > MAX_MESSAGE_SIZE) {
+            Log.w(TAG, "$url: oversized message rejected (${text.length} bytes)")
+            return
+        }
+        try {
+            val array = JSONArray(text)
+            when (array.getString(0)) {
+                "EVENT" -> {
+                    if (array.length() < 3) return
+                    val subId = array.getString(1)
+                    val event = NostrEvent.fromJson(array.getJSONObject(2)) ?: return
+                    if (!event.verifyEventId()) {
+                        Log.w(TAG, "$url: invalid event id rejected (sub=$subId)")
+                        return
+                    }
+                    subscriptions[subId]?.second?.invoke(event)
+                }
+                "EOSE" -> {
+                    // End of stored events for the named subscription.
+                    // No-op: callers don't currently need the
+                    // historical-vs-live boundary.
+                }
+                "OK" -> {
+                    if (array.length() < 3) return
+                    val eventId = array.getString(1)
+                    val accepted = array.getBoolean(2)
+                    pendingOKs.remove(eventId)?.complete(accepted)
+                    onOK?.invoke(eventId, accepted)
+                }
+                "NOTICE" -> {
+                    // Relay informational text; callers don't currently
+                    // need to surface this anywhere.
+                }
+                else -> { /* unknown frame type, ignore */ }
+            }
+        } catch (e: Throwable) {
+            Log.w(TAG, "$url: malformed frame rejected: ${e.message}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "NostrRelayConnection"
+        private const val MAX_RECONNECT_DELAY_MS = 120_000L
+        private const val BASE_RECONNECT_DELAY_MS = 1_000L
+        private const val MAX_MESSAGE_SIZE = 1_048_576
+        private const val CONNECT_TIMEOUT_SECONDS = 15L
+        private const val PING_INTERVAL_SECONDS = 30L
+        private const val PUBLISH_TIMEOUT_MS = 5_000L
+        private const val NORMAL_CLOSURE_CODE = 1000
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrSigner.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrSigner.kt
@@ -1,0 +1,72 @@
+package chat.onym.android.transport.nostr
+
+import chat.onym.sdk.Common
+import chat.onym.sdk.OnymException
+import java.security.SecureRandom
+
+/**
+ * BIP340 secp256k1 Schnorr signer over a Nostr event id. The
+ * transport layer never sees the secret key — it only asks for the
+ * x-only public key (32 bytes) and a signature (64 bytes) for a
+ * given event id.
+ *
+ * Mirrors `NostrSigner.swift` from onym-ios PR #12.
+ */
+interface NostrSigner {
+    fun publicKey(): ByteArray
+    fun signEventId(eventId: ByteArray): ByteArray
+}
+
+/**
+ * [NostrSigner] backed by a 32-byte secp256k1 secret. The signer
+ * uses [chat.onym.sdk.Common] for the underlying BIP340 operations
+ * — same crypto stack the identity layer uses; no second
+ * implementation.
+ *
+ * Keep instances short-lived: every call to [publicKey] re-derives
+ * from the secret rather than caching, so the secret is the only
+ * thing pinned in memory.
+ */
+class OnymNostrSigner(private val secretKey: ByteArray) : NostrSigner {
+
+    init {
+        require(secretKey.size == 32) {
+            "secp256k1 secret key must be 32 bytes, got ${secretKey.size}"
+        }
+    }
+
+    override fun publicKey(): ByteArray = try {
+        Common.nostrDerivePublicKey(secretKey)
+    } catch (e: OnymException) {
+        throw NostrSignerException("nostrDerivePublicKey failed: ${e.message}", e)
+    }
+
+    override fun signEventId(eventId: ByteArray): ByteArray {
+        require(eventId.size == 32) {
+            "Nostr event id must be 32 bytes (SHA-256 of canonical JSON), got ${eventId.size}"
+        }
+        return try {
+            Common.nostrSignEventId(secretKey, eventId)
+        } catch (e: OnymException) {
+            throw NostrSignerException("nostrSignEventId failed: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        /**
+         * Per-event ephemeral signer backed by a fresh CSPRNG-derived
+         * secret. Used for metadata-hiding kinds (44114 / 34113) so
+         * the outer event `pubkey` can't be used to cluster
+         * co-membership across the relay's view.
+         */
+        fun ephemeral(): OnymNostrSigner {
+            val bytes = ByteArray(32)
+            SecureRandom().nextBytes(bytes)
+            return OnymNostrSigner(bytes)
+        }
+    }
+}
+
+/** Wraps lower-layer FFI failures so callers don't have to depend
+ *  on `chat.onym.sdk.OnymException`. */
+class NostrSignerException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,10 @@ androidx-biometric = "1.2.0-alpha05"
 androidx-fragment = "1.8.5"
 androidx-lifecycle-viewmodel-compose = "2.8.7"
 androidx-navigation-compose = "2.8.5"
+# OkHttp WebSocket — used by NostrRelayConnection. Same library
+# stellar-mls/clients/android uses; built-in `pingInterval` covers
+# the heartbeat so we don't need the iOS CFNetwork-pong workaround.
+okhttp = "4.12.0"
 
 # OnymSDK — published to the static Maven repo at
 # raw.githubusercontent.com/onymchat/onym-sdk-kotlin/releases/
@@ -63,6 +67,7 @@ androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "a
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidx-fragment" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-viewmodel-compose" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 
 # Compose UI test (versions managed by androidx-compose-bom)
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }


### PR DESCRIPTION
## Summary

- Carve a transport seam ([`MessageTransport`](app/src/main/kotlin/chat/onym/android/transport/Transport.kt), [`InboxTransport`](app/src/main/kotlin/chat/onym/android/transport/Transport.kt)) so the chat layer can target many backends — Nostr today, Tor or others later — through one Kotlin interface surface that speaks opaque `ByteArray` + `TransportTopic` / `TransportInboxId`. No `NostrEvent`, kinds, tags, or relay concepts leak across the boundary.
- Port the Nostr concrete impl from `stellar-mls/clients/android/StellarChat/.../nostr/`, stripping all chat semantics (GroupCrypto encrypt/decrypt, `SealedEnvelope`, BLS sender wrapper, member tracking, image/protocol message routing, key resolver / epoch tag handling, `PendingInvitation` / `SEPRekeyEnvelope` decoding). Adapters now do exactly one thing: ship opaque bytes in/out.
- Replace the kotlin-mls `KeyManager` + `RustBackedNostrSigner` couplings with a local `NostrSigner` interface + `OnymNostrSigner.ephemeral()` backed by `OnymSDK.Common.nostrDerivePublicKey` / `nostrSignEventId` — no second crypto stack.

Android twin of [onym-ios PR #12](https://github.com/onymchat/onym-ios/pull/12); same seam, same scope, same names — only the language idioms (Kotlin / coroutines / Flow vs Swift / actors / AsyncStream; OkHttp vs URLSession) differ.

## What landed

```
app/src/main/kotlin/chat/onym/android/transport/
├── Transport.kt                       (abstract layer — interfaces + value types)
└── nostr/
    ├── NostrEvent.kt                  (NIP-01 codable + verifyEventId + build)
    ├── NostrSigner.kt                 (NostrSigner interface + OnymSDK-backed ephemeral)
    ├── NostrRelayConnection.kt        (OkHttp WebSocket port — pure transport, no chat code)
    ├── NostrMessageTransport.kt       (kind 44114 → MessageTransport)
    └── NostrInboxTransport.kt         (kind 34113 → InboxTransport)
```

## Preserved verbatim (protocol-correctness invariants)

- NIP-01 event-id canonical JSON + SHA-256.
- Ephemeral per-event signing for kinds 44114 / 34113 (metadata-hiding — the stable pubkey would let a relay cluster co-membership).
- The `["ms", "<unix_ms>"]` sub-second ordering tag that `build()` appends; subscribers read it via `NostrEvent.displayMilliseconds`.
- 60-second slack on `since` for clock skew across relays.
- 1 MB inbound size cap — rejects oversized frames so a malicious relay can't OOM the app.
- Inbox triple-filter shape (`#d` `sep-inbox:` + `#t` + legacy 24113) and the same outbound tag set (`d` / `t` / `sep_inbox` / `sep_version`).
- `publishAndAwaitOK` 5 s timeout-as-acceptance so a flaky relay can't block the chat layer.

## Android-vs-iOS divergences (intentional)

- **OkHttp's built-in `pingInterval` handles the heartbeat.** The iOS twin uses `["CLOSE","__hb"]` frames because `URLSessionWebSocketTask.sendPing` has a CFNetwork-pong crash; OkHttp doesn't.
- **Reconnect runs on an injected `CoroutineScope`** (default `SupervisorJob() + Dispatchers.IO`) via `delay()`. The stellar-mls Android impl used `Thread.sleep` on OkHttp's listener dispatcher; porting forward we use coroutine `delay()` so we don't block a worker thread for up to 2 minutes.
- **`disconnect()` does NOT clear the subscriptions map.** Matches the iOS twin so subscriptions survive an explicit disconnect+reconnect cycle and only the per-subscription `unsubscribe` clears state. (stellar-mls Android cleared on disconnect — that diverged from iOS; corrected here.)
- **`State.subscribe` locks via kotlinx-coroutines `Mutex`** (the iOS twin uses Swift actor isolation; same end semantics).

## Out of scope (intentional)

- `GroupCrypto` / `SealedEnvelope` / BLS-attested wrapper / member-list management / protocol-message routing — those will land above the transport seam.
- Schnorr signature verification on inbound events. `NostrEvent.verifyEventId()` catches relay-level tampering of `content` / `pubkey` / `tags` via the canonical-JSON hash; full BIP340 verify lands when the SDK exposes a verifier (or when the chat layer's authenticated-encryption layer makes it redundant).

## Test plan

- [x] `./gradlew :app:assembleDebug` clean from the worktree.
- [x] `./gradlew :app:lintDebug` clean (no `MissingTranslation` etc. since the transport layer is locale-free).
- [x] `python3 scripts/lint-secrets.py` exit 0 (no `.recoveryPhrase` / `.nostrSecretKey` / etc. reads in the new files).
- [ ] Wire-level smoke test deferred until the chat repository above plumbs a real caller through the interfaces.

## Deps

`com.squareup.okhttp3:okhttp:4.12.0` — same library stellar-mls/Android uses; built-in WebSocket + pingInterval.