### PR TITLE
decryption: incoming Nostr invitations (X25519 ECDH + AES-GCM, stateless interactor + tests)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,20 @@ android {
             excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
+
+    // Shared test source set — fakes / fixtures / encryptors that
+    // both `test/` (JVM unit) and `androidTest/` (instrumented) can
+    // consume from the same `chat.onym.android.support` package.
+    // Mirrors the iOS pattern of a single `Tests/OnymIOSTests/Support/`
+    // directory available to every XCTest target.
+    sourceSets {
+        getByName("test") {
+            java.srcDirs("src/test/kotlin", "src/sharedTest/kotlin")
+        }
+        getByName("androidTest") {
+            java.srcDirs("src/androidTest/kotlin", "src/sharedTest/kotlin")
+        }
+    }
 }
 
 dependencies {

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
@@ -1,0 +1,246 @@
+package chat.onym.android.identity
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.support.TestInvitationEncryptor
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.SecureRandom
+import java.security.Security
+import java.util.UUID
+
+/**
+ * End-to-end test of [IdentityRepository.decryptInvitation] against
+ * a real `EncryptedSharedPreferences`-backed [IdentitySecretStore]
+ * + the OnymSDK FFI for identity bootstrap. Each test uses a unique
+ * prefs file so runs are isolated.
+ *
+ * Lives in `androidTest/` (not `test/`) for two reasons that match
+ * the existing [IdentityRepositoryTest] placement:
+ *
+ *  - `EncryptedSharedPreferences` requires the real Android
+ *    Keystore (Robolectric's keystore shadow doesn't carry the
+ *    AndroidX Security crypto path).
+ *  - `IdentityRepository.restore` invokes
+ *    `chat.onym.sdk.Common.nostrDerivePublicKey` (and `publicKey`),
+ *    which need the FFI .so loaded from the AAR's `jni/<abi>/`.
+ *
+ * The brief asked for `app/src/test/`; deviation is intentional and
+ * mirrors the existing `IdentityRepositoryTest`.
+ *
+ * Mirrors `IdentityRepositoryInvitationDecryptTests.swift` from
+ * onym-ios PR #17. iOS uses the host Mac's real Keychain + CryptoKit
+ * directly inside an XCTest target, which is why the iOS twin is in
+ * `Tests/OnymIOSTests/` (their JVM equivalent of `app/src/test/`).
+ */
+@RunWith(AndroidJUnit4::class)
+class IdentityRepositoryInvitationDecryptTest {
+
+    /** BIP39 mnemonic used across iOS / stellar-mls / onym-android
+     *  cross-platform fixtures. Recovery yields the same identity on
+     *  every platform — see `CrossPlatformFixtureTest`. */
+    private val testMnemonic =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow"
+
+    private lateinit var ctx: Context
+    private lateinit var store: IdentitySecretStore
+    private lateinit var repo: IdentityRepository
+
+    @Before
+    fun setUp() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.insertProviderAt(BouncyCastleProvider(), 2)
+        }
+        ctx = ApplicationProvider.getApplicationContext()
+        store = IdentitySecretStore(
+            ctx,
+            prefsFileName = "chat.onym.android.identity.invitedecrypt.${UUID.randomUUID()}",
+        )
+        repo = IdentityRepository(store)
+        runBlocking { repo.restore(testMnemonic) }
+    }
+
+    @After
+    fun tearDown() {
+        try { store.wipe() } catch (_: Throwable) { /* best-effort */ }
+    }
+
+    // ─── happy paths ──────────────────────────────────────────────
+
+    @Test
+    fun decrypt_roundTrip_withoutSignature() = runBlocking {
+        val identity = repo.snapshots.value!!
+        val payload = "secret bootstrap payload — withSignature=false".toByteArray()
+
+        val envelope = TestInvitationEncryptor.envelopeBytes(
+            payload = payload,
+            recipientX25519Pubkey = identity.inboxPublicKey,
+        )
+        val plaintext = repo.decryptInvitation(envelope)
+        assertArrayEquals(payload, plaintext)
+    }
+
+    @Test
+    fun decrypt_roundTrip_withSenderEd25519Signature() = runBlocking {
+        val identity = repo.snapshots.value!!
+        val sender = Ed25519PrivateKeyParameters(SecureRandom())
+        val payload = "secret bootstrap payload — withSignature=true".toByteArray()
+
+        val envelope = TestInvitationEncryptor.envelopeBytes(
+            payload = payload,
+            recipientX25519Pubkey = identity.inboxPublicKey,
+            senderEd25519Private = sender,
+        )
+        val plaintext = repo.decryptInvitation(envelope)
+        assertArrayEquals(payload, plaintext)
+    }
+
+    // ─── error paths ──────────────────────────────────────────────
+
+    @Test
+    fun decrypt_malformedJson_throwsMalformedEnvelope() = runBlocking {
+        val garbage = "not really json {{".toByteArray()
+        assertThrows(InvitationDecryptError.MalformedEnvelope::class.java) {
+            runBlocking { repo.decryptInvitation(garbage) }
+        }
+        Unit
+    }
+
+    @Test
+    fun decrypt_unsupportedScheme_throwsUnsupportedScheme() = runBlocking {
+        val bad = """
+            {
+              "version": 1,
+              "scheme": "aes-128-cbc-v0",
+              "ephemeral_public_key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+              "nonce": "AQIDBAUGBwgJCgsM",
+              "ciphertext": "AQID",
+              "authentication_tag": "AAECAwQFBgcICQoLDA0ODw=="
+            }
+        """.trimIndent().toByteArray()
+        val thrown = assertThrows(InvitationDecryptError.UnsupportedScheme::class.java) {
+            runBlocking { repo.decryptInvitation(bad) }
+        }
+        assertEquals("aes-128-cbc-v0", thrown.scheme)
+        Unit
+    }
+
+    @Test
+    fun decrypt_missingEphemeralKey_throwsMissingEphemeralKey() = runBlocking {
+        val bad = """
+            {
+              "version": 1,
+              "scheme": "x25519-aes-256-gcm-v1",
+              "nonce": "AQIDBAUGBwgJCgsM",
+              "ciphertext": "AQID",
+              "authentication_tag": "AAECAwQFBgcICQoLDA0ODw=="
+            }
+        """.trimIndent().toByteArray()
+        val thrown = assertThrows(InvitationDecryptError.MissingEphemeralKey::class.java) {
+            runBlocking { repo.decryptInvitation(bad) }
+        }
+        assertSame(InvitationDecryptError.MissingEphemeralKey, thrown)
+        Unit
+    }
+
+    @Test
+    fun decrypt_tamperedSignature_throwsSignatureFailed() = runBlocking {
+        val identity = repo.snapshots.value!!
+        val sender = Ed25519PrivateKeyParameters(SecureRandom())
+        val envelope = TestInvitationEncryptor.sealedEnvelope(
+            payload = "p".toByteArray(),
+            recipientX25519Pubkey = identity.inboxPublicKey,
+            senderEd25519Private = sender,
+        )
+        // Flip a bit in the signature (offset past the size header).
+        val tampered = envelope.copy(
+            ephemeralKeySignature = envelope.ephemeralKeySignature!!.copyOf().also {
+                it[0] = (it[0].toInt() xor 0x01).toByte()
+            },
+        )
+        val bytes = Json { encodeDefaults = true }
+            .encodeToString(SealedEnvelope.serializer(), tampered)
+            .toByteArray()
+        val thrown = assertThrows(InvitationDecryptError.SignatureFailed::class.java) {
+            runBlocking { repo.decryptInvitation(bytes) }
+        }
+        assertSame(InvitationDecryptError.SignatureFailed, thrown)
+        Unit
+    }
+
+    @Test
+    fun decrypt_tamperedCiphertext_throwsDecryptionFailed() = runBlocking {
+        val identity = repo.snapshots.value!!
+        val envelope = TestInvitationEncryptor.sealedEnvelope(
+            payload = "to be tampered".toByteArray(),
+            recipientX25519Pubkey = identity.inboxPublicKey,
+        )
+        val tampered = envelope.copy(
+            ciphertext = envelope.ciphertext.copyOf().also {
+                it[0] = (it[0].toInt() xor 0x01).toByte()
+            },
+        )
+        val bytes = Json { encodeDefaults = true }
+            .encodeToString(SealedEnvelope.serializer(), tampered)
+            .toByteArray()
+        assertThrows(InvitationDecryptError.DecryptionFailed::class.java) {
+            runBlocking { repo.decryptInvitation(bytes) }
+        }
+        Unit
+    }
+
+    @Test
+    fun decrypt_wrongRecipient_throwsDecryptionFailed() = runBlocking {
+        // Encrypt for some random other recipient — auth tag fails
+        // for the same reason as a tampered ciphertext (AES-GCM
+        // can't tell them apart). Same error class is correct.
+        val otherInbox = ByteArray(32).also { SecureRandom().nextBytes(it) }
+        val envelope = TestInvitationEncryptor.envelopeBytes(
+            payload = "not for us".toByteArray(),
+            recipientX25519Pubkey = wellFormedX25519Pubkey(otherInbox),
+        )
+        assertThrows(InvitationDecryptError.DecryptionFailed::class.java) {
+            runBlocking { repo.decryptInvitation(envelope) }
+        }
+        Unit
+    }
+
+    @Test
+    fun decrypt_afterWipe_throwsIdentityNotLoaded() = runBlocking {
+        val identity = repo.snapshots.value!!
+        val envelope = TestInvitationEncryptor.envelopeBytes(
+            payload = "p".toByteArray(),
+            recipientX25519Pubkey = identity.inboxPublicKey,
+        )
+        repo.wipe()
+        val thrown = assertThrows(InvitationDecryptError.IdentityNotLoaded::class.java) {
+            runBlocking { repo.decryptInvitation(envelope) }
+        }
+        assertSame(InvitationDecryptError.IdentityNotLoaded, thrown)
+        Unit
+    }
+
+    /** Force [bytes] onto the X25519 small-subgroup-clear shape that
+     *  BouncyCastle expects (clamp the first/last bytes per RFC
+     *  7748). Used to fabricate a "well-formed but not us" recipient
+     *  pubkey from arbitrary 32 bytes. */
+    private fun wellFormedX25519Pubkey(bytes: ByteArray): ByteArray {
+        val clamped = bytes.copyOf()
+        // The X25519 public key is just a 32-byte u-coord; no
+        // clamping needed (clamping applies to private keys). Any
+        // 32 random bytes is a valid public key (with negligible
+        // probability of being weak / on a small subgroup).
+        return clamped
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -10,9 +10,20 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.agreement.X25519Agreement
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
 import java.security.MessageDigest
+import javax.crypto.AEADBadTagException
+import javax.crypto.Cipher
+import javax.crypto.IllegalBlockSizeException
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 
 /**
  * Owns the on-device identity. All EncryptedSharedPreferences I/O,
@@ -50,7 +61,7 @@ import java.security.MessageDigest
 class IdentityRepository(
     private val store: IdentitySecretStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) {
+) : InvitationEnvelopeDecrypter {
     private val mutex = Mutex()
     private val _snapshots = MutableStateFlow<Identity?>(null)
 
@@ -116,6 +127,96 @@ class IdentityRepository(
         withContext(ioDispatcher) {
             store.wipe()
             _snapshots.value = null
+        }
+    }
+
+    // ─── InvitationEnvelopeDecrypter ────────────────────────────────
+
+    /**
+     * Open an X25519+AES-GCM-sealed invitation envelope addressed to
+     * this identity's inbox keypair. The X25519 private key is
+     * recomputed from the persisted nostr secret on every call and
+     * never assigned to a stored property — so the only persistent
+     * footprint of this method on the recipient's machine is the
+     * already-encrypted SharedPreferences blob.
+     *
+     * Throws [InvitationDecryptError]; never raw `javax.crypto` /
+     * `kotlinx.serialization` exceptions. See [InvitationDecryptError]
+     * for the failure-mode taxonomy.
+     */
+    override suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray =
+        withContext(ioDispatcher) {
+            // Snapshot read happens off the mutex — `store.load()` is a
+            // single atomic SharedPreferences read; concurrent `wipe()`
+            // either observes the pre-wipe blob or post-wipe null,
+            // both internally consistent.
+            val snapshot = store.load() ?: throw InvitationDecryptError.IdentityNotLoaded
+            decryptInvitationLocked(snapshot, envelopeBytes)
+        }
+
+    private fun decryptInvitationLocked(
+        snapshot: StoredSnapshot,
+        envelopeBytes: ByteArray,
+    ): ByteArray {
+        val envelope = try {
+            envelopeJsonFormat.decodeFromString<SealedEnvelope>(envelopeBytes.toString(Charsets.UTF_8))
+        } catch (e: SerializationException) {
+            throw InvitationDecryptError.MalformedEnvelope("invalid JSON: ${e.message}", e)
+        } catch (e: IllegalArgumentException) {
+            // base64 decode failure inside the field serializer
+            throw InvitationDecryptError.MalformedEnvelope("invalid base64: ${e.message}", e)
+        }
+        if (envelope.scheme != INVITATION_SCHEME) {
+            throw InvitationDecryptError.UnsupportedScheme(envelope.scheme)
+        }
+        val ephemeralPub = envelope.ephemeralPublicKey
+            ?: throw InvitationDecryptError.MissingEphemeralKey
+
+        // M-5: verify Ed25519 signature on the ephemeral pubkey if
+        // the envelope provides one. Prevents MITM substitution of
+        // the ephemeral key. Mirrors `GroupCrypto.decryptInvitation`
+        // in stellar-mls.
+        if (envelope.ephemeralKeySignature != null) {
+            val senderPubkey = envelope.senderEd25519PublicKey
+                ?: throw InvitationDecryptError.MalformedEnvelope(
+                    "ephemeral_key_signature present without sender_ed25519_public_key"
+                )
+            val verifier = Ed25519Signer().apply {
+                init(false, Ed25519PublicKeyParameters(senderPubkey, 0))
+            }
+            verifier.update(ephemeralPub, 0, ephemeralPub.size)
+            if (!verifier.verifySignature(envelope.ephemeralKeySignature)) {
+                throw InvitationDecryptError.SignatureFailed
+            }
+        }
+
+        // ECDH against the recipient's X25519 private (recomputed
+        // from nostrSecret per call; not stashed on `this`).
+        val recipientPrivate = inboxKeyAgreementPrivateKey(snapshot.nostrSecretKey)
+        val agreement = X25519Agreement().apply { init(recipientPrivate) }
+        val sharedSecret = ByteArray(agreement.agreementSize)
+        agreement.calculateAgreement(X25519PublicKeyParameters(ephemeralPub, 0), sharedSecret, 0)
+
+        // HKDF salt + info MUST match stellar-mls exactly — interop
+        // with iOS senders + Android stellar-mls senders rides on
+        // these constants.
+        val aesKey = Bip39.hkdfSha256(
+            ikm = sharedSecret,
+            salt = "sep-invitation-v1".toByteArray(Charsets.UTF_8),
+            info = "aes-256-gcm".toByteArray(Charsets.UTF_8),
+            length = 32,
+        )
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.DECRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, envelope.nonce))
+        }
+        return try {
+            // GCM expects ciphertext + tag concatenated.
+            cipher.doFinal(envelope.ciphertext + envelope.authenticationTag)
+        } catch (e: AEADBadTagException) {
+            throw InvitationDecryptError.DecryptionFailed(e)
+        } catch (e: IllegalBlockSizeException) {
+            throw InvitationDecryptError.DecryptionFailed(e)
         }
     }
 
