### PR TITLE
persistence: incoming Nostr invitations (seam + repository + stateless interactor + tests)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -111,6 +112,13 @@ dependencies {
 
     implementation(libs.onym.sdk)
 
+    // Room — `suspend` DAO + KSP-generated bindings. PersistenceStore
+    // for incoming invitations + (later) groups / messages / contact
+    // aliases / transport bundles.
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
     // JVM unit tests. Pure-logic only — Bip39, StellarStrKey, the
     // cross-platform fixture. Anything touching EncryptedSharedPreferences
     // goes in androidTest.
@@ -121,6 +129,12 @@ dependencies {
     // use JSONObject + JSONArray for canonical JSON, so tests need a
     // real impl on the classpath.
     testImplementation("org.json:json:20240303")
+    // Robolectric — drives Room (`Context.getApplicationContext()` is
+    // required to open the in-memory DB) from the JVM unit-test
+    // runner. Used by `RoomInvitationStoreTest` only; everything else
+    // in `app/src/test/` is plain JUnit and won't load Robolectric.
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.ext.junit)
 
     // Instrumented tests. Real EncryptedSharedPreferences against the
     // emulator's hardware-backed Keystore.

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
@@ -1,0 +1,47 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.flow.collect
+
+/**
+ * Stateless transport-to-persistence pump. Holds two refs — the
+ * upstream [InboxTransport] seam and the downstream
+ * [IncomingInvitationsRepository] — and connects them in [run].
+ *
+ * Touch-surface compliance:
+ *
+ *  - No state of its own. Cancellation comes from the caller's
+ *    coroutine scope; there's no `start` / `stop` surface to forget
+ *    to clean up.
+ *  - No OnymSDK. No `Context`. No persistence backend.
+ *  - One job: forward each [chat.onym.android.transport.InboundInbox]
+ *    into [IncomingInvitationsRepository.recordIncoming]. Decryption
+ *    + parsing of the inner payload belongs in a future
+ *    `InvitationDetailsRepository` that owns the X25519 read; this
+ *    interactor stays opaque-byte-shipping by design.
+ *
+ * Mirrors `IncomingInvitationsInteractor.swift` from onym-ios PR #16.
+ */
+class IncomingInvitationsInteractor(
+    private val inboxTransport: InboxTransport,
+    private val repository: IncomingInvitationsRepository,
+) {
+
+    /**
+     * Subscribe to [inbox] and forward each delivered message into
+     * the repository. Suspends for the lifetime of the subscription;
+     * cancellation of the calling scope unsubscribes upstream
+     * (production `NostrInboxTransport` runs `unsubscribe` from the
+     * subscribe Flow's `awaitClose`).
+     */
+    suspend fun run(inbox: TransportInboxId) {
+        inboxTransport.subscribe(inbox).collect { inbound ->
+            repository.recordIncoming(
+                id = inbound.messageId,
+                payload = inbound.payload,
+                receivedAt = inbound.receivedAt,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsRepository.kt
@@ -1,0 +1,127 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.persistence.IncomingInvitationRecord
+import chat.onym.android.persistence.IncomingInvitationStatus
+import chat.onym.android.persistence.InvitationStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+
+/**
+ * Owns the in-memory view of "incoming invitations the user hasn't
+ * dealt with yet" plus the corresponding writes to the persistence
+ * seam. Touch-surface compliance:
+ *
+ *  - Holds **only** an [InvitationStore] reference. No transport,
+ *    no OnymSDK, no Compose, no `Context`.
+ *  - Exposes a [StateFlow] for observation; [recordIncoming] /
+ *    [updateStatus] / [delete] are the suspend mutators.
+ *  - Mutations serialise through a [Mutex]; reads are lock-free off
+ *    the [StateFlow].
+ *
+ * The shape mirrors `IdentityRepository` exactly — same Mutex +
+ * StateFlow + asStateFlow pattern. iOS uses `actor + AsyncStream`
+ * for the same role; Android stays with [StateFlow] because Compose
+ * subscribes via `collectAsStateWithLifecycle()` with no per-view
+ * boilerplate (see *Why `StateFlow` instead of `actor + AsyncStream`*
+ * in `README.md`).
+ *
+ * Mirrors `IncomingInvitationsRepository.swift` from onym-ios PR #16.
+ */
+class IncomingInvitationsRepository(
+    private val store: InvitationStore,
+) {
+    private val mutex = Mutex()
+    private val _invitations = MutableStateFlow<List<IncomingInvitation>>(emptyList())
+
+    /** Hot stream of incoming invitations, sorted by [IncomingInvitation.receivedAt]
+     *  desc. Empty until [bootstrap] runs. New collectors get the
+     *  current value immediately, then one new value per successful
+     *  mutation (dedup-only saves don't push a redundant snapshot). */
+    val invitations: StateFlow<List<IncomingInvitation>> = _invitations.asStateFlow()
+
+    /**
+     * Hydrate from disk. Idempotent — safe to call from any
+     * `onCreate` / `LaunchedEffect`. Repeated calls reload but don't
+     * error.
+     */
+    suspend fun bootstrap() = mutex.withLock {
+        _invitations.value = store.list().map(::toInvitation)
+    }
+
+    /**
+     * Persist a freshly-arrived inbound. No-op (and no snapshot
+     * push) if [id] was already persisted — relays can replay events
+     * across reconnects, so dedup-on-id is the correctness property.
+     */
+    suspend fun recordIncoming(
+        id: String,
+        payload: ByteArray,
+        receivedAt: Instant,
+    ) = mutex.withLock {
+        val record = IncomingInvitationRecord(
+            id = id,
+            payload = payload,
+            receivedAt = receivedAt,
+            status = IncomingInvitationStatus.Pending,
+        )
+        if (store.save(record)) {
+            _invitations.value = store.list().map(::toInvitation)
+        }
+    }
+
+    /** Update the status of an existing invitation; refresh the
+     *  StateFlow snapshot. No-op for unknown ids (the store
+     *  swallows them, and the snapshot rebuild is idempotent). */
+    suspend fun updateStatus(id: String, status: IncomingInvitationStatus) = mutex.withLock {
+        store.updateStatus(id, status)
+        _invitations.value = store.list().map(::toInvitation)
+    }
+
+    /** Remove the invitation by id; refresh the StateFlow snapshot. */
+    suspend fun delete(id: String) = mutex.withLock {
+        store.delete(id)
+        _invitations.value = store.list().map(::toInvitation)
+    }
+
+    private fun toInvitation(rec: IncomingInvitationRecord) = IncomingInvitation(
+        id = rec.id,
+        payload = rec.payload,
+        receivedAt = rec.receivedAt,
+        status = rec.status,
+    )
+}
+
+/**
+ * Public-facing snapshot type the repository emits. Structurally
+ * identical to [IncomingInvitationRecord] today; kept separate so
+ * the persistence-layer record can grow Room-specific fields
+ * (encrypted columns, indexed-only joins, etc.) without leaking
+ * into the repository's API surface.
+ */
+data class IncomingInvitation(
+    val id: String,
+    val payload: ByteArray,
+    val receivedAt: Instant,
+    val status: IncomingInvitationStatus,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IncomingInvitation) return false
+        return id == other.id &&
+            payload.contentEquals(other.payload) &&
+            receivedAt == other.receivedAt &&
+            status == other.status
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + receivedAt.hashCode()
+        result = 31 * result + status.hashCode()
+        return result
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationDao.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationDao.kt
@@ -1,0 +1,36 @@
+package chat.onym.android.persistence
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * Room DAO over [PersistedInvitation]. Three CRUD verbs the
+ * repository needs (list, insert with dedup, update status, delete);
+ * nothing else.
+ *
+ * Suspend functions throughout — Room dispatches them on its
+ * single-threaded query executor by default, which is fine for our
+ * volume (an invitation arrives at user-action speed).
+ */
+@Dao
+interface InvitationDao {
+
+    @Query("SELECT * FROM incoming_invitations ORDER BY receivedAt DESC")
+    suspend fun list(): List<PersistedInvitation>
+
+    /**
+     * Insert with `IGNORE` on PK conflict. Returns the new row id on
+     * insert, or `-1` if the row was ignored (id collision).
+     * Callers use the `-1` sentinel for dedup.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(record: PersistedInvitation): Long
+
+    @Query("UPDATE incoming_invitations SET statusRaw = :statusRaw WHERE id = :id")
+    suspend fun updateStatus(id: String, statusRaw: String): Int
+
+    @Query("DELETE FROM incoming_invitations WHERE id = :id")
+    suspend fun delete(id: String): Int
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationDatabase.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationDatabase.kt
@@ -1,0 +1,27 @@
+package chat.onym.android.persistence
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * Room database housing [PersistedInvitation].
+ *
+ * Currently a single-table DB. Future persistence domains (groups,
+ * messages, contact aliases — see the planned-box notes in
+ * `README.md`'s architecture section) can either land here or in
+ * sibling `@Database` classes. Sibling classes keep migrations
+ * scoped per-domain and avoid the `version = 17` rebase pain the
+ * stellar-mls reference impl shows.
+ */
+@Database(
+    entities = [PersistedInvitation::class],
+    version = 1,
+    // Schema export is for cross-version diffing during migration
+    // authoring; nothing to diff at v1 and KSP warns loudly about
+    // the missing `room.schemaLocation` directory otherwise.
+    // Flip to true and add the apt arg when version 2 lands.
+    exportSchema = false,
+)
+abstract class InvitationDatabase : RoomDatabase() {
+    abstract fun invitationDao(): InvitationDao
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationStore.kt
@@ -1,0 +1,75 @@
+package chat.onym.android.persistence
+
+import java.time.Instant
+
+/**
+ * Persistence seam for incoming Nostr invitations. Implementations
+ * provide CRUD over an opaque payload + a status field; encryption
+ * at rest is the impl's responsibility (Room-backed impls wrap the
+ * payload with [StorageEncryption] before the row hits SQLite).
+ *
+ * `suspend` everywhere — production calls use Room's coroutine
+ * support; tests run against [chat.onym.android.support.InMemoryInvitationStore]
+ * which serialises via `Mutex`.
+ *
+ * Mirrors the iOS `InvitationStore` protocol from onym-ios PR #16.
+ */
+interface InvitationStore {
+    /** All persisted records, sorted by [IncomingInvitationRecord.receivedAt] desc. */
+    suspend fun list(): List<IncomingInvitationRecord>
+
+    /**
+     * Persist a fresh inbound. Returns `true` if the row was newly
+     * inserted; `false` if [IncomingInvitationRecord.id] was already
+     * present (dedup). Callers use the return value to skip
+     * redundant downstream notifications.
+     */
+    suspend fun save(record: IncomingInvitationRecord): Boolean
+
+    /** No-op if [id] is absent. */
+    suspend fun updateStatus(id: String, status: IncomingInvitationStatus)
+
+    /** No-op if [id] is absent. */
+    suspend fun delete(id: String)
+}
+
+/**
+ * Plaintext value type the seam exposes. Persistence-side encryption
+ * is invisible to callers — the [payload] is the unwrapped bytes
+ * delivered by [InvitationStore.list].
+ */
+data class IncomingInvitationRecord(
+    val id: String,
+    val payload: ByteArray,
+    val receivedAt: Instant,
+    val status: IncomingInvitationStatus,
+) {
+    // Override equals / hashCode so tests can compare records (data
+    // class auto-generated equals uses ByteArray reference equality).
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IncomingInvitationRecord) return false
+        return id == other.id &&
+            payload.contentEquals(other.payload) &&
+            receivedAt == other.receivedAt &&
+            status == other.status
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + receivedAt.hashCode()
+        result = 31 * result + status.hashCode()
+        return result
+    }
+}
+
+/** Lifecycle of an invitation as the user interacts with it. */
+enum class IncomingInvitationStatus {
+    /** Just received; awaiting user decision. */
+    Pending,
+    /** User accepted; the joining-flow has consumed it. */
+    Accepted,
+    /** User dismissed; persisted only so we don't re-prompt on next inbound. */
+    Rejected,
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/PersistedInvitation.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/PersistedInvitation.kt
@@ -1,0 +1,49 @@
+package chat.onym.android.persistence
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room row shape for an incoming Nostr invitation.
+ *
+ * `id` is the Nostr event id (lowercase hex). The Nostr inbox
+ * transport already exposes it on the relay, so storing it
+ * cleartext doesn't leak anything — and it's the natural primary
+ * key for dedup.
+ *
+ * `receivedAt` is wall-clock ms since the Unix epoch. Stored as a
+ * primitive INTEGER so the DAO can `ORDER BY receivedAt DESC`
+ * without a converter.
+ *
+ * `statusRaw` is [IncomingInvitationStatus.name]. Keeping it a
+ * primitive TEXT lets the DAO update it with a one-line `@Query`,
+ * no `@Update` reflection-roundtrip required.
+ *
+ * `encryptedPayload` is the AES-GCM-wrapped output of
+ * [StorageEncryption.encrypt] over the inbound NaCl-sealed bytes.
+ * Stored as BLOB; opaque to SQLite.
+ */
+@Entity(tableName = "incoming_invitations")
+data class PersistedInvitation(
+    @PrimaryKey val id: String,
+    val encryptedPayload: ByteArray,
+    val receivedAt: Long,
+    val statusRaw: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PersistedInvitation) return false
+        return id == other.id &&
+            encryptedPayload.contentEquals(other.encryptedPayload) &&
+            receivedAt == other.receivedAt &&
+            statusRaw == other.statusRaw
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + encryptedPayload.contentHashCode()
+        result = 31 * result + receivedAt.hashCode()
+        result = 31 * result + statusRaw.hashCode()
+        return result
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/RoomInvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/RoomInvitationStore.kt
@@ -1,0 +1,59 @@
+package chat.onym.android.persistence
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+
+/**
+ * [InvitationStore] backed by Room + [StorageEncryption]. Wraps the
+ * payload with AES-GCM on the way in, unwraps on the way out — the
+ * encryption is invisible to callers.
+ *
+ * IO happens on [ioDispatcher]; default is [Dispatchers.IO]. Tests
+ * pass `UnconfinedTestDispatcher` for deterministic ordering.
+ */
+class RoomInvitationStore(
+    private val dao: InvitationDao,
+    private val encryption: StorageEncryption,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : InvitationStore {
+
+    override suspend fun list(): List<IncomingInvitationRecord> = withContext(ioDispatcher) {
+        dao.list().map { row ->
+            IncomingInvitationRecord(
+                id = row.id,
+                payload = encryption.decrypt(row.encryptedPayload),
+                receivedAt = Instant.ofEpochMilli(row.receivedAt),
+                status = parseStatus(row.statusRaw),
+            )
+        }
+    }
+
+    override suspend fun save(record: IncomingInvitationRecord): Boolean = withContext(ioDispatcher) {
+        val rowId = dao.insert(
+            PersistedInvitation(
+                id = record.id,
+                encryptedPayload = encryption.encrypt(record.payload),
+                receivedAt = record.receivedAt.toEpochMilli(),
+                statusRaw = record.status.name,
+            )
+        )
+        rowId != -1L
+    }
+
+    override suspend fun updateStatus(id: String, status: IncomingInvitationStatus) {
+        withContext(ioDispatcher) { dao.updateStatus(id, status.name) }
+    }
+
+    override suspend fun delete(id: String) {
+        withContext(ioDispatcher) { dao.delete(id) }
+    }
+
+    /** Tolerant parse: an unknown enum value (from a future schema
+     *  rolled back, say) falls back to [IncomingInvitationStatus.Pending]
+     *  rather than crashing the read. */
+    private fun parseStatus(raw: String): IncomingInvitationStatus =
+        IncomingInvitationStatus.entries.firstOrNull { it.name == raw }
+            ?: IncomingInvitationStatus.Pending
+}

--- a/app/src/main/kotlin/chat/onym/android/persistence/StorageEncryption.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/StorageEncryption.kt
@@ -1,0 +1,164 @@
+package chat.onym.android.persistence
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Field-level AES-256-GCM encryption for Room columns. The on-disk
+ * layout is `nonce(12) || ciphertext || tag(16)` — GCM appends the
+ * tag to the ciphertext, so a single contiguous `ByteArray` is
+ * enough to round-trip.
+ *
+ * Defence-in-depth wrapper for already-encrypted payloads: the
+ * inbox transport delivers NaCl-sealed bytes from the sender, which
+ * we wrap in this AES layer so disk forensics with the device
+ * locked can't read the inner ciphertext structure either. The
+ * inner ciphertext is recoverable only by the recipient's X25519
+ * private key, which lives in `IdentityRepository`.
+ *
+ * Ported from `stellar-mls/clients/android/StellarChat/app/src/main/java/chat/onym/android/crypto/StorageEncryption.kt`,
+ * minus the NSE / shared-keystore bits that don't apply to onym-android.
+ *
+ * **Ctor takes the AES key directly** rather than the singleton
+ * `init(context: Context)` pattern — tests pass a fresh key per case
+ * (no Robolectric Keystore dance), and production wires the
+ * Keystore-backed loader through [fromContext] at app startup.
+ *
+ * Mirrors `StorageEncryption.swift` from onym-ios PR #16.
+ */
+class StorageEncryption internal constructor(private val keySpec: SecretKeySpec) {
+
+    /** Encrypt bytes. Returns `nonce(12) || ciphertext || tag(16)`. */
+    fun encrypt(plaintext: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec)
+        val iv = cipher.iv  // GCM ctor populates a fresh 12-byte nonce
+        val ciphertextWithTag = cipher.doFinal(plaintext)
+        return iv + ciphertextWithTag
+    }
+
+    /** Encrypt a UTF-8 string; same on-disk layout as [encrypt]. */
+    fun encrypt(string: String): ByteArray = encrypt(string.toByteArray(Charsets.UTF_8))
+
+    /** Decrypt the combined `nonce(12) || ciphertext || tag(16)` layout. */
+    fun decrypt(combined: ByteArray): ByteArray {
+        require(combined.size >= NONCE_SIZE + TAG_SIZE) {
+            "ciphertext too short: ${combined.size} bytes (need >= ${NONCE_SIZE + TAG_SIZE})"
+        }
+        val iv = combined.copyOfRange(0, NONCE_SIZE)
+        val ciphertextWithTag = combined.copyOfRange(NONCE_SIZE, combined.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, GCMParameterSpec(TAG_SIZE * 8, iv))
+        return cipher.doFinal(ciphertextWithTag)
+    }
+
+    /** Decrypt and decode the result as UTF-8. */
+    fun decryptString(combined: ByteArray): String =
+        String(decrypt(combined), Charsets.UTF_8)
+
+    companion object {
+        /** AES-GCM nonce size in bytes. */
+        const val NONCE_SIZE = 12
+
+        /** AES-GCM auth tag size in bytes (128 bits). */
+        const val TAG_SIZE = 16
+
+        /** Current key-derivation version. Increment + handle migration
+         *  if the [hkdfSha256] inputs change. */
+        private const val DERIVATION_VERSION = 1
+
+        private const val PREFS_NAME = "chat.onym.android.storage_root"
+        private const val ROOT_KEY_PREF = "root_secret"
+
+        /**
+         * Production loader: pulls the 32-byte root secret from
+         * EncryptedSharedPreferences (creating one on first launch),
+         * then HKDF-derives the AES key. The root never leaves the
+         * Keystore-backed prefs file; the storage key is derived
+         * fresh on every load so future versions can rotate keys
+         * by bumping [DERIVATION_VERSION].
+         *
+         * Synchronisation isn't needed here — every caller gets its
+         * own [StorageEncryption] instance with the same derived
+         * key bytes. Wire one instance into the persistence root in
+         * `OnymApplication` and pass it to every `Room*Store`.
+         */
+        fun fromContext(context: Context): StorageEncryption {
+            val rootSecret = loadOrCreateRootSecret(context)
+            val storageKey = hkdfSha256(
+                ikm = rootSecret,
+                salt = "chat.onym.android.storage".toByteArray(Charsets.UTF_8),
+                info = "local-storage-v$DERIVATION_VERSION".toByteArray(Charsets.UTF_8),
+                length = 32,
+            )
+            return StorageEncryption(SecretKeySpec(storageKey, "AES"))
+        }
+
+        private fun loadOrCreateRootSecret(context: Context): ByteArray {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+            val prefs = EncryptedSharedPreferences.create(
+                context,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+            val storedHex = prefs.getString(ROOT_KEY_PREF, null)
+            if (storedHex != null) return storedHex.hexToBytes()
+            val secret = ByteArray(32).also { SecureRandom().nextBytes(it) }
+            prefs.edit().putString(ROOT_KEY_PREF, secret.toHex()).apply()
+            return secret
+        }
+
+        /**
+         * RFC-5869 HKDF-SHA256. Same algorithm as the Bip39 derivation
+         * chain in `chat.onym.android.identity` but lives here so the
+         * persistence layer doesn't import from identity (touch-surface
+         * rule: persistence seam talks to its backend + nothing above).
+         */
+        private fun hkdfSha256(ikm: ByteArray, salt: ByteArray, info: ByteArray, length: Int): ByteArray {
+            require(length in 1..(255 * 32)) { "HKDF output length out of range: $length" }
+            val mac = Mac.getInstance("HmacSHA256")
+            // extract
+            mac.init(SecretKeySpec(salt, "HmacSHA256"))
+            val prk = mac.doFinal(ikm)
+            // expand
+            mac.init(SecretKeySpec(prk, "HmacSHA256"))
+            val out = ByteArray(length)
+            var t = ByteArray(0)
+            var pos = 0
+            var counter: Byte = 1
+            while (pos < length) {
+                mac.reset()
+                mac.update(t)
+                mac.update(info)
+                mac.update(counter)
+                t = mac.doFinal()
+                val take = minOf(t.size, length - pos)
+                System.arraycopy(t, 0, out, pos, take)
+                pos += take
+                counter = (counter + 1).toByte()
+            }
+            return out
+        }
+
+        private fun ByteArray.toHex(): String = buildString(size * 2) {
+            for (b in this@toHex) append("%02x".format(b.toInt() and 0xFF))
+        }
+
+        private fun String.hexToBytes(): ByteArray {
+            require(length % 2 == 0) { "hex string must have even length" }
+            return ByteArray(length / 2) { i ->
+                ((this[i * 2].digitToInt(16) shl 4) or this[i * 2 + 1].digitToInt(16)).toByte()
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.inbox
+
+import chat.onym.android.support.FakeInboxTransport
+import chat.onym.android.support.InMemoryInvitationStore
+import chat.onym.android.transport.InboundInbox
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * End-to-end pump test against both reusable fakes
+ * ([FakeInboxTransport] + [InMemoryInvitationStore]). Validates the
+ * one job [IncomingInvitationsInteractor] has — forward each
+ * inbound message into the repository, dedup at the repo, exit
+ * cleanly on cancellation.
+ *
+ * Mirrors `IncomingInvitationsInteractorTests.swift` from onym-ios PR #16.
+ */
+class IncomingInvitationsInteractorTest {
+
+    private val inbox = TransportInboxId("inbox-test")
+    private val now = Instant.parse("2026-05-02T12:00:00Z")
+
+    @Test
+    fun oneInbound_oneRecord() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        coroutineScope {
+            val job = async { interactor.run(inbox) }
+            transport.emit(inbound("ev1", "p1"))
+            transport.finish(inbox)
+            job.await()
+        }
+
+        val all = store.list()
+        assertEquals(1, all.size)
+        assertEquals("ev1", all[0].id)
+        assertArrayEquals("p1".toByteArray(), all[0].payload)
+    }
+
+    @Test
+    fun multipleInbounds_persistedInOrder() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        coroutineScope {
+            val job = async { interactor.run(inbox) }
+            transport.emit(inbound("ev1", "first", at = now))
+            transport.emit(inbound("ev2", "second", at = now.plusSeconds(1)))
+            transport.emit(inbound("ev3", "third", at = now.plusSeconds(2)))
+            transport.finish(inbox)
+            job.await()
+        }
+
+        // store.list() is ordered receivedAt desc.
+        assertEquals(listOf("ev3", "ev2", "ev1"), store.list().map { it.id })
+    }
+
+    @Test
+    fun duplicateMessageId_dedupedAtRepository() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        coroutineScope {
+            val job = async { interactor.run(inbox) }
+            // Same id, different payload — relays can replay events
+            // across reconnects and the dedup-on-id property is what
+            // protects the repository.
+            transport.emit(inbound("ev1", "first"))
+            transport.emit(inbound("ev1", "second-replay"))
+            transport.finish(inbox)
+            job.await()
+        }
+
+        val rec = store.list().single()
+        assertEquals("ev1", rec.id)
+        assertArrayEquals("first".toByteArray(), rec.payload)
+    }
+
+    @Test
+    fun cancellation_unsubscribesUpstream() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        coroutineScope {
+            val job = async { interactor.run(inbox) }
+            // Make sure subscribe() has fired before we cancel.
+            transport.emit(inbound("ev1", "x"))
+            yield()
+            assertEquals(1, transport.subscribeCallCount)
+            job.cancel()
+            // Wait for the cancellation to propagate through onCompletion.
+            withTimeout(1_000) {
+                while (transport.unsubscribedInboxes.isEmpty()) yield()
+            }
+        }
+
+        assertTrue(
+            "cancellation must trigger upstream unsubscribe (mirrors NostrInboxTransport's awaitClose)",
+            transport.unsubscribedInboxes.contains(inbox),
+        )
+    }
+
+    @Test
+    fun finishWhileIdle_exitsCleanly() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        coroutineScope {
+            val job = async { interactor.run(inbox) }
+            // No inbounds — just close the channel.
+            yield()
+            transport.finish(inbox)
+            job.await()  // must complete without throwing
+        }
+
+        assertTrue("no records persisted on a finish-while-idle path", store.list().isEmpty())
+        assertTrue(
+            "subscribe Flow's onCompletion must still fire unsubscribe on graceful close",
+            transport.unsubscribedInboxes.contains(inbox),
+        )
+    }
+
+    private fun inbound(id: String, payload: String, at: Instant = now) = InboundInbox(
+        inbox = inbox,
+        payload = payload.toByteArray(Charsets.UTF_8),
+        receivedAt = at,
+        messageId = id,
+    )
+}

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsRepositoryTest.kt
@@ -1,0 +1,159 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.persistence.IncomingInvitationRecord
+import chat.onym.android.persistence.IncomingInvitationStatus
+import chat.onym.android.support.InMemoryInvitationStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Repository contract against [InMemoryInvitationStore]. The
+ * Room-backed companion ([chat.onym.android.persistence.RoomInvitationStoreTest])
+ * exercises the same seam against the real backend; this suite
+ * focuses on repository semantics — StateFlow emission discipline,
+ * dedup, mutation propagation.
+ *
+ * Mirrors `IncomingInvitationsRepositoryTests.swift` from onym-ios PR #16.
+ */
+class IncomingInvitationsRepositoryTest {
+
+    private val now = Instant.parse("2026-05-02T12:00:00Z")
+
+    // ─── recordIncoming ───────────────────────────────────────────
+
+    @Test
+    fun recordIncoming_savesViaStore() = runTest {
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+
+        repo.recordIncoming(id = "ev1", payload = "p1".toByteArray(), receivedAt = now)
+
+        val stored = store.list().single()
+        assertEquals("ev1", stored.id)
+        assertArrayEquals("p1".toByteArray(), stored.payload)
+        assertEquals(IncomingInvitationStatus.Pending, stored.status)
+    }
+
+    @Test
+    fun recordIncoming_idempotentOnId() = runTest {
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+
+        repo.recordIncoming(id = "ev1", payload = "first".toByteArray(), receivedAt = now)
+        // Second record with same id — different payload — must be ignored.
+        repo.recordIncoming(id = "ev1", payload = "second".toByteArray(), receivedAt = now)
+
+        val stored = store.list().single()
+        assertArrayEquals("first".toByteArray(), stored.payload)
+    }
+
+    // ─── status / delete propagation ──────────────────────────────
+
+    @Test
+    fun updateStatus_propagatesToStore() = runTest {
+        val store = InMemoryInvitationStore()
+        store.save(record("ev1", "x", now, IncomingInvitationStatus.Pending))
+        val repo = IncomingInvitationsRepository(store)
+        repo.bootstrap()
+
+        repo.updateStatus("ev1", IncomingInvitationStatus.Accepted)
+
+        assertEquals(IncomingInvitationStatus.Accepted, store.list().single().status)
+    }
+
+    @Test
+    fun delete_propagatesToStore() = runTest {
+        val store = InMemoryInvitationStore()
+        store.save(record("ev1", "x", now))
+        store.save(record("ev2", "y", now.plusSeconds(1)))
+        val repo = IncomingInvitationsRepository(store)
+        repo.bootstrap()
+
+        repo.delete("ev1")
+
+        assertEquals(listOf("ev2"), store.list().map { it.id })
+    }
+
+    // ─── StateFlow emission discipline ────────────────────────────
+
+    @Test
+    fun stateFlow_initialValue_isEmptyBeforeBootstrap() = runTest {
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        assertTrue(repo.invitations.value.isEmpty())
+    }
+
+    @Test
+    fun stateFlow_initialValue_hydratedAfterBootstrap() = runTest {
+        val store = InMemoryInvitationStore()
+        store.save(record("ev1", "x", now))
+        store.save(record("ev2", "y", now.plusSeconds(1)))
+        val repo = IncomingInvitationsRepository(store)
+
+        repo.bootstrap()
+
+        // Sorted by receivedAt desc — ev2 first.
+        assertEquals(listOf("ev2", "ev1"), repo.invitations.value.map { it.id })
+    }
+
+    @Test
+    fun stateFlow_skipsRedundantEmitOnDedup() = runTest {
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val seen = mutableListOf<List<String>>()
+        // Subscribe synchronously by snapshot — value-only check.
+        seen.add(repo.invitations.value.map { it.id })
+
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
+        val firstSnapshot = repo.invitations.value
+        seen.add(firstSnapshot.map { it.id })
+
+        // Duplicate id — must NOT push a redundant snapshot. We
+        // assert on object identity: the StateFlow's `value` must
+        // be the *same* list instance, not a freshly-built equal
+        // one. The repository skips the rebuild when store.save
+        // returns false.
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
+        assertSame(
+            "duplicate recordIncoming must not rebuild the snapshot",
+            firstSnapshot,
+            repo.invitations.value,
+        )
+    }
+
+    @Test
+    fun stateFlow_emitsAfterUpdateStatusAndDelete() = runTest {
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev2", payload = "y".toByteArray(), receivedAt = now.plusSeconds(1))
+
+        repo.updateStatus("ev1", IncomingInvitationStatus.Accepted)
+        assertEquals(
+            IncomingInvitationStatus.Accepted,
+            repo.invitations.value.first { it.id == "ev1" }.status,
+        )
+
+        repo.delete("ev1")
+        assertEquals(listOf("ev2"), repo.invitations.value.map { it.id })
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun record(
+        id: String,
+        payload: String,
+        receivedAt: Instant,
+        status: IncomingInvitationStatus = IncomingInvitationStatus.Pending,
+    ) = IncomingInvitationRecord(
+        id = id,
+        payload = payload.toByteArray(Charsets.UTF_8),
+        receivedAt = receivedAt,
+        status = status,
+    )
+}

--- a/app/src/test/kotlin/chat/onym/android/persistence/RoomInvitationStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/persistence/RoomInvitationStoreTest.kt
@@ -1,0 +1,172 @@
+package chat.onym.android.persistence
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.security.SecureRandom
+import java.time.Instant
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Exercises the seam contract against the real Room backend.
+ * Companion to [chat.onym.android.inbox.IncomingInvitationsRepositoryTest]
+ * (which runs the same contract against
+ * [chat.onym.android.support.InMemoryInvitationStore]) — same shape,
+ * two backends, both verified.
+ *
+ * Robolectric provides the [Context] Room needs to open the
+ * in-memory DB. No Keystore touched (StorageEncryption is
+ * constructed with a known key per test), so Robolectric's lack of
+ * Keystore simulation doesn't bite.
+ *
+ * Mirrors `SwiftDataInvitationStoreTests.swift` from onym-ios PR #16.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])  // pin to a stable Robolectric SDK to avoid rev-dependent flakes
+class RoomInvitationStoreTest {
+
+    private lateinit var db: InvitationDatabase
+    private lateinit var store: RoomInvitationStore
+    private lateinit var encryption: StorageEncryption
+
+    @Before
+    fun setUp() {
+        val ctx: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(ctx, InvitationDatabase::class.java)
+            .allowMainThreadQueries()  // tests run sync; no UI thread to protect
+            .build()
+        encryption = StorageEncryption(
+            SecretKeySpec(ByteArray(32).also { SecureRandom().nextBytes(it) }, "AES")
+        )
+        store = RoomInvitationStore(db.invitationDao(), encryption)
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    // ─── save + list ──────────────────────────────────────────────
+
+    @Test
+    fun save_then_list_returnsRecord() = runTest {
+        val rec = sampleRecord(id = "ev1", payload = "hello")
+        assertTrue("first save returns true", store.save(rec))
+
+        val all = store.list()
+        assertEquals(1, all.size)
+        assertEquals("ev1", all[0].id)
+        assertArrayEquals("hello".toByteArray(), all[0].payload)
+        assertEquals(rec.receivedAt, all[0].receivedAt)
+        assertEquals(IncomingInvitationStatus.Pending, all[0].status)
+    }
+
+    @Test
+    fun save_dedupOnId_returnsFalseOnSecondSave() = runTest {
+        val rec = sampleRecord(id = "ev1", payload = "first")
+        assertTrue(store.save(rec))
+        // Different payload, same id — IGNORE strategy means the
+        // second save is a no-op AND the original row is preserved.
+        assertFalse(
+            "second save with same id must report dedup",
+            store.save(rec.copy(payload = "second".toByteArray())),
+        )
+        assertArrayEquals(
+            "original payload must be preserved on dedup",
+            "first".toByteArray(),
+            store.list().single().payload,
+        )
+    }
+
+    @Test
+    fun list_sortedByReceivedAtDesc() = runTest {
+        val now = Instant.parse("2026-05-02T12:00:00Z")
+        store.save(sampleRecord(id = "old", payload = "1", receivedAt = now.minusSeconds(60)))
+        store.save(sampleRecord(id = "new", payload = "2", receivedAt = now))
+        store.save(sampleRecord(id = "mid", payload = "3", receivedAt = now.minusSeconds(30)))
+        assertEquals(listOf("new", "mid", "old"), store.list().map { it.id })
+    }
+
+    @Test
+    fun payload_isEncryptedAtRest() = runTest {
+        val plaintext = "sensitive sealed-box bytes".toByteArray(Charsets.UTF_8)
+        store.save(sampleRecord(id = "ev1", payload = "sensitive sealed-box bytes"))
+        // Read the raw row directly via the DAO (bypasses RoomInvitationStore's decrypt).
+        val raw = db.invitationDao().list().single()
+        assertNotEquals(
+            "encryptedPayload column must not contain the plaintext",
+            plaintext.toList(),
+            raw.encryptedPayload.toList(),
+        )
+        // …but the seam decrypts it back to the plaintext.
+        assertArrayEquals(plaintext, store.list().single().payload)
+        // Layout sanity: nonce(12) + plaintext(26) + tag(16) = 54B.
+        assertEquals(
+            StorageEncryption.NONCE_SIZE + plaintext.size + StorageEncryption.TAG_SIZE,
+            raw.encryptedPayload.size,
+        )
+    }
+
+    // ─── updateStatus ─────────────────────────────────────────────
+
+    @Test
+    fun updateStatus_changesStoredStatus() = runTest {
+        store.save(sampleRecord(id = "ev1", payload = "x"))
+        store.updateStatus("ev1", IncomingInvitationStatus.Accepted)
+        assertEquals(IncomingInvitationStatus.Accepted, store.list().single().status)
+    }
+
+    @Test
+    fun updateStatus_unknownId_isNoOp() = runTest {
+        store.save(sampleRecord(id = "ev1", payload = "x"))
+        store.updateStatus("ev-does-not-exist", IncomingInvitationStatus.Accepted)
+        // Existing row untouched; no exception.
+        assertEquals(IncomingInvitationStatus.Pending, store.list().single().status)
+    }
+
+    // ─── delete ───────────────────────────────────────────────────
+
+    @Test
+    fun delete_removesRow() = runTest {
+        store.save(sampleRecord(id = "ev1", payload = "x"))
+        store.save(sampleRecord(id = "ev2", payload = "y"))
+        store.delete("ev1")
+        assertEquals(listOf("ev2"), store.list().map { it.id })
+    }
+
+    @Test
+    fun delete_unknownId_isNoOp() = runTest {
+        store.save(sampleRecord(id = "ev1", payload = "x"))
+        store.delete("ev-does-not-exist")
+        assertNull(
+            "row must remain after no-op delete",
+            store.list().firstOrNull { it.id != "ev1" },
+        )
+        assertEquals(1, store.list().size)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun sampleRecord(
+        id: String,
+        payload: String,
+        receivedAt: Instant = Instant.parse("2026-05-02T12:00:00Z"),
+        status: IncomingInvitationStatus = IncomingInvitationStatus.Pending,
+    ) = IncomingInvitationRecord(
+        id = id,
+        payload = payload.toByteArray(Charsets.UTF_8),
+        receivedAt = receivedAt,
+        status = status,
+    )
+}

--- a/app/src/test/kotlin/chat/onym/android/persistence/StorageEncryptionTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/persistence/StorageEncryptionTest.kt
@@ -1,0 +1,133 @@
+package chat.onym.android.persistence
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.security.SecureRandom
+import javax.crypto.AEADBadTagException
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Pure-JVM tests for the AES-GCM crypto primitive. Skips the
+ * Keystore-backed loader path (covered by `androidTest/` reading
+ * back from a real device) — instead instantiates with a known
+ * 32-byte key per test for deterministic assertions.
+ *
+ * Mirrors `StorageEncryptionTests.swift` from onym-ios PR #16.
+ */
+class StorageEncryptionTest {
+
+    private lateinit var enc: StorageEncryption
+    private lateinit var keyBytes: ByteArray
+
+    @Before
+    fun setUp() {
+        keyBytes = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        enc = StorageEncryption(SecretKeySpec(keyBytes, "AES"))
+    }
+
+    // ─── roundtrip ────────────────────────────────────────────────
+
+    @Test
+    fun roundtrip_byteArray() {
+        val plaintext = "hello, onym".toByteArray(Charsets.UTF_8)
+        val ciphertext = enc.encrypt(plaintext)
+        assertArrayEquals(plaintext, enc.decrypt(ciphertext))
+    }
+
+    @Test
+    fun roundtrip_string() {
+        val plaintext = "hello, onym — кириллица + emoji 🔐"
+        val ciphertext = enc.encrypt(plaintext)
+        assertEquals(plaintext, enc.decryptString(ciphertext))
+    }
+
+    @Test
+    fun roundtrip_emptyPayload() {
+        val ciphertext = enc.encrypt(ByteArray(0))
+        // GCM still emits nonce + 16-byte tag for an empty plaintext.
+        assertEquals(StorageEncryption.NONCE_SIZE + StorageEncryption.TAG_SIZE, ciphertext.size)
+        assertArrayEquals(ByteArray(0), enc.decrypt(ciphertext))
+    }
+
+    // ─── layout ───────────────────────────────────────────────────
+
+    @Test
+    fun ciphertext_layout_is_nonce_then_ciphertextWithTag() {
+        val plaintext = ByteArray(100) { it.toByte() }
+        val ciphertext = enc.encrypt(plaintext)
+        // 12B nonce + 100B body + 16B tag = 128B
+        assertEquals(
+            StorageEncryption.NONCE_SIZE + plaintext.size + StorageEncryption.TAG_SIZE,
+            ciphertext.size,
+        )
+    }
+
+    @Test
+    fun nonce_is_unique_per_encryption() {
+        val plaintext = "same plaintext".toByteArray(Charsets.UTF_8)
+        val a = enc.encrypt(plaintext)
+        val b = enc.encrypt(plaintext)
+        // Identical plaintext + key + AES/GCM/NoPadding must produce
+        // distinct outputs (because the nonce is fresh per call). If
+        // the nonces collide the entire ciphertext would be identical
+        // — and re-using a GCM nonce is catastrophic. Assert on the
+        // first NONCE_SIZE bytes specifically.
+        val nonceA = a.copyOfRange(0, StorageEncryption.NONCE_SIZE)
+        val nonceB = b.copyOfRange(0, StorageEncryption.NONCE_SIZE)
+        assertFalse(
+            "GCM nonce reuse across two encrypt() calls — fatal for confidentiality",
+            nonceA.contentEquals(nonceB),
+        )
+        assertNotEquals(
+            "encrypt() of the same plaintext twice must produce different ciphertexts",
+            a.toList(),
+            b.toList(),
+        )
+    }
+
+    // ─── tamper rejection ─────────────────────────────────────────
+
+    @Test
+    fun tamper_rejection_singleBitFlip() {
+        val ciphertext = enc.encrypt("don't tamper with me".toByteArray(Charsets.UTF_8))
+        // Flip a bit in the body (past the nonce so we can be sure
+        // we're hitting AES-GCM's tag check, not just the IV).
+        val tampered = ciphertext.copyOf().also { it[StorageEncryption.NONCE_SIZE + 2] = (it[StorageEncryption.NONCE_SIZE + 2].toInt() xor 0x01).toByte() }
+        assertThrows(AEADBadTagException::class.java) { enc.decrypt(tampered) }
+    }
+
+    @Test
+    fun tamper_rejection_truncatedTag() {
+        val ciphertext = enc.encrypt("don't tamper with me".toByteArray(Charsets.UTF_8))
+        // Drop the last byte of the tag — auth check must fail
+        // (either AEADBadTagException or one of its callers).
+        val truncated = ciphertext.copyOfRange(0, ciphertext.size - 1)
+        // GCM may surface the failure as AEADBadTagException OR
+        // IllegalBlockSizeException(cause = AEADBadTagException) —
+        // accept either as long as some throw happens.
+        var threw = false
+        try { enc.decrypt(truncated) } catch (_: Throwable) { threw = true }
+        assertTrue("truncating the tag must fail decryption", threw)
+    }
+
+    @Test
+    fun key_stability_across_encrypt_calls() {
+        // Property: a single instance encrypts with a stable key — so
+        // ciphertexts from any call decrypt back to the same plaintext
+        // through the same instance. (The Keystore-backed loader
+        // produces the same key bytes across process restarts; covered
+        // separately via androidTest.)
+        val a = enc.encrypt("a".toByteArray())
+        val b = enc.encrypt("b".toByteArray())
+        val c = enc.encrypt("c".toByteArray())
+        assertArrayEquals("a".toByteArray(), enc.decrypt(a))
+        assertArrayEquals("b".toByteArray(), enc.decrypt(b))
+        assertArrayEquals("c".toByteArray(), enc.decrypt(c))
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/support/FakeInboxTransport.kt
+++ b/app/src/test/kotlin/chat/onym/android/support/FakeInboxTransport.kt
@@ -1,0 +1,103 @@
+package chat.onym.android.support
+
+import chat.onym.android.transport.InboundInbox
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.PublishReceipt
+import chat.onym.android.transport.TransportEndpoint
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Reusable test fake for [InboxTransport]. Drives an interactor
+ * test by exposing two driver methods alongside the protocol
+ * surface:
+ *
+ *  - [emit] — push an [InboundInbox] into the subscriber's flow.
+ *  - [finish] — close the subscriber's channel so the collecting
+ *    coroutine completes naturally.
+ *
+ * Tracks observable side effects so tests can assert on them:
+ *
+ *  - [subscribeCallCount] — how many times anyone subscribed.
+ *  - [unsubscribedInboxes] — every inbox that's been unsubscribed
+ *    (either explicitly via [unsubscribe] or implicitly via the
+ *    Flow's cancellation `onCompletion`). Mirrors production
+ *    [chat.onym.android.transport.nostr.NostrInboxTransport] which
+ *    routes `awaitClose` through `unsubscribe`.
+ *  - [disconnectCallCount].
+ *
+ * Channel-per-inbox + `consumeAsFlow` (single subscriber) — gives
+ * the iOS-style `AsyncStream` semantics (explicit termination on
+ * [finish]) that `MutableSharedFlow` doesn't.
+ *
+ * Mirrors `FakeInboxTransport.swift` from onym-ios PR #16.
+ */
+class FakeInboxTransport : InboxTransport {
+
+    private val mutex = Mutex()
+    private val channels = mutableMapOf<TransportInboxId, Channel<InboundInbox>>()
+
+    var subscribeCallCount: Int = 0
+        private set
+    var disconnectCallCount: Int = 0
+        private set
+
+    /** Every inbox that's been unsubscribed — explicitly or via Flow
+     *  cancellation. Tests assert on this to verify cleanup. */
+    val unsubscribedInboxes: List<TransportInboxId> get() = _unsubscribedInboxes.toList()
+    private val _unsubscribedInboxes = mutableListOf<TransportInboxId>()
+
+    override suspend fun connect(endpoints: List<TransportEndpoint>) { /* no-op */ }
+
+    override suspend fun disconnect() {
+        disconnectCallCount += 1
+        mutex.withLock {
+            channels.values.forEach { it.close() }
+            channels.clear()
+        }
+    }
+
+    override suspend fun send(payload: ByteArray, inbox: TransportInboxId): PublishReceipt =
+        PublishReceipt(messageId = "fake-${inbox.rawValue}", acceptedBy = 0)
+
+    override fun subscribe(inbox: TransportInboxId): Flow<InboundInbox> {
+        subscribeCallCount += 1
+        // Pre-create the channel so a test that calls emit() before
+        // the collector starts doesn't hit a missing-key error;
+        // unbounded buffer because tests typically know what they
+        // emit and we don't want to wedge on suspension.
+        val channel = synchronized(channels) {
+            channels.getOrPut(inbox) { Channel(Channel.UNLIMITED) }
+        }
+        return channel.consumeAsFlow()
+            .onCompletion { _unsubscribedInboxes.add(inbox) }
+    }
+
+    override suspend fun unsubscribe(inbox: TransportInboxId) {
+        mutex.withLock {
+            channels.remove(inbox)?.close()
+            _unsubscribedInboxes.add(inbox)
+        }
+    }
+
+    /** Push a message to whoever is subscribed to [inbox]. Creates
+     *  the channel if no subscriber has connected yet (the message
+     *  is then buffered; first subscriber receives it). */
+    suspend fun emit(message: InboundInbox) {
+        val channel = synchronized(channels) {
+            channels.getOrPut(message.inbox) { Channel(Channel.UNLIMITED) }
+        }
+        channel.send(message)
+    }
+
+    /** Close the inbox's channel so the collecting Flow completes.
+     *  No-op if no channel exists for [inbox]. */
+    fun finish(inbox: TransportInboxId) {
+        synchronized(channels) { channels[inbox]?.close() }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/support/InMemoryInvitationStore.kt
+++ b/app/src/test/kotlin/chat/onym/android/support/InMemoryInvitationStore.kt
@@ -1,0 +1,48 @@
+package chat.onym.android.support
+
+import chat.onym.android.persistence.IncomingInvitationRecord
+import chat.onym.android.persistence.IncomingInvitationStatus
+import chat.onym.android.persistence.InvitationStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory [InvitationStore] for repository tests. Same contract as
+ * [chat.onym.android.persistence.RoomInvitationStore], no Room / no
+ * Robolectric / no SQLite — ~10× faster per test, lets repository
+ * tests focus on contract behaviour instead of CRUD plumbing.
+ *
+ * The Room-backed impl has its own [chat.onym.android.persistence.RoomInvitationStoreTest]
+ * exercising the same seam contract against the real backend; this
+ * fake covers the rest.
+ *
+ * Mirrors `InMemoryInvitationStore.swift` from onym-ios PR #16.
+ */
+class InMemoryInvitationStore : InvitationStore {
+
+    private val mutex = Mutex()
+    private val storage = LinkedHashMap<String, IncomingInvitationRecord>()
+
+    override suspend fun list(): List<IncomingInvitationRecord> = mutex.withLock {
+        storage.values.sortedByDescending { it.receivedAt }
+    }
+
+    override suspend fun save(record: IncomingInvitationRecord): Boolean = mutex.withLock {
+        if (storage.containsKey(record.id)) {
+            false
+        } else {
+            storage[record.id] = record
+            true
+        }
+    }
+
+    override suspend fun updateStatus(id: String, status: IncomingInvitationStatus) {
+        mutex.withLock {
+            storage[id]?.let { storage[id] = it.copy(status = status) }
+        }
+    }
+
+    override suspend fun delete(id: String) {
+        mutex.withLock { storage.remove(id) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,10 +36,25 @@ onym-sdk = "0.0.2"
 # Crypto
 bouncycastle = "1.78.1"
 
+# Room — Kotlin-coroutines DAO (`suspend` queries) + KSP-generated
+# bindings. 2.6.1 is the newest stable that pairs cleanly with AGP
+# 8.7 and Kotlin 2.0.21 KSP without dragging in 2.7's KMP refactor.
+androidx-room = "2.6.1"
+
+# KSP plugin — must match the Kotlin version exactly (the X.Y.Z-N
+# suffix is the KSP toolchain rev). Required for Room's annotation
+# processor (`androidx.room:room-compiler`).
+ksp = "2.0.21-1.0.27"
+
 # Test
 junit = "4.13.2"
 androidx-test-ext-junit = "1.2.1"
 androidx-test-runner = "1.6.2"
+
+# Robolectric — drives Room (which needs an Android `Context`) from
+# the JVM unit-test runner. Used only for `RoomInvitationStoreTest`;
+# everything else is plain JUnit.
+robolectric = "4.14.1"
 # Espresso 3.7.0 — first version with the InputManager.getInstance()
 # reflection fix for Android 15+/16+. Compose UI tests use Espresso
 # under the hood for `onIdle()` synchronisation, and on newer API
@@ -81,6 +96,11 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 # OnymSDK
 onym-sdk = { module = "chat.onym:onym-sdk", version.ref = "onym-sdk" }
 
+# Room
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
+
 # BouncyCastle — Curve25519 (Ed25519 + X25519) raw-key APIs not in the JDK
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 
@@ -89,9 +109,11 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary

End-to-end slice for receiving and persisting Nostr invitations, ending at a tested capability the next PR can wire into `OnymApplication`. Establishes the **reusable test pattern for any seam-A → interactor → seam-B pump** — `FakeInboxTransport` + `InMemoryInvitationStore` will drive every future "transport-to-persistence" interactor test.

Mirrors [onym-ios#16](https://github.com/onymchat/onym-ios/pull/16) 1:1 in shape.

## What lands

```
app/src/main/kotlin/chat/onym/android/
├── persistence/
│   ├── StorageEncryption.kt              ← AES-256-GCM + HKDF off Keystore root secret
│   ├── PersistedInvitation.kt            ← @Entity (id PK, encryptedPayload BLOB, receivedAt INTEGER, statusRaw TEXT)
│   ├── InvitationDao.kt                  ← @Dao with list/insert(IGNORE)/updateStatus/delete
│   ├── InvitationDatabase.kt             ← @Database, version=1
│   ├── InvitationStore.kt                ← interface + IncomingInvitationRecord + IncomingInvitationStatus
│   └── RoomInvitationStore.kt            ← Room-backed impl, applies StorageEncryption to payload
└── inbox/
    ├── IncomingInvitationsRepository.kt  ← Mutex + StateFlow<List<IncomingInvitation>>
    └── IncomingInvitationsInteractor.kt  ← stateless pump: InboxTransport → repository

app/src/test/kotlin/chat/onym/android/
├── support/
│   ├── FakeInboxTransport.kt             ← reusable upstream-seam fake (emit/finish driver)
│   └── InMemoryInvitationStore.kt        ← reusable downstream-seam fake
├── persistence/
│   ├── StorageEncryptionTest.kt          ← 8 cases
│   └── RoomInvitationStoreTest.kt        ← 8 cases against Room.inMemoryDatabaseBuilder (Robolectric)
└── inbox/
    ├── IncomingInvitationsRepositoryTest.kt ← 8 cases against InMemoryInvitationStore
    └── IncomingInvitationsInteractorTest.kt ← 5 cases against both fakes
```

## Architecture compliance

Every layer matches the touch-surface table in `README.md`'s architecture section:

| Layer | What this PR adds | Touches |
|---|---|---|
| **Persistence seam** | `InvitationStore` interface + Room impl | `androidx.room` + `androidx.security.crypto` + `StorageEncryption` only |
| **Repository** | `IncomingInvitationsRepository` (Mutex + StateFlow) | `InvitationStore` only |
| **Interactor** | `IncomingInvitationsInteractor` (stateless class) | `InboxTransport` (read) + repository (write) — and that's it |
| **OnymSDK** | nothing | nothing |

## Encryption at rest

The `InboundInbox.payload` arriving from the Nostr inbox transport is already a NaCl-sealed box from the sender — we can't read it without `IdentityRepository`'s X25519 key. Persistence wraps it in a *second* AES-256-GCM layer using `StorageEncryption` (HKDF-SHA256 off a 32-byte root secret stored in `EncryptedSharedPreferences`) so disk forensics with the device locked recovers neither the seed nor the inner ciphertext structure. Same defence-in-depth approach the stellar-mls reference impl takes for everything sensitive.

The `id` (Nostr event id) and `receivedAt` columns stay cleartext for query — they're already visible on relays.

## The reusable test pattern

The two fakes are the heart of this PR's contribution to the codebase:

- **`FakeInboxTransport`** — Channel-per-inbox + `consumeAsFlow` (gives the iOS `AsyncStream` semantics that `MutableSharedFlow` can't). Exposes `emit(message)` / `finish(inbox)` driver methods alongside the protocol surface. Tracks `subscribeCallCount`, `unsubscribedInboxes`, `disconnectCallCount`. Cancellation routes through `Flow.onCompletion` → `unsubscribedInboxes`, mirroring production `NostrInboxTransport`'s `awaitClose`. Drop-in for any test that needs to drive an interactor that subscribes to an inbox.
- **`InMemoryInvitationStore`** — `Mutex`-guarded `LinkedHashMap`. Same seam contract as `RoomInvitationStore`; ~10× faster per test (no SQLite + Robolectric tax). Free for repository tests that don't care about CRUD plumbing.

`RoomInvitationStoreTest` exercises the seam contract against the real backend; `IncomingInvitationsRepositoryTest` exercises it against the in-memory fake — same contract, two backends, both verified. Future stores can mirror this layout for cheap.

## Test plan

- [x] `./gradlew :app:assembleDebug` — production builds clean
- [x] `./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.persistence.*' --tests 'chat.onym.android.inbox.*'` — 29/29 pass (8 + 8 + 8 + 5)
- [x] `./gradlew :app:testDebugUnitTest` — full unit suite green (29 new + pre-existing all pass)
- [x] `python3 scripts/lint-secrets.py` — exit 0

## Build deps added

- Room 2.6.1 (`runtime` + `ktx`) + KSP 2.0.21-1.0.27 plugin for the annotation processor.
- Robolectric 4.14.1 (test-only) for the Room JVM-test path.
- The Room schema-export warning is silenced via `exportSchema = false`; flip to `true` and add the apt arg the day version 2 lands.

## Out of scope (intentionally — match iOS PR #16)

- **App wiring.** `OnymApplication` doesn't yet construct the repository or start the interactor. Capability ships tested; wire-up + "start at app launch with identity's `inboxTag`" sequence lands in the follow-up.
- **Decryption + parsing.** The interactor stores opaque ciphertext. Decryption needs `IdentityRepository`'s X25519 private key; the next slice resolves it on read.
- **UI.** No composable consumes `repository.invitations` yet. The `InviteFlow` shown as "planned" in the architecture diagram lands when there's a screen for received invitations.
- **Other persistence domains.** Groups / messages / contact aliases / transport bundles / pending rekeys / epoch snapshots from stellar-mls Android's `StellarChatDao.kt` aren't ported — port each when there's an interactor that needs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)