### PR TITLE
test(nostr-signer): assert Boolean return from nostrVerifyEventSignature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ google-services.json
 
 # Android Profiling
 *.hprof
+.kotlin/

--- a/app/src/androidTest/kotlin/chat/onym/android/transport/nostr/OnymNostrSignerTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/transport/nostr/OnymNostrSignerTest.kt
@@ -3,12 +3,12 @@ package chat.onym.android.transport.nostr
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import chat.onym.android.identity.OnymNostrSigner
 import chat.onym.sdk.Common
-import chat.onym.sdk.OnymException
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -97,9 +97,16 @@ class OnymNostrSignerTest {
         val pub = signer.publicKey()
         val eventId = ByteArray(32) { 0xAA.toByte() }
         val sig = signer.signEventId(eventId)
-        // Common.nostrVerifyEventSignature throws OnymException on
-        // verification failure; not throwing = success.
-        Common.nostrVerifyEventSignature(pub, eventId, sig)
+        // Android's Common.nostrVerifyEventSignature returns Boolean
+        // — the underlying FFI conflates "verify failed" with "input
+        // malformed" into a single `bool` (see the wrapper KDoc in
+        // onym-sdk-kotlin). iOS's binding throws on failure instead.
+        // Inputs here are well-formed and the sig is freshly produced,
+        // so the result must be true.
+        assertTrue(
+            "schnorr verify of own signature must return true",
+            Common.nostrVerifyEventSignature(pub, eventId, sig),
+        )
     }
 
     @Test
@@ -109,9 +116,10 @@ class OnymNostrSignerTest {
         val signedId = ByteArray(32) { 0xAA.toByte() }
         val otherId = ByteArray(32) { 0xBB.toByte() }
         val sig = signer.signEventId(signedId)
-        assertThrows(OnymException::class.java) {
-            Common.nostrVerifyEventSignature(pub, otherId, sig)
-        }
+        assertFalse(
+            "verify with a different eventId must return false",
+            Common.nostrVerifyEventSignature(pub, otherId, sig),
+        )
     }
 
     // ─── ephemeral ────────────────────────────────────────────────
@@ -138,6 +146,9 @@ class OnymNostrSignerTest {
         val pub = signer.publicKey()
         val eventId = ByteArray(32) { 0x55 }
         val sig = signer.signEventId(eventId)
-        Common.nostrVerifyEventSignature(pub, eventId, sig)
+        assertTrue(
+            "ephemeral signer roundtrip must verify",
+            Common.nostrVerifyEventSignature(pub, eventId, sig),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fix the one instrumented-test regression that landed in #12 and was flagged in the trailing notes of #13. `OnymNostrSignerTest.signEventId_verificationFailsForWrongMessage` was failing reliably; the two positive verify call sites were silently passing regardless of FFI behavior.

Root cause: the test was modeled 1:1 on iOS PR #13's pattern, where `Common.nostrVerifyEventSignature` throws on bad signatures. On Android the binding diverges — the wrapper in `onym-sdk-kotlin/src/main/kotlin/chat/onym/sdk/Common.kt:109` returns a `Boolean` (the underlying Rust FFI conflates "verify failed" with "input malformed" into a single `bool`):

```kotlin
fun nostrVerifyEventSignature(
    publicKey: ByteArray, eventId: ByteArray, signature: ByteArray
): Boolean = OnymJni.nostrVerifyEventSignature(publicKey, eventId, signature)
```

So `assertThrows(OnymException::class.java) { Common.nostrVerifyEventSignature(...) }` could never pass — the call returns `false`, no exception ever gets thrown.

## What changed

- `signEventId_verificationFailsForWrongMessage` → `assertFalse("verify with a different eventId must return false", Common.nostrVerifyEventSignature(pub, otherId, sig))`
- `signEventId_verifiesAgainstOnymSDK` and `ephemeral_canSignAndVerify` → wrap the call in `assertTrue(...)` so a future SDK regression that flips the bool actually fails the test (instead of silently succeeding like before).
- Drop the unused `chat.onym.sdk.OnymException` import; add `assertTrue`.
- Comment on the iOS-vs-Android binding divergence at the call site so the next person doesn't try to re-port the throwing pattern.

## Out of scope

- Fixing the underlying SDK divergence — iOS throws, Android returns Boolean. Either binding could be "right"; reconciling them is an `onym-sdk-kotlin` / `onym-sdk-swift` API change, not a single-platform test fix.

## Test plan

- [x] `./gradlew :app:connectedDebugAndroidTest` — 47/47 pass on Pixel 9 Pro AVD (API 36)
- [x] `./gradlew :app:testDebugUnitTest` — JVM unit tests still pass
- [x] `python3 scripts/lint-secrets.py` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)