@@ -207,15 +308,35 @@ class IdentityRepository(
          *
          * See `stellarPublicKey` for the salt-quirk note.
          */
-        internal fun inboxPublicKey(nostrSecret: ByteArray): ByteArray {
+        internal fun inboxPublicKey(nostrSecret: ByteArray): ByteArray =
+            inboxKeyAgreementPrivateKey(nostrSecret).generatePublicKey().encoded
+
+        /**
+         * X25519 private-key parameters for the recipient's inbox
+         * keypair. Internal because it returns secret material —
+         * intentional only callers are [IdentityRepository] (for
+         * decryption) and [inboxPublicKey] (for the public half).
+         * Production callers MUST discard the returned object after
+         * a single use; never assign to a stored property.
+         */
+        internal fun inboxKeyAgreementPrivateKey(nostrSecret: ByteArray): X25519PrivateKeyParameters {
             val seed = Bip39.hkdfSha256(
                 ikm = nostrSecret,
                 salt = "chat.onym.ios".toByteArray(Charsets.UTF_8),
                 info = "x25519-key-agreement-v1".toByteArray(Charsets.UTF_8),
                 length = 32,
             )
-            val sk = X25519PrivateKeyParameters(seed, 0)
-            return sk.generatePublicKey().encoded
+            return X25519PrivateKeyParameters(seed, 0)
+        }
+
+        /** Cross-platform interop scheme tag for invitations. Anything
+         *  else triggers [InvitationDecryptError.UnsupportedScheme]. */
+        private const val INVITATION_SCHEME = "x25519-aes-256-gcm-v1"
+
+        /** Permissive JSON for envelope decoding — extra fields the
+         *  sender adds in a future schema version don't break us. */
+        private val envelopeJsonFormat = Json {
+            ignoreUnknownKeys = true
         }
 
         /**

--- a/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
@@ -1,0 +1,69 @@
+package chat.onym.android.identity
+
+/**
+ * Narrow decryption seam. The only producer is [IdentityRepository]
+ * (see [IdentityRepository.decryptInvitation]) — secret material
+ * (X25519 private key, nostr secret) never escapes the repository
+ * actor; downstream interactors only ever see the plaintext bytes
+ * this method returns.
+ *
+ * Lives in the identity layer alongside the only producer. The
+ * inbox-side interactor ([chat.onym.android.inbox.InvitationDecryptor])
+ * holds a reference to this interface — *not* to `IdentityRepository`
+ * directly — so tests substitute fakes.
+ *
+ * Mirrors `InvitationEnvelopeDecrypting.swift` from onym-ios PR #17.
+ */
+interface InvitationEnvelopeDecrypter {
+    /**
+     * Decrypt an X25519+AES-GCM-sealed invitation envelope.
+     *
+     * @param envelopeBytes UTF-8 JSON of a [SealedEnvelope] with
+     *        `scheme = "x25519-aes-256-gcm-v1"`.
+     * @return the inner plaintext (typically a `BootstrapPayload`
+     *         JSON for the inbox interactor to parse downstream).
+     * @throws InvitationDecryptError on every failure mode — the
+     *         seam never throws raw `javax.crypto` /
+     *         `kotlinx.serialization` exceptions, so callers can
+     *         classify with a `when (e: InvitationDecryptError)`.
+     */
+    suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray
+}
+
+/**
+ * Failure modes for [InvitationEnvelopeDecrypter.decryptInvitation].
+ * Sealed so `when` exhaustiveness checks downstream don't need an
+ * `else` branch.
+ */
+sealed class InvitationDecryptError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    /** JSON parse failed — the envelope isn't well-formed. */
+    class MalformedEnvelope(reason: String, cause: Throwable? = null) : InvitationDecryptError(reason, cause)
+
+    /** Scheme tag wasn't `"x25519-aes-256-gcm-v1"`. */
+    class UnsupportedScheme(val scheme: String) : InvitationDecryptError("unsupported scheme: $scheme")
+
+    /** Envelope omitted `ephemeral_public_key` (required for ECDH). */
+    object MissingEphemeralKey : InvitationDecryptError("envelope missing ephemeral_public_key") {
+        private fun readResolve(): Any = MissingEphemeralKey
+    }
+
+    /** M-5 Ed25519 signature over the ephemeral pubkey is present
+     *  but doesn't verify (tampered key, wrong sender pubkey, …). */
+    object SignatureFailed : InvitationDecryptError("ephemeral key signature verification failed") {
+        private fun readResolve(): Any = SignatureFailed
+    }
+
+    /** AES-GCM auth tag check failed. Covers both "ciphertext was
+     *  tampered with" and "envelope was sent to a different
+     *  recipient" — semantically indistinguishable at this layer. */
+    class DecryptionFailed(cause: Throwable) :
+        InvitationDecryptError("decryption failed (auth tag check)", cause)
+
+    /** [IdentityRepository.bootstrap] hasn't been called or [wipe] was
+     *  called — there's no recipient secret to derive the X25519 key
+     *  from. */
+    object IdentityNotLoaded : InvitationDecryptError("identity not loaded; call bootstrap() first") {
+        private fun readResolve(): Any = IdentityNotLoaded
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/SealedEnvelope.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/SealedEnvelope.kt
@@ -1,0 +1,110 @@
+package chat.onym.android.identity
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.Base64
+
+/**
+ * NIP-XX sealed envelope wire format. Mirrors the JSON shape that
+ * `stellar-mls/clients/android/StellarChat/.../crypto/GroupCrypto.kt`
+ * writes for `kind = 34113` invitations and that iOS PR #17 expects:
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "scheme": "x25519-aes-256-gcm-v1",
+ *   "ephemeral_public_key": "<base64 32B>",
+ *   "ephemeral_key_signature": "<base64 64B Ed25519, optional>",
+ *   "sender_ed25519_public_key": "<base64 32B, optional>",
+ *   "nonce": "<base64 12B>",
+ *   "ciphertext": "<base64 N B>",
+ *   "authentication_tag": "<base64 16B>"
+ * }
+ * ```
+ *
+ * Field names are **load-bearing** for cross-platform interop with
+ * stellar-mls senders + iOS receivers — keep the snake_case
+ * `@SerialName` overrides verbatim.
+ *
+ * `ByteArray` fields are encoded as base64 strings (matching
+ * Foundation's default `Data` JSON encoding on iOS); see
+ * [Base64ByteArraySerializer].
+ *
+ * Mirrors `SealedEnvelope.swift` from onym-ios PR #17.
+ */
+@Serializable
+data class SealedEnvelope(
+    val version: Int = 1,
+    val scheme: String,
+    @SerialName("ephemeral_public_key")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val ephemeralPublicKey: ByteArray? = null,
+    @SerialName("ephemeral_key_signature")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val ephemeralKeySignature: ByteArray? = null,
+    @SerialName("sender_ed25519_public_key")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val senderEd25519PublicKey: ByteArray? = null,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val nonce: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val ciphertext: ByteArray,
+    @SerialName("authentication_tag")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val authenticationTag: ByteArray,
+) {
+    // Default data-class equals/hashCode use reference equality for
+    // ByteArray; override with content-based comparison so test
+    // assertions on round-tripped envelopes work.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SealedEnvelope) return false
+        return version == other.version &&
+            scheme == other.scheme &&
+            (ephemeralPublicKey?.contentEquals(other.ephemeralPublicKey) ?: (other.ephemeralPublicKey == null)) &&
+            (ephemeralKeySignature?.contentEquals(other.ephemeralKeySignature) ?: (other.ephemeralKeySignature == null)) &&
+            (senderEd25519PublicKey?.contentEquals(other.senderEd25519PublicKey) ?: (other.senderEd25519PublicKey == null)) &&
+            nonce.contentEquals(other.nonce) &&
+            ciphertext.contentEquals(other.ciphertext) &&
+            authenticationTag.contentEquals(other.authenticationTag)
+    }
+
+    override fun hashCode(): Int {
+        var result = version
+        result = 31 * result + scheme.hashCode()
+        result = 31 * result + (ephemeralPublicKey?.contentHashCode() ?: 0)
+        result = 31 * result + (ephemeralKeySignature?.contentHashCode() ?: 0)
+        result = 31 * result + (senderEd25519PublicKey?.contentHashCode() ?: 0)
+        result = 31 * result + nonce.contentHashCode()
+        result = 31 * result + ciphertext.contentHashCode()
+        result = 31 * result + authenticationTag.contentHashCode()
+        return result
+    }
+}
+
+/**
+ * Encodes `ByteArray` as a base64 string. Matches iOS Foundation's
+ * default `Data` JSON encoding (which emits a base64 string, not a
+ * JSON array of integers like kotlinx.serialization's default).
+ *
+ * Used per-field via `@Serializable(with = Base64ByteArraySerializer::class)`
+ * so it doesn't bleed into other `ByteArray` fields elsewhere in the
+ * codebase that may want a different encoding.
+ */
+object Base64ByteArraySerializer : KSerializer<ByteArray> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("Base64ByteArray", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ByteArray) {
+        encoder.encodeString(Base64.getEncoder().encodeToString(value))
+    }
+
+    override fun deserialize(decoder: Decoder): ByteArray =
+        Base64.getDecoder().decode(decoder.decodeString())
+}

--- a/app/src/main/kotlin/chat/onym/android/inbox/DecryptedInvitation.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/DecryptedInvitation.kt
@@ -1,0 +1,51 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.Serializable
+
+/**
+ * Parsed subset of the stellar-mls `BootstrapPayload` JSON — just
+ * the fields a UI layer would show while the user decides whether
+ * to accept the invitation. The remaining fields (members,
+ * groupSecret, relayHints, salt, commitment, senderTransportBundle,
+ * etc.) only matter once a flow actually joins the group; they
+ * land in a future PR alongside the join interactor.
+ *
+ * Wire format is camelCase (matches the writer in
+ * `stellar-mls/clients/android/StellarChat/.../model/BootstrapPayload.kt`).
+ * `groupID` ships as a base64 string. `epoch` is permissive on
+ * whether the wire value is signed or unsigned — JSON sees an
+ * integer.
+ *
+ * `Json { ignoreUnknownKeys = true }` is used by the decoder
+ * (configured in [InvitationDecryptor]), so adding fields here is
+ * non-breaking and adding fields to the wire format upstream is
+ * non-breaking.
+ *
+ * Mirrors `DecryptedInvitation.swift` from onym-ios PR #17.
+ */
+@Serializable
+data class DecryptedInvitation(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupID: ByteArray,
+    val name: String,
+    val epoch: ULong,
+    val senderNostrPubkey: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DecryptedInvitation) return false
+        return groupID.contentEquals(other.groupID) &&
+            name == other.name &&
+            epoch == other.epoch &&
+            senderNostrPubkey == other.senderNostrPubkey
+    }
+
+    override fun hashCode(): Int {
+        var result = groupID.contentHashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + epoch.hashCode()
+        result = 31 * result + senderNostrPubkey.hashCode()
+        return result
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/inbox/InvitationDecryptor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/InvitationDecryptor.kt
@@ -1,0 +1,46 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.identity.InvitationEnvelopeDecrypter
+import kotlinx.serialization.json.Json
+
+/**
+ * Stateless interactor that pumps an encrypted invitation envelope
+ * through the seam decrypter and parses the inner plaintext into a
+ * [DecryptedInvitation].
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds **only** an [InvitationEnvelopeDecrypter] reference. No
+ *    other repository, no OnymSDK, no `Context`.
+ *  - The seam strips secret material on its side; this interactor
+ *    only ever sees plaintext bytes.
+ *  - Stateless — the only mutable thing in scope is the [Json]
+ *    parser, which is thread-safe + immutable after construction.
+ *
+ * Mirrors `InvitationDecryptor.swift` from onym-ios PR #17.
+ */
+class InvitationDecryptor(
+    private val envelopeDecrypter: InvitationEnvelopeDecrypter,
+) {
+    /**
+     * Open + parse [envelopeBytes] (UTF-8 JSON of a
+     * [chat.onym.android.identity.SealedEnvelope]).
+     *
+     * @throws chat.onym.android.identity.InvitationDecryptError on
+     *         decryption failure; propagated verbatim from the seam.
+     * @throws kotlinx.serialization.SerializationException if the
+     *         decrypted plaintext isn't a well-formed
+     *         [DecryptedInvitation] JSON.
+     */
+    suspend fun decrypt(envelopeBytes: ByteArray): DecryptedInvitation {
+        val plaintext = envelopeDecrypter.decryptInvitation(envelopeBytes)
+        return jsonFormat.decodeFromString(plaintext.toString(Charsets.UTF_8))
+    }
+
+    private companion object {
+        // Permissive — extra fields the sender added in a future
+        // BootstrapPayload version (members, salt, relayHints, …)
+        // are silently dropped, so this 4-field subset stays valid.
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
@@ -1,0 +1,62 @@
+package chat.onym.android.support
+
+import chat.onym.android.identity.InvitationDecryptError
+import chat.onym.android.identity.InvitationEnvelopeDecrypter
+
+/**
+ * Reusable test fake for [InvitationEnvelopeDecrypter]. Three modes
+ * cover the three shapes of test:
+ *
+ *  - [Mode.Fixed] — happy-path pump tests that don't care about the
+ *    input bytes, only that the decrypter returns *some* plaintext.
+ *  - [Mode.Scripted] — multi-input tests that need different
+ *    plaintexts depending on the envelope. Lookup is by content
+ *    equality; an unmapped envelope throws.
+ *  - [Mode.Failing] — error-path coverage; throws the supplied
+ *    error verbatim.
+ *
+ * Tracks every envelope it's been called with in [decryptCalls] so
+ * tests can assert on pump fan-out, ordering, dedup behaviour, etc.
+ *
+ * Mirrors `FakeInvitationEnvelopeDecrypter.swift` from onym-ios PR #17
+ * (an actor there; not a coroutine actor here — just a plain class
+ * with a `suspend fun` that switches on [Mode]).
+ */
+class FakeInvitationEnvelopeDecrypter(var mode: Mode) : InvitationEnvelopeDecrypter {
+
+    sealed class Mode {
+        /** Always returns [plaintext], regardless of input. */
+        data class Fixed(val plaintext: ByteArray) : Mode() {
+            override fun equals(other: Any?): Boolean =
+                this === other || (other is Fixed && plaintext.contentEquals(other.plaintext))
+            override fun hashCode(): Int = plaintext.contentHashCode()
+        }
+
+        /** Looks up plaintext by exact-content envelope match. Tests
+         *  build the script with `mapOf(env1.toList() to plaintext1, …)`
+         *  — keying on `List<Byte>` because raw `ByteArray` uses
+         *  reference equality. */
+        data class Scripted(val script: Map<List<Byte>, ByteArray>) : Mode()
+
+        /** Throws [error] on every call. */
+        data class Failing(val error: Throwable) : Mode()
+    }
+
+    /** Every envelope this fake has been asked to decrypt, in call
+     *  order. Tests assert with `decryptCalls.last().contentEquals(...)`
+     *  or by counting size. */
+    val decryptCalls: List<ByteArray> get() = _decryptCalls.toList()
+    private val _decryptCalls = mutableListOf<ByteArray>()
+
+    override suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray {
+        _decryptCalls.add(envelopeBytes.copyOf())
+        return when (val m = mode) {
+            is Mode.Fixed -> m.plaintext.copyOf()
+            is Mode.Scripted -> m.script[envelopeBytes.toList()]
+                ?: throw InvitationDecryptError.MalformedEnvelope(
+                    "FakeInvitationEnvelopeDecrypter: no script entry for envelope (${envelopeBytes.size} bytes)"
+                )
+            is Mode.Failing -> throw m.error
+        }
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/TestInvitationEncryptor.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/TestInvitationEncryptor.kt
@@ -1,0 +1,109 @@
+package chat.onym.android.support
+
+import chat.onym.android.identity.Bip39
+import chat.onym.android.identity.SealedEnvelope
+import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.agreement.X25519Agreement
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.X25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Test-only sender-side helper. Replicates the
+ * [stellar-mls/clients/android/StellarChat/.../crypto/GroupCrypto.kt
+ * encryptInvitation](https://github.com/stellarmls/clients-android)
+ * formula so round-trip tests can produce real
+ * `x25519-aes-256-gcm-v1` ciphertext without polluting production
+ * with sender-side code (no app code sends invitations yet — that's
+ * a future capability).
+ *
+ * Will move to production when the app gains create-group +
+ * invite-contact capability; until then it lives in
+ * `app/src/test/.../support/` so the production target carries
+ * zero invitation-sender code.
+ *
+ * Mirrors `TestInvitationEncryptor.swift` from onym-ios PR #17.
+ */
+object TestInvitationEncryptor {
+
+    /**
+     * Build a sealed envelope addressed to [recipientX25519Pubkey].
+     * If [senderEd25519Private] is supplied, signs the ephemeral
+     * pubkey with it (M-5 path) and includes the sender's Ed25519
+     * pubkey in the envelope so the recipient can verify without an
+     * out-of-band key exchange.
+     *
+     * @param payload arbitrary plaintext (typically a serialized
+     *        BootstrapPayload subset; tests pass anything).
+     */
+    fun sealedEnvelope(
+        payload: ByteArray,
+        recipientX25519Pubkey: ByteArray,
+        senderEd25519Private: Ed25519PrivateKeyParameters? = null,
+    ): SealedEnvelope {
+        // Ephemeral X25519 keypair — fresh per call.
+        val ephemeralPrivate = X25519PrivateKeyParameters(SecureRandom())
+        val ephemeralPublic = ephemeralPrivate.generatePublicKey()
+
+        // ECDH against the recipient.
+        val recipientParams = X25519PublicKeyParameters(recipientX25519Pubkey, 0)
+        val agreement = X25519Agreement().apply { init(ephemeralPrivate) }
+        val sharedSecret = ByteArray(agreement.agreementSize)
+        agreement.calculateAgreement(recipientParams, sharedSecret, 0)
+
+        // HKDF — same constants the production decrypter uses.
+        val aesKey = Bip39.hkdfSha256(
+            ikm = sharedSecret,
+            salt = "sep-invitation-v1".toByteArray(Charsets.UTF_8),
+            info = "aes-256-gcm".toByteArray(Charsets.UTF_8),
+            length = 32,
+        )
+
+        // AES-GCM encrypt — split the trailing 16-byte tag off the
+        // ciphertext to match the JSON envelope shape.
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+            init(Cipher.ENCRYPT_MODE, SecretKeySpec(aesKey, "AES"))
+        }
+        val nonce = cipher.iv
+        val ciphertextWithTag = cipher.doFinal(payload)
+        val tagOffset = ciphertextWithTag.size - 16
+        val ciphertext = ciphertextWithTag.copyOfRange(0, tagOffset)
+        val tag = ciphertextWithTag.copyOfRange(tagOffset, ciphertextWithTag.size)
+
+        // M-5: optionally sign the ephemeral pubkey.
+        val (sig, senderPub) = if (senderEd25519Private != null) {
+            val signer = Ed25519Signer().apply { init(true, senderEd25519Private) }
+            signer.update(ephemeralPublic.encoded, 0, ephemeralPublic.encoded.size)
+            signer.generateSignature() to senderEd25519Private.generatePublicKey().encoded
+        } else null to null
+
+        return SealedEnvelope(
+            version = 1,
+            scheme = "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey = ephemeralPublic.encoded,
+            ephemeralKeySignature = sig,
+            senderEd25519PublicKey = senderPub,
+            nonce = nonce,
+            ciphertext = ciphertext,
+            authenticationTag = tag,
+        )
+    }
+
+    /** Same as [sealedEnvelope] but returns the JSON-encoded UTF-8
+     *  bytes — drop straight into
+     *  [chat.onym.android.identity.InvitationEnvelopeDecrypter.decryptInvitation]. */
+    fun envelopeBytes(
+        payload: ByteArray,
+        recipientX25519Pubkey: ByteArray,
+        senderEd25519Private: Ed25519PrivateKeyParameters? = null,
+    ): ByteArray = jsonFormat.encodeToString(
+        SealedEnvelope.serializer(),
+        sealedEnvelope(payload, recipientX25519Pubkey, senderEd25519Private),
+    ).toByteArray(Charsets.UTF_8)
+
+    private val jsonFormat = Json { encodeDefaults = true }
+}

--- a/app/src/test/kotlin/chat/onym/android/identity/SealedEnvelopeTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/identity/SealedEnvelopeTest.kt
@@ -1,0 +1,108 @@
+package chat.onym.android.identity
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JSON contract for the [SealedEnvelope] wire format. Cross-platform
+ * interop with stellar-mls senders + iOS receivers rides on:
+ *
+ *  - snake_case `@SerialName` overrides on every camelCase Kotlin
+ *    property,
+ *  - base64 string encoding for every `ByteArray` (matching iOS
+ *    Foundation's default `Data` JSON encoding), and
+ *  - tolerant decoding of envelopes that omit the optional M-5
+ *    Ed25519 signature fields.
+ *
+ * Mirrors `SealedEnvelopeTests.swift` from onym-ios PR #17.
+ */
+class SealedEnvelopeTest {
+
+    private val format = Json { encodeDefaults = true }
+
+    @Test
+    fun toJson_usesSnakeCaseFieldNames() {
+        val envelope = SealedEnvelope(
+            scheme = "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey = ByteArray(32) { 0x11 },
+            ephemeralKeySignature = ByteArray(64) { 0x22 },
+            senderEd25519PublicKey = ByteArray(32) { 0x33 },
+            nonce = ByteArray(12) { 0x44 },
+            ciphertext = ByteArray(8) { 0x55 },
+            authenticationTag = ByteArray(16) { 0x66 },
+        )
+        val json = format.encodeToString(SealedEnvelope.serializer(), envelope)
+
+        // Required snake_case keys (interop contract).
+        for (key in listOf(
+            "\"ephemeral_public_key\"",
+            "\"ephemeral_key_signature\"",
+            "\"sender_ed25519_public_key\"",
+            "\"authentication_tag\"",
+        )) {
+            assertTrue("expected `$key` in $json", json.contains(key))
+        }
+        // CamelCase variants must NOT appear — the wire contract is
+        // snake_case and a regression here would break stellar-mls /
+        // iOS interop silently.
+        for (forbidden in listOf(
+            "ephemeralPublicKey",
+            "ephemeralKeySignature",
+            "senderEd25519PublicKey",
+            "authenticationTag",
+        )) {
+            assertTrue(
+                "field name `$forbidden` leaked into wire JSON: $json",
+                !json.contains(forbidden),
+            )
+        }
+    }
+
+    @Test
+    fun roundtrip_preservesAllFields() {
+        val original = SealedEnvelope(
+            scheme = "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey = ByteArray(32) { it.toByte() },
+            ephemeralKeySignature = ByteArray(64) { (it + 1).toByte() },
+            senderEd25519PublicKey = ByteArray(32) { (it + 2).toByte() },
+            nonce = ByteArray(12) { (it + 3).toByte() },
+            ciphertext = ByteArray(40) { (it + 4).toByte() },
+            authenticationTag = ByteArray(16) { (it + 5).toByte() },
+        )
+        val json = format.encodeToString(SealedEnvelope.serializer(), original)
+        val decoded = format.decodeFromString(SealedEnvelope.serializer(), json)
+        assertEquals(original, decoded)
+        // Spot-check a few `ByteArray` fields explicitly so a future
+        // bug in the data class equals doesn't mask a real mismatch.
+        assertArrayEquals(original.ephemeralPublicKey, decoded.ephemeralPublicKey)
+        assertArrayEquals(original.authenticationTag, decoded.authenticationTag)
+    }
+
+    @Test
+    fun decodes_envelopeWithoutOptionalSignatureFields() {
+        // Sender omitted M-5 signature fields entirely — must decode
+        // with the optional fields as null, not error out.
+        val json = """
+            {
+              "version": 1,
+              "scheme": "x25519-aes-256-gcm-v1",
+              "ephemeral_public_key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+              "nonce": "AQIDBAUGBwgJCgsM",
+              "ciphertext": "AQID",
+              "authentication_tag": "AAECAwQFBgcICQoLDA0ODw=="
+            }
+        """.trimIndent()
+        val decoded = Json { ignoreUnknownKeys = true }.decodeFromString(SealedEnvelope.serializer(), json)
+        assertEquals("x25519-aes-256-gcm-v1", decoded.scheme)
+        assertNotNull(decoded.ephemeralPublicKey)
+        assertNull(decoded.ephemeralKeySignature)
+        assertNull(decoded.senderEd25519PublicKey)
+        assertEquals(12, decoded.nonce.size)
+        assertEquals(16, decoded.authenticationTag.size)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/inbox/InvitationDecryptorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/InvitationDecryptorTest.kt
@@ -1,0 +1,137 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.identity.InvitationDecryptError
+import chat.onym.android.support.FakeInvitationEnvelopeDecrypter
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Pump shape for [InvitationDecryptor] — verifies the interactor
+ * forwards bytes to the seam unchanged and parses the returned
+ * plaintext into [DecryptedInvitation], plus that errors on either
+ * side propagate without translation.
+ *
+ * Uses [FakeInvitationEnvelopeDecrypter] so the production X25519+AES
+ * path stays out of scope; that's covered by
+ * `IdentityRepositoryInvitationDecryptTest` against a real
+ * EncryptedSharedPreferences-backed identity.
+ *
+ * Mirrors `InvitationDecryptorTests.swift` from onym-ios PR #17.
+ */
+class InvitationDecryptorTest {
+
+    @Test
+    fun decrypt_passesEnvelopeBytesThroughToDecrypter() = runTest {
+        val plaintext = decryptedInvitationJson("aGVsbG8=", "Group A", 7uL, "abcd")
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext)
+        )
+        val decryptor = InvitationDecryptor(fake)
+
+        val envelope = "envelope-bytes".toByteArray()
+        val result = decryptor.decrypt(envelope)
+
+        assertEquals(1, fake.decryptCalls.size)
+        assertArrayEquals(envelope, fake.decryptCalls.single())
+        assertEquals("Group A", result.name)
+        assertEquals(7uL, result.epoch)
+        assertEquals("abcd", result.senderNostrPubkey)
+    }
+
+    @Test
+    fun decrypt_scriptedMode_decodesEachInputCorrectly() = runTest {
+        val envA = "env-A".toByteArray()
+        val envB = "env-B".toByteArray()
+        val ptA = decryptedInvitationJson("AAA=", "Alpha", 1uL, "pkA")
+        val ptB = decryptedInvitationJson("AAEC", "Beta",  2uL, "pkB")
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Scripted(
+                mapOf(envA.toList() to ptA, envB.toList() to ptB)
+            )
+        )
+        val decryptor = InvitationDecryptor(fake)
+
+        val resA = decryptor.decrypt(envA)
+        val resB = decryptor.decrypt(envB)
+
+        assertEquals("Alpha", resA.name); assertEquals(1uL, resA.epoch)
+        assertEquals("Beta",  resB.name); assertEquals(2uL, resB.epoch)
+        assertEquals(2, fake.decryptCalls.size)
+    }
+
+    @Test
+    fun decrypt_fixedMode_returnsSamePlaintextForAnyInput() = runTest {
+        val pt = decryptedInvitationJson("AAA=", "Constant", 99uL, "pk")
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Fixed(pt)
+        )
+        val decryptor = InvitationDecryptor(fake)
+
+        val r1 = decryptor.decrypt("anything-1".toByteArray())
+        val r2 = decryptor.decrypt("anything-2".toByteArray())
+
+        assertEquals(r1, r2)
+        assertEquals("Constant", r1.name)
+    }
+
+    @Test
+    fun decrypt_propagatesDecrypterException() = runTest {
+        val cause = InvitationDecryptError.UnsupportedScheme("aes-128-cbc-v0")
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Failing(cause)
+        )
+        val decryptor = InvitationDecryptor(fake)
+
+        val thrown = assertThrows(InvitationDecryptError.UnsupportedScheme::class.java) {
+            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray()) }
+        }
+        // Same instance — interactor MUST NOT wrap or rewrap the seam's error.
+        assertSame(cause, thrown)
+    }
+
+    @Test
+    fun decrypt_throwsOnMalformedPlaintextJson() = runTest {
+        val garbage = "not valid json {{{".toByteArray(Charsets.UTF_8)
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Fixed(garbage)
+        )
+        val decryptor = InvitationDecryptor(fake)
+
+        // SerializationException not InvitationDecryptError — the
+        // contract is: seam errors are decryption failures; parser
+        // errors are payload-shape failures, surfaced separately.
+        val thrown = assertThrows(SerializationException::class.java) {
+            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray()) }
+        }
+        assertTrue("expected SerializationException, got ${thrown::class.simpleName}: ${thrown.message}", true)
+    }
+
+    /** Build a JSON byte string for [DecryptedInvitation] without
+     *  going through kotlinx.serialization (so the test asserts
+     *  decoding rather than encoding-then-decoding). */
+    private fun decryptedInvitationJson(
+        groupIdBase64: String,
+        name: String,
+        epoch: ULong,
+        senderNostrPubkey: String,
+    ): ByteArray = """
+        {
+          "groupID": "$groupIdBase64",
+          "name": "$name",
+          "epoch": $epoch,
+          "senderNostrPubkey": "$senderNostrPubkey"
+        }
+    """.trimIndent().toByteArray(Charsets.UTF_8)
+
+    // Touch Base64 to avoid the unused-import warning if the helper
+    // ever drops it; intentionally kept for ergonomics in future tests.
+    @Suppress("unused")
+    private val b64 = Base64.getEncoder()
+}


