### PR TITLE
transport: unit tests for Nostr framing + signer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,6 +116,11 @@ dependencies {
     // goes in androidTest.
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    // Android unit tests stub `org.json` (every method throws "not
+    // mocked"). The transport layer's NostrEvent / subscriptionFilters
+    // use JSONObject + JSONArray for canonical JSON, so tests need a
+    // real impl on the classpath.
+    testImplementation("org.json:json:20240303")
 
     // Instrumented tests. Real EncryptedSharedPreferences against the
     // emulator's hardware-backed Keystore.

--- a/app/src/androidTest/kotlin/chat/onym/android/transport/nostr/OnymNostrSignerTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/transport/nostr/OnymNostrSignerTest.kt
@@ -1,0 +1,142 @@
+package chat.onym.android.transport.nostr
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.sdk.Common
+import chat.onym.sdk.OnymException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Hits OnymSDK's BIP340 / secp256k1 FFI through [OnymNostrSigner] —
+ * no mocks. The roundtrip uses
+ * [chat.onym.sdk.Common.nostrVerifyEventSignature] so a regression
+ * in either signing or verification surfaces here.
+ *
+ * Lives in `androidTest/` (not `test/`) because the OnymSDK FFI
+ * lives in jni/abi/lib*.so inside the AAR — only loadable on
+ * emulator/device, not on host JVM. Same pattern the existing
+ * `IdentityRepositoryTest` uses for `Common.publicKey` /
+ * `Common.nostrDerivePublicKey` calls.
+ *
+ * Mirrors `OnymNostrSignerTests.swift` from onym-ios PR #13.
+ */
+@RunWith(AndroidJUnit4::class)
+class OnymNostrSignerTest {
+
+    // ─── constructor ──────────────────────────────────────────────
+
+    @Test
+    fun init_acceptsValid32ByteSecret() {
+        // Should not throw.
+        OnymNostrSigner(ByteArray(32) { 0x01 })
+    }
+
+    @Test
+    fun init_rejectsShortSecret() {
+        assertThrows(IllegalArgumentException::class.java) {
+            OnymNostrSigner(ByteArray(31) { 0x01 })
+        }
+    }
+
+    @Test
+    fun init_rejectsLongSecret() {
+        assertThrows(IllegalArgumentException::class.java) {
+            OnymNostrSigner(ByteArray(33) { 0x01 })
+        }
+    }
+
+    @Test
+    fun init_rejectsEmptySecret() {
+        assertThrows(IllegalArgumentException::class.java) {
+            OnymNostrSigner(ByteArray(0))
+        }
+    }
+
+    // ─── publicKey ────────────────────────────────────────────────
+
+    @Test
+    fun publicKey_is32Bytes() {
+        val signer = OnymNostrSigner(ByteArray(32) { 0x42 })
+        assertEquals("BIP340 x-only pubkey is 32 bytes", 32, signer.publicKey().size)
+    }
+
+    @Test
+    fun publicKey_isDeterministic() {
+        val secret = ByteArray(32) { 0x42 }
+        val pubA = OnymNostrSigner(secret).publicKey()
+        val pubB = OnymNostrSigner(secret).publicKey()
+        assertArrayEquals(pubA, pubB)
+    }
+
+    // ─── signEventId ──────────────────────────────────────────────
+
+    @Test
+    fun signEventId_rejectsShortEventId() {
+        val signer = OnymNostrSigner(ByteArray(32) { 0x01 })
+        assertThrows(IllegalArgumentException::class.java) {
+            signer.signEventId(ByteArray(31) { 0xAA.toByte() })
+        }
+    }
+
+    @Test
+    fun signEventId_returns64Bytes() {
+        val signer = OnymNostrSigner(ByteArray(32) { 0x01 })
+        val sig = signer.signEventId(ByteArray(32) { 0xAA.toByte() })
+        assertEquals("BIP340 schnorr sig is 64 bytes", 64, sig.size)
+    }
+
+    @Test
+    fun signEventId_verifiesAgainstOnymSDK() {
+        val signer = OnymNostrSigner(ByteArray(32) { 0x01 })
+        val pub = signer.publicKey()
+        val eventId = ByteArray(32) { 0xAA.toByte() }
+        val sig = signer.signEventId(eventId)
+        // Common.nostrVerifyEventSignature throws OnymException on
+        // verification failure; not throwing = success.
+        Common.nostrVerifyEventSignature(pub, eventId, sig)
+    }
+
+    @Test
+    fun signEventId_verificationFailsForWrongMessage() {
+        val signer = OnymNostrSigner(ByteArray(32) { 0x01 })
+        val pub = signer.publicKey()
+        val signedId = ByteArray(32) { 0xAA.toByte() }
+        val otherId = ByteArray(32) { 0xBB.toByte() }
+        val sig = signer.signEventId(signedId)
+        assertThrows(OnymException::class.java) {
+            Common.nostrVerifyEventSignature(pub, otherId, sig)
+        }
+    }
+
+    // ─── ephemeral ────────────────────────────────────────────────
+
+    @Test
+    fun ephemeral_producesDistinctKeysPerCall() {
+        val a = OnymNostrSigner.ephemeral()
+        val b = OnymNostrSigner.ephemeral()
+        assertFalse("CSPRNG produced identical secrets — astronomically unlikely",
+            a.secretKey.contentEquals(b.secretKey))
+        assertFalse("distinct secrets must produce distinct pubkeys",
+            a.publicKey().contentEquals(b.publicKey()))
+    }
+
+    @Test
+    fun ephemeral_secretIs32Bytes() {
+        val signer = OnymNostrSigner.ephemeral()
+        assertEquals(32, signer.secretKey.size)
+    }
+
+    @Test
+    fun ephemeral_canSignAndVerify() {
+        val signer = OnymNostrSigner.ephemeral()
+        val pub = signer.publicKey()
+        val eventId = ByteArray(32) { 0x55 }
+        val sig = signer.signEventId(eventId)
+        Common.nostrVerifyEventSignature(pub, eventId, sig)
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrInboxTransport.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrInboxTransport.kt
@@ -56,22 +56,7 @@ class NostrInboxTransport(
     }
 
     override suspend fun send(payload: ByteArray, inbox: TransportInboxId): PublishReceipt {
-        val signer = OnymNostrSigner.ephemeral()
-        // Outbound tag set preserved verbatim from iOS / stellar-mls.
-        // Each tag carries the inbox under a different key so a
-        // subscriber on any of the three filter shapes catches it.
-        val tags = listOf(
-            listOf("d", INBOX_TAG_PREFIX + inbox.rawValue),
-            listOf("t", inbox.rawValue),
-            listOf("sep_inbox", inbox.rawValue),
-            listOf("sep_version", "1"),
-        )
-        val event = NostrEvent.build(
-            kind = PRIMARY_KIND,
-            tags = tags,
-            content = Base64.getEncoder().encodeToString(payload),
-            signer = signer,
-        )
+        val event = buildSendEvent(payload, inbox, OnymNostrSigner.ephemeral())
         val accepted = state.send(event)
         return PublishReceipt(messageId = event.id, acceptedBy = accepted)
     }
@@ -90,26 +75,6 @@ class NostrInboxTransport(
         state.unsubscribe(inbox)
     }
 
-    /**
-     * Triple filter shape preserved verbatim — `#d` primary with the
-     * `sep-inbox:` prefix is the canonical addressing scheme;
-     * `#t` secondary catches clients that drop `d`; the legacy kind
-     * 24113 keeps backward-compat with older senders.
-     */
-    private fun subscriptionFilters(inbox: String): List<JSONObject> = listOf(
-        JSONObject().apply {
-            put("kinds", JSONArray().put(PRIMARY_KIND))
-            put("#d", JSONArray().put(INBOX_TAG_PREFIX + inbox))
-        },
-        JSONObject().apply {
-            put("kinds", JSONArray().put(PRIMARY_KIND))
-            put("#t", JSONArray().put(inbox))
-        },
-        JSONObject().apply {
-            put("kinds", JSONArray().put(LEGACY_KIND))
-            put("#t", JSONArray().put(inbox))
-        },
-    )
 
     private inner class State(private val scope: CoroutineScope) {
         private val mutex = Mutex()
@@ -159,7 +124,7 @@ class NostrInboxTransport(
                 activeSubscriptions[inbox]?.cancel()
                 "inbox-${inbox.rawValue}" to connections.values.toList()
             }
-            val filters = subscriptionFilters(inbox.rawValue)
+            val filters = subscriptionFilters(inbox.rawValue)  // companion helper
             val job = scope.launch {
                 for (conn in conns) {
                     filters.forEachIndexed { index, filter ->
@@ -199,5 +164,59 @@ class NostrInboxTransport(
         private const val PRIMARY_KIND = 34113
         private const val LEGACY_KIND = 24113
         private const val INBOX_TAG_PREFIX = "sep-inbox:"
+
+        /**
+         * Pure event-construction path. Extracted from [send] so
+         * tests can pin the wire format (kind, full tag set, base64-
+         * encoded payload) without standing up a WebSocket relay.
+         *
+         * `internal` because this is a transport-implementation
+         * detail — callers should only see [InboxTransport.send].
+         */
+        internal fun buildSendEvent(
+            payload: ByteArray,
+            inbox: TransportInboxId,
+            signer: NostrSigner,
+        ): NostrEvent {
+            // Outbound tag set preserved verbatim from iOS / stellar-mls.
+            // Each tag carries the inbox under a different key so a
+            // subscriber on any of the three filter shapes catches it.
+            val tags = listOf(
+                listOf("d", INBOX_TAG_PREFIX + inbox.rawValue),
+                listOf("t", inbox.rawValue),
+                listOf("sep_inbox", inbox.rawValue),
+                listOf("sep_version", "1"),
+            )
+            return NostrEvent.build(
+                kind = PRIMARY_KIND,
+                tags = tags,
+                content = Base64.getEncoder().encodeToString(payload),
+                signer = signer,
+            )
+        }
+
+        /**
+         * Triple filter shape preserved verbatim — `#d` primary with
+         * the `sep-inbox:` prefix is the canonical addressing scheme;
+         * `#t` secondary catches clients that drop `d`; the legacy
+         * kind 24113 keeps backward-compat with older senders.
+         *
+         * `internal` so tests can assert the shape without going
+         * through `subscribe`.
+         */
+        internal fun subscriptionFilters(inbox: String): List<JSONObject> = listOf(
+            JSONObject().apply {
+                put("kinds", JSONArray().put(PRIMARY_KIND))
+                put("#d", JSONArray().put(INBOX_TAG_PREFIX + inbox))
+            },
+            JSONObject().apply {
+                put("kinds", JSONArray().put(PRIMARY_KIND))
+                put("#t", JSONArray().put(inbox))
+            },
+            JSONObject().apply {
+                put("kinds", JSONArray().put(LEGACY_KIND))
+                put("#t", JSONArray().put(inbox))
+            },
+        )
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrMessageTransport.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrMessageTransport.kt
@@ -57,13 +57,7 @@ class NostrMessageTransport(
     }
 
     override suspend fun publish(payload: ByteArray, topic: TransportTopic): PublishReceipt {
-        val signer = OnymNostrSigner.ephemeral()
-        val event = NostrEvent.build(
-            kind = PRIMARY_KIND,
-            tags = listOf(listOf("t", topic.rawValue)),
-            content = Base64.getEncoder().encodeToString(payload),
-            signer = signer,
-        )
+        val event = buildPublishEvent(payload, topic, OnymNostrSigner.ephemeral())
         val accepted = state.publish(event)
         return PublishReceipt(messageId = event.id, acceptedBy = accepted)
     }
@@ -205,5 +199,24 @@ class NostrMessageTransport(
         private const val DEFAULT_CATCH_UP_SECONDS = 300L
         /** Tolerance applied to `since` to handle clock skew across relays. */
         private const val SINCE_SLACK_SECONDS = 60L
+
+        /**
+         * Pure event-construction path. Extracted from [publish] so
+         * tests can pin the wire format (kind, tags, base64-encoded
+         * payload) without standing up a WebSocket relay.
+         *
+         * `internal` because this is a transport-implementation detail
+         * — callers should only see [MessageTransport.publish].
+         */
+        internal fun buildPublishEvent(
+            payload: ByteArray,
+            topic: TransportTopic,
+            signer: NostrSigner,
+        ): NostrEvent = NostrEvent.build(
+            kind = PRIMARY_KIND,
+            tags = listOf(listOf("t", topic.rawValue)),
+            content = Base64.getEncoder().encodeToString(payload),
+            signer = signer,
+        )
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrSigner.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrSigner.kt
@@ -27,7 +27,13 @@ interface NostrSigner {
  * from the secret rather than caching, so the secret is the only
  * thing pinned in memory.
  */
-class OnymNostrSigner(private val secretKey: ByteArray) : NostrSigner {
+class OnymNostrSigner(
+    /** `internal` (not `private`) so tests can assert ephemeral
+     *  signers produce distinct secrets — the metadata-hiding
+     *  invariant. Production code should never read this directly;
+     *  go through [signEventId] / [publicKey] instead. */
+    internal val secretKey: ByteArray,
+) : NostrSigner {
 
     init {
         require(secretKey.size == 32) {

--- a/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrEventTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrEventTest.kt
@@ -1,0 +1,219 @@
+package chat.onym.android.transport.nostr
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.MessageDigest
+
+/**
+ * Tests for the NIP-01 wire format and the integrity check that
+ * [NostrRelayConnection] runs on every inbound event. These are the
+ * only invariants that protect us from relay-side tampering, so the
+ * coverage is deliberately blunt: build → mutate one byte → verify
+ * fails.
+ *
+ * Mirrors `NostrEventTests.swift` from onym-ios PR #13. iOS uses the
+ * real OnymSDK-backed signer because Swift Package + XCFramework
+ * loads the FFI directly into XCTest. On Android the OnymSDK FFI
+ * lives in jni/abi/lib*.so inside the AAR — only loadable on
+ * emulator/device, not on host JVM. So this JVM-unit test uses a
+ * deterministic [DeterministicFakeSigner] (pubkey = SHA-256(secret),
+ * sig = SHA-512(secret || eventId).take(64)) instead. The framing
+ * assertions don't depend on real BIP340; the signer-FFI roundtrip
+ * is covered separately in [androidTest's OnymNostrSignerTest]
+ * (instrumented).
+ */
+class NostrEventTest {
+
+    private val signer = DeterministicFakeSigner(secret = ByteArray(32) { 0xAB.toByte() })
+
+    // ─── build ─────────────────────────────────────────────────────
+
+    @Test
+    fun build_producesValidEventId() {
+        val event = NostrEvent.build(
+            kind = 44114,
+            tags = listOf(listOf("t", "topic-x")),
+            content = "hello",
+            signer = signer,
+        )
+        assertTrue("freshly built event must verify", event.verifyEventId())
+    }
+
+    @Test
+    fun build_appendsMillisecondTag() {
+        val event = NostrEvent.build(
+            kind = 44114,
+            tags = listOf(listOf("t", "topic-x")),
+            content = "hello",
+            signer = signer,
+        )
+        val msTag = event.tags.firstOrNull { it.firstOrNull() == "ms" }
+        assertNotNull("build() must append [\"ms\", ...]", msTag)
+        assertEquals(2, msTag!!.size)
+        val ms = msTag[1].toLongOrNull()
+        assertNotNull(ms)
+        // Within 5s of "now" — sanity, not exact equality.
+        val nowMs = System.currentTimeMillis()
+        assertTrue("ms within 5s of now (got $ms vs $nowMs)", kotlin.math.abs(ms!! - nowMs) < 5_000)
+    }
+
+    @Test
+    fun build_signatureIsHex128Chars() {
+        val event = NostrEvent.build(kind = 44114, tags = emptyList(), content = "x", signer = signer)
+        // BIP340 sig is 64 bytes = 128 hex chars. The fake signer
+        // returns 64 bytes too, so this asserts the framing/encoding
+        // path — not BIP340 validity.
+        assertEquals(128, event.sig.length)
+    }
+
+    @Test
+    fun build_pubkeyMatchesSigner() {
+        val event = NostrEvent.build(kind = 44114, tags = emptyList(), content = "x", signer = signer)
+        val expectedPubkeyHex = signer.publicKey().toHex()
+        assertEquals(expectedPubkeyHex, event.pubkey)
+    }
+
+    @Test
+    fun build_preservesCallerProvidedTags() {
+        val userTags = listOf(listOf("t", "topic-x"), listOf("sep_version", "1"))
+        val event = NostrEvent.build(
+            kind = 34113,
+            tags = userTags,
+            content = "x",
+            signer = signer,
+        )
+        // Caller tags appear first, then the appended ms tag.
+        assertEquals(userTags, event.tags.take(userTags.size))
+    }
+
+    // ─── verifyEventId tampering ──────────────────────────────────
+
+    @Test
+    fun verifyEventId_rejectsTamperedContent() {
+        val event = NostrEvent.build(kind = 44114, tags = emptyList(), content = "hello", signer = signer)
+        val tampered = event.copy(content = "goodbye")
+        assertFalse(tampered.verifyEventId())
+    }
+
+    @Test
+    fun verifyEventId_rejectsTamperedTags() {
+        val event = NostrEvent.build(kind = 44114, tags = listOf(listOf("t", "a")), content = "x", signer = signer)
+        val tampered = event.copy(
+            tags = listOf(listOf("t", "b")) + event.tags.drop(1),
+        )
+        assertFalse(tampered.verifyEventId())
+    }
+
+    @Test
+    fun verifyEventId_rejectsTamperedKind() {
+        val event = NostrEvent.build(kind = 44114, tags = emptyList(), content = "x", signer = signer)
+        val tampered = event.copy(kind = 1)
+        assertFalse(tampered.verifyEventId())
+    }
+
+    // ─── displayMilliseconds ──────────────────────────────────────
+
+    @Test
+    fun displayMilliseconds_readsMsTag() {
+        val event = NostrEvent(
+            id = "00", pubkey = "00", createdAt = 1_700_000_000L,
+            kind = 44114, tags = listOf(listOf("ms", "1700000000123")),
+            content = "", sig = "",
+        )
+        assertEquals(1_700_000_000_123L, event.displayMilliseconds)
+    }
+
+    @Test
+    fun displayMilliseconds_fallsBackToCreatedAt() {
+        val event = NostrEvent(
+            id = "00", pubkey = "00", createdAt = 1_700_000_000L,
+            kind = 44114, tags = emptyList(),
+            content = "", sig = "",
+        )
+        assertEquals(1_700_000_000_000L, event.displayMilliseconds)
+    }
+
+    @Test
+    fun displayMilliseconds_ignoresMalformedMsTag() {
+        val event = NostrEvent(
+            id = "00", pubkey = "00", createdAt = 1_700_000_000L,
+            kind = 44114, tags = listOf(listOf("ms", "not-a-number")),
+            content = "", sig = "",
+        )
+        assertEquals(1_700_000_000_000L, event.displayMilliseconds)
+    }
+
+    @Test
+    fun displayMilliseconds_ignoresNegativeMs() {
+        val event = NostrEvent(
+            id = "00", pubkey = "00", createdAt = 1_700_000_000L,
+            kind = 44114, tags = listOf(listOf("ms", "-1")),
+            content = "", sig = "",
+        )
+        assertEquals(1_700_000_000_000L, event.displayMilliseconds)
+    }
+
+    // ─── wire format ──────────────────────────────────────────────
+
+    @Test
+    fun toJson_usesCreatedAtFieldName() {
+        val event = NostrEvent(
+            id = "deadbeef", pubkey = "abc", createdAt = 42L,
+            kind = 1, tags = listOf(listOf("t", "x")), content = "hi", sig = "sig",
+        )
+        val json = event.toJson()
+        assertEquals(42L, json.getLong("created_at"))
+        // Wire field is `created_at`, not `createdAt`.
+        assertFalse(json.has("createdAt"))
+    }
+
+    @Test
+    fun toJson_fromJson_roundtrip() {
+        val original = NostrEvent(
+            id = "deadbeef", pubkey = "abc", createdAt = 42L,
+            kind = 1,
+            tags = listOf(listOf("t", "x"), listOf("ms", "42000")),
+            content = "hi", sig = "sig",
+        )
+        val decoded = NostrEvent.fromJson(JSONObject(original.toJson().toString()))
+        assertNotNull(decoded)
+        assertEquals(original.id, decoded!!.id)
+        assertEquals(original.createdAt, decoded.createdAt)
+        assertEquals(original.tags, decoded.tags)
+        assertEquals(original.content, decoded.content)
+    }
+
+    // ─── Fakes ────────────────────────────────────────────────────
+
+    /**
+     * Deterministic, no-FFI signer that lets framing tests run on
+     * host JVM. Pubkey = SHA-256(secret), sig = first 64 bytes of
+     * SHA-512(secret || eventId). Both transforms are stable and
+     * differ between distinct secrets, which is enough to exercise
+     * the [NostrEvent.build] paths.
+     *
+     * NOT BIP340-compatible — the signer-FFI roundtrip is covered
+     * by `androidTest/.../OnymNostrSignerTest` against the real
+     * `chat.onym.sdk.Common` on an emulator.
+     */
+    private class DeterministicFakeSigner(private val secret: ByteArray) : NostrSigner {
+        override fun publicKey(): ByteArray =
+            MessageDigest.getInstance("SHA-256").digest(secret)
+
+        override fun signEventId(eventId: ByteArray): ByteArray =
+            MessageDigest.getInstance("SHA-512")
+                .digest(secret + eventId)
+                .copyOf(64)
+    }
+
+    private fun ByteArray.toHex(): String {
+        val sb = StringBuilder(size * 2)
+        for (b in this) sb.append("%02x".format(b.toInt() and 0xFF))
+        return sb.toString()
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrInboxTransportTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrInboxTransportTest.kt
@@ -1,0 +1,143 @@
+package chat.onym.android.transport.nostr
+
+import chat.onym.android.transport.TransportInboxId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Covers the pure event-building and filter-shape paths of the
+ * inbox adapter. Connection-bearing paths await an integration test
+ * layer.
+ *
+ * Mirrors `NostrInboxTransportTests.swift` from onym-ios PR #13.
+ * Uses [DeterministicFakeSigner] for the same JVM-vs-FFI reason as
+ * the rest of the framing-test suite.
+ */
+class NostrInboxTransportTest {
+
+    private val signer = DeterministicFakeSigner(secret = ByteArray(32) { 0xEF.toByte() })
+
+    // ─── buildSendEvent ───────────────────────────────────────────
+
+    @Test
+    fun buildSendEvent_usesKind34113() {
+        val event = NostrInboxTransport.buildSendEvent(
+            payload = ByteArray(0),
+            inbox = TransportInboxId("abc123"),
+            signer = signer,
+        )
+        assertEquals(34113, event.kind)
+    }
+
+    @Test
+    fun buildSendEvent_emitsExpectedTagSet() {
+        val event = NostrInboxTransport.buildSendEvent(
+            payload = ByteArray(0),
+            inbox = TransportInboxId("abc123"),
+            signer = signer,
+        )
+        // Strip the appended ms tag — its value is non-deterministic.
+        val userTags = event.tags.filter { it.firstOrNull() != "ms" }
+        assertEquals(
+            listOf(
+                listOf("d", "sep-inbox:abc123"),
+                listOf("t", "abc123"),
+                listOf("sep_inbox", "abc123"),
+                listOf("sep_version", "1"),
+            ),
+            userTags,
+        )
+    }
+
+    @Test
+    fun buildSendEvent_dTagPrefixIsLoadBearing() {
+        // A relay using the parameterised-replaceable `d` tag for
+        // routing keys on the literal string — drift on the prefix
+        // would silently break delivery.
+        val event = NostrInboxTransport.buildSendEvent(
+            payload = ByteArray(0),
+            inbox = TransportInboxId("id-1"),
+            signer = signer,
+        )
+        val dTag = event.tags.firstOrNull { it.firstOrNull() == "d" }
+        assertNotNull(dTag)
+        assertEquals("sep-inbox:id-1", dTag!![1])
+    }
+
+    @Test
+    fun buildSendEvent_payloadRoundtripsViaBase64() {
+        val payload = "invitation-blob".toByteArray()
+        val event = NostrInboxTransport.buildSendEvent(
+            payload = payload,
+            inbox = TransportInboxId("x"),
+            signer = signer,
+        )
+        assertTrue(payload.contentEquals(Base64.getDecoder().decode(event.content)))
+    }
+
+    @Test
+    fun buildSendEvent_eventIdIsValid() {
+        val event = NostrInboxTransport.buildSendEvent(
+            payload = "x".toByteArray(),
+            inbox = TransportInboxId("x"),
+            signer = signer,
+        )
+        assertTrue(event.verifyEventId())
+    }
+
+    // ─── subscriptionFilters ──────────────────────────────────────
+
+    @Test
+    fun subscriptionFilters_returnsThreeShapes() {
+        val filters = NostrInboxTransport.subscriptionFilters("id-1")
+        assertEquals(
+            "primary #d + secondary #t + legacy kind = 3 filters",
+            3,
+            filters.size,
+        )
+    }
+
+    @Test
+    fun subscriptionFilters_primaryUsesDTagWithPrefix() {
+        val filter = NostrInboxTransport.subscriptionFilters("id-1")[0]
+        val kinds = filter.getJSONArray("kinds")
+        val dValues = filter.getJSONArray("#d")
+        assertEquals(1, kinds.length())
+        assertEquals(34113, kinds.getInt(0))
+        assertEquals(1, dValues.length())
+        assertEquals("sep-inbox:id-1", dValues.getString(0))
+    }
+
+    @Test
+    fun subscriptionFilters_secondaryUsesTTagOnPrimaryKind() {
+        val filter = NostrInboxTransport.subscriptionFilters("id-1")[1]
+        val kinds = filter.getJSONArray("kinds")
+        val tValues = filter.getJSONArray("#t")
+        assertEquals(1, kinds.length())
+        assertEquals(34113, kinds.getInt(0))
+        assertEquals(1, tValues.length())
+        assertEquals("id-1", tValues.getString(0))
+    }
+
+    @Test
+    fun subscriptionFilters_legacyUsesTTagOnLegacyKind() {
+        val filter = NostrInboxTransport.subscriptionFilters("id-1")[2]
+        val kinds = filter.getJSONArray("kinds")
+        val tValues = filter.getJSONArray("#t")
+        assertEquals(1, kinds.length())
+        assertEquals(24113, kinds.getInt(0))
+        assertEquals(1, tValues.length())
+        assertEquals("id-1", tValues.getString(0))
+    }
+
+    private class DeterministicFakeSigner(private val secret: ByteArray) : NostrSigner {
+        override fun publicKey(): ByteArray =
+            MessageDigest.getInstance("SHA-256").digest(secret)
+        override fun signEventId(eventId: ByteArray): ByteArray =
+            MessageDigest.getInstance("SHA-512").digest(secret + eventId).copyOf(64)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrMessageTransportTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrMessageTransportTest.kt
@@ -1,0 +1,117 @@
+package chat.onym.android.transport.nostr
+
+import chat.onym.android.transport.TransportTopic
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.MessageDigest
+import java.util.Base64
+
+/**
+ * Covers the pure event-building path of the broadcast adapter. The
+ * connection / publish / subscribe paths require a real or fake
+ * WebSocket server and are deferred to integration tests.
+ *
+ * Mirrors `NostrMessageTransportTests.swift` from onym-ios PR #13.
+ * Uses [DeterministicFakeSigner] instead of the OnymSDK-backed
+ * signer for the same JVM-vs-FFI reason as [NostrEventTest] — see
+ * the doc on that class for the rationale.
+ */
+class NostrMessageTransportTest {
+
+    private val signer = DeterministicFakeSigner(secret = ByteArray(32) { 0xCD.toByte() })
+
+    @Test
+    fun buildPublishEvent_usesKind44114() {
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = "hello".toByteArray(),
+            topic = TransportTopic("topic-a"),
+            signer = signer,
+        )
+        assertEquals(44114, event.kind)
+    }
+
+    @Test
+    fun buildPublishEvent_emitsTopicTag() {
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = ByteArray(0),
+            topic = TransportTopic("topic-a"),
+            signer = signer,
+        )
+        val tTags = event.tags.filter { it.firstOrNull() == "t" }
+        assertEquals(
+            "publish must emit exactly one [t, topic] tag",
+            listOf(listOf("t", "topic-a")),
+            tTags,
+        )
+    }
+
+    @Test
+    fun buildPublishEvent_appendsMsTag() {
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = ByteArray(0),
+            topic = TransportTopic("x"),
+            signer = signer,
+        )
+        assertNotNull(event.tags.firstOrNull { it.firstOrNull() == "ms" })
+    }
+
+    @Test
+    fun buildPublishEvent_payloadRoundtripsViaBase64() {
+        val payload = ByteArray(256) { it.toByte() }
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = payload,
+            topic = TransportTopic("x"),
+            signer = signer,
+        )
+        val decoded = Base64.getDecoder().decode(event.content)
+        assertTrue(payload.contentEquals(decoded))
+    }
+
+    @Test
+    fun buildPublishEvent_emptyPayloadProducesEmptyBase64() {
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = ByteArray(0),
+            topic = TransportTopic("x"),
+            signer = signer,
+        )
+        assertEquals("", event.content)
+    }
+
+    @Test
+    fun buildPublishEvent_eventIdIsValid() {
+        val event = NostrMessageTransport.buildPublishEvent(
+            payload = "hello".toByteArray(),
+            topic = TransportTopic("topic-a"),
+            signer = signer,
+        )
+        assertTrue(event.verifyEventId())
+    }
+
+    @Test
+    fun buildPublishEvent_distinctSignersProduceDifferentPubkeys() {
+        // Use two distinct fake signers (different secrets → different
+        // SHA-256 pubkeys). On real BIP340 + ephemeral SecureRandom
+        // the property holds with overwhelming probability; covered
+        // end-to-end in the instrumented OnymNostrSignerTest.
+        val signerA = DeterministicFakeSigner(secret = ByteArray(32) { 0x01 })
+        val signerB = DeterministicFakeSigner(secret = ByteArray(32) { 0x02 })
+        val topic = TransportTopic("x")
+        val eventA = NostrMessageTransport.buildPublishEvent(ByteArray(0), topic, signerA)
+        val eventB = NostrMessageTransport.buildPublishEvent(ByteArray(0), topic, signerB)
+        assertNotEquals(
+            "ephemeral signing is the metadata-hiding property — pubkeys must differ",
+            eventA.pubkey,
+            eventB.pubkey,
+        )
+    }
+
+    private class DeterministicFakeSigner(private val secret: ByteArray) : NostrSigner {
+        override fun publicKey(): ByteArray =
+            MessageDigest.getInstance("SHA-256").digest(secret)
+        override fun signEventId(eventId: ByteArray): ByteArray =
+            MessageDigest.getInstance("SHA-512").digest(secret + eventId).copyOf(64)
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the Nostr transport layer landed in #11. Mirrors the iOS suite from [onym-ios#13](https://github.com/onymchat/onym-ios/pull/13) for cross-platform parity.

- **JVM unit tests** (`app/src/test/`) — framing, canonical-JSON event-id, tampering rejection, ms-tag fallback, base64 payload roundtrip, and adapter event/filter shapes (kinds, `d`/`t` tags, three-filter subscription set).
- **Instrumented tests** (`app/src/androidTest/`) — `OnymNostrSigner` against the real `chat.onym.sdk.Common` FFI: secret-length validation, deterministic 32-byte BIP340 pubkey, 64-byte schnorr sig, signing roundtrip via `Common.nostrVerifyEventSignature`, and `ephemeral()` distinct-pubkey property.

## Refactor enabling the tests

- `OnymNostrSigner.secretKey` promoted from `private` to `internal` with a comment explaining the test-only read path; production code still goes through `signEventId` / `publicKey`.
- `NostrMessageTransport.buildPublishEvent` and `NostrInboxTransport.buildSendEvent` / `subscriptionFilters` extracted into `internal` companion functions so the framing assertions don't need a live WebSocket.

## Android-specific divergences from iOS PR #13

- **Split into unit + instrumented** — on iOS the OnymSDK XCFramework loads its FFI directly into XCTest, so the entire suite runs as `swift test`. On Android the OnymSDK FFI lives in `jni/abi/lib*.so` inside the AAR — only loadable on emulator/device, not on host JVM. So the signer-roundtrip test runs in `androidTest/` against a real emulator, and the framing tests use a `DeterministicFakeSigner` (SHA-256 pubkey, SHA-512-truncated sig — stable + distinct, but not BIP340-valid).
- **`testImplementation("org.json:json:20240303")`** — Android's unit-test environment stubs `org.json` (every method throws "not mocked"). The transport's canonical-JSON path uses `JSONObject` / `JSONArray`, so unit tests need a real impl on the classpath.

## Out of scope

- WebSocket-bearing paths (`connect`, `publish`, `subscribe`) — deferred to an integration layer with a real or fake relay; same as iOS PR #13.
- Reconnect/backoff logic in `NostrRelayConnection` — same deferral.

## Test plan

- [x] `./gradlew testDebugUnitTest` — 30 framing tests pass on host JVM
- [x] `./gradlew compileDebugAndroidTestKotlin` — instrumented suite compiles
- [x] `bash scripts/lint-secrets.sh` — clean
- [ ] CI release pipeline runs the full instrumented suite against the API 35 emulator (covered by the gate added in #9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)