### PR DESCRIPTION
## Summary

Decryption layer for the invitations PR #15 persists. Adds a narrow `InvitationEnvelopeDecrypter` seam (one method, returns plaintext bytes) that the inbox-side interactor depends on — the production implementation lives on `IdentityRepository` so secret material never escapes the actor; tests substitute fakes. Carries the X25519 ECDH + HKDF + AES-GCM open and (when the envelope provides one) verifies the M-5 Ed25519 signature on the ephemeral pubkey to prevent MITM substitution.

Mirrors [onym-ios#17](https://github.com/onymchat/onym-ios/pull/17) 1:1 in shape; cross-platform interop with `stellar-mls/clients/android` senders rides on identical scheme tag, HKDF salt/info, and base64 wire encoding.

## What lands

```
app/src/main/kotlin/chat/onym/android/
├── identity/
│   ├── SealedEnvelope.kt                            ← @Serializable wire format (snake_case)
│   ├── InvitationEnvelopeDecrypter.kt               ← interface + InvitationDecryptError sealed class
│   └── IdentityRepository.kt (modified)             ← + decryptInvitation + inboxKeyAgreementPrivateKey helper
└── inbox/
    ├── DecryptedInvitation.kt                       ← @Serializable 4-field subset of BootstrapPayload
    └── InvitationDecryptor.kt                       ← stateless: pump envelope → plaintext → DecryptedInvitation

app/src/sharedTest/kotlin/chat/onym/android/        ← new shared source set; both test/ and androidTest/ pick it up
└── support/
    ├── FakeInvitationEnvelopeDecrypter.kt           ← reusable: Fixed / Scripted(map) / Failing(error)
    └── TestInvitationEncryptor.kt                   ← test-only sender-side encrypt for round-trip tests

app/src/test/kotlin/chat/onym/android/
├── identity/SealedEnvelopeTest.kt                   ← 3 cases (cross-platform JSON contract)
└── inbox/InvitationDecryptorTest.kt                 ← 5 cases (pump shape + error propagation)

app/src/androidTest/kotlin/chat/onym/android/
└── identity/IdentityRepositoryInvitationDecryptTest.kt  ← 9 cases (real X25519 round-trip + 7 error paths)
```

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Seam protocol** | `InvitationEnvelopeDecrypter` | nothing from `chat.onym.sdk.*`; lives in `identity/` |
| **Repository** | `IdentityRepository.decryptInvitation` | `IdentitySecretStore` (snapshot load) + BouncyCastle X25519 + JDK Cipher AES-GCM + Ed25519 verify — no transport, no OnymSDK call from this method |
| **Interactor** | `InvitationDecryptor` | the seam interface + kotlinx.serialization `Json` — no other repository, no OnymSDK |
| **OnymSDK** | nothing | nothing |

Secret material (X25519 private key) is recomputed inside the repository on every call from the persisted nostr secret and discarded — never assigned to a stored property. `InvitationDecryptor` only ever sees plaintext bytes the seam gives it.

## Crypto specifics

For interop with iOS senders **and** stellar-mls Android senders, the formula is identical:

- Scheme tag: `"x25519-aes-256-gcm-v1"` (anything else throws `InvitationDecryptError.UnsupportedScheme`).
- HKDF salt: `"sep-invitation-v1"`.
- HKDF info: `"aes-256-gcm"`.
- HKDF output: 32 bytes (SHA-256).
- AES-GCM: 12-byte nonce, 16-byte tag, ciphertext + tag concatenated for `Cipher.doFinal`.
- M-5: Ed25519 verifier over the `ephemeral_public_key` raw bytes; uses the embedded `sender_ed25519_public_key`; rejects if signature present but verification fails or signature present but pubkey field absent.
- `ByteArray` fields ship as base64 strings via `Base64ByteArraySerializer` (matches iOS Foundation's default `Data` JSON encoding, not kotlinx.serialization's default JSON-array-of-ints).

The instrumented test cross-checks against ciphertext produced by `TestInvitationEncryptor` (which replicates stellar-mls's sender formula) — round-trip success implies wire compatibility.

## The reusable test pattern

PR #15 introduced `FakeInboxTransport` + `InMemoryInvitationStore` for upstream/downstream seam pumps. This PR adds two more pieces of scaffolding:

- **`FakeInvitationEnvelopeDecrypter`** — sealed `Mode` with `Fixed(plaintext)` (happy-path pumps), `Scripted(map<List<Byte>, ByteArray>)` (multi-input tests), `Failing(error)` (error-path coverage). Tracks `decryptCalls`.
- **`TestInvitationEncryptor`** — replicates `stellar-mls/clients/android/StellarChat/.../crypto/GroupCrypto.encryptInvitation` so round-trip tests produce real `x25519-aes-256-gcm-v1` ciphertext without polluting production with sender-side code (no app code sends invitations yet — that's a future capability). Will move to production when send-invitation lands.

Both fakes live in a new `app/src/sharedTest/kotlin/` source set wired into both `test/` and `androidTest/` via `app/build.gradle.kts`. Mirrors the iOS pattern of a single `Tests/OnymIOSTests/Support/` directory available to every XCTest target.

## Test plan

- [x] `./gradlew :app:assembleDebug` — production builds clean
- [x] `./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.identity.SealedEnvelopeTest' --tests 'chat.onym.android.inbox.InvitationDecryptorTest'` — 8/8 JVM
- [x] `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=chat.onym.android.identity.IdentityRepositoryInvitationDecryptTest` — 9/9 on Pixel 9 Pro AVD (API 36)
- [x] Full unit-test suite still green
- [x] `python3 scripts/lint-secrets.py` — exit 0

## Note on test placement

The brief asked for `IdentityRepositoryInvitationDecryptTest` in `app/src/test/` (Robolectric). Deviation is intentional: `IdentityRepository.restore` invokes `chat.onym.sdk.Common.nostrDerivePublicKey` (and `publicKey`) which need the OnymSDK FFI .so loaded from the AAR's `jni/<abi>/`, plus `EncryptedSharedPreferences` needs the real Android Keystore. Same constraints that put the existing `IdentityRepositoryTest` in `androidTest/`. The other two test files (`SealedEnvelopeTest`, `InvitationDecryptorTest`) live in `app/src/test/` per the brief — they touch only kotlinx.serialization + the fake decrypter.

## Out of scope (intentionally — match iOS PR #17)

- **App wiring.** `OnymApplication` doesn't consume `InvitationDecryptor` yet — capability ships tested; wire-up belongs with the next slice.
- **The full BootstrapPayload.** `DecryptedInvitation` is a 4-field subset; `members` / `groupSecret` / `relayHints` / `salt` / `commitment` / `senderTransportBundle` etc. land when a UI needs them or a flow needs to actually join the group. `Json { ignoreUnknownKeys = true }` means adding fields is non-breaking.
- **Sender side.** `encryptInvitation` lives only in test code today; moves to production when the app gains create-group + invite-contact capability.
- **UI.** No composable consumes `DecryptedInvitation` yet. The `InviteFlow` shown as "planned" in the architecture diagram lands when there's a screen for received invitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)