### PR TITLE
settings: user-configurable relayer URL (Network section + GitHub Releases discovery)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,8 +116,15 @@ dependencies {
 
     // OkHttp WebSocket — NostrRelayConnection uses it for the relay
     // connection. Built-in pingInterval handles heartbeat; no need
-    // for the iOS CFNetwork-pong workaround.
+    // for the iOS CFNetwork-pong workaround. Also used by
+    // GitHubReleasesKnownRelayersFetcher (HTTPS GET of relayers.json).
     implementation(libs.okhttp)
+
+    // DataStore Preferences — flow-based persistence for the relayer
+    // URL selection. URLs aren't secret material; identity bytes
+    // continue to live in EncryptedSharedPreferences via
+    // IdentitySecretStore.
+    implementation(libs.androidx.datastore.preferences)
 
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
@@ -149,6 +156,11 @@ dependencies {
     // in `app/src/test/` is plain JUnit and won't load Robolectric.
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.ext.junit)
+    // DataStore-Preferences `-core` artifact — JVM-only flavour with
+    // no Android dep. RelayerSelectionStoreTest opens a real
+    // PreferenceDataStoreFactory backed by a per-test temp file; no
+    // Robolectric / mocking required.
+    testImplementation(libs.androidx.datastore.preferences.core)
 
     // Instrumented tests. Real EncryptedSharedPreferences against the
     // emulator's hardware-backed Keystore.

--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -2,6 +2,7 @@ package chat.onym.android
 
 import androidx.fragment.app.FragmentActivity
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
+import chat.onym.android.settings.RelayerPickerViewModel
 import chat.onym.android.transport.nostr.NostrEphemeralSignerProvider
 
 /**
@@ -31,4 +32,5 @@ class AppDependencies(
      *  into the app shell yet. */
     val nostrSignerProvider: NostrEphemeralSignerProvider,
     val makeRecoveryPhraseBackupViewModel: (activityProvider: () -> FragmentActivity) -> RecoveryPhraseBackupViewModel,
+    val makeRelayerPickerViewModel: () -> RelayerPickerViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -2,8 +2,15 @@ package chat.onym.android
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.os.Bundle
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.FragmentActivity
+import chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore
+import chat.onym.android.chain.GitHubReleasesKnownRelayersFetcher
+import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.identity.IdentitySecretStore
 import chat.onym.android.identity.OnymNostrSignerProvider
@@ -11,9 +18,29 @@ import chat.onym.android.recovery.AndroidBiometricAuthenticator
 import chat.onym.android.recovery.AndroidClipboardWriter
 import chat.onym.android.recovery.AndroidStringProvider
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
+import chat.onym.android.settings.RelayerPickerViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.lang.ref.WeakReference
 import java.security.Security
+
+/**
+ * Single DataStore Preferences instance for non-secret app config
+ * (today: relayer URL selection + cached known list). The
+ * `preferencesDataStore` delegate guarantees one instance per
+ * `Context` per filename across the process — safe to call from
+ * anywhere; we only read it from [OnymApplication.onCreate].
+ *
+ * Identity material continues to live in EncryptedSharedPreferences
+ * via [IdentitySecretStore]; URLs aren't secret so DataStore is fine.
+ */
+private val Context.relayerDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "chat.onym.android.relayer_prefs",
+)
 
 /**
  * Composition root. Two responsibilities:
@@ -41,6 +68,12 @@ class OnymApplication : Application() {
      *  `BiometricPrompt` dialog fragment. `WeakReference` so a
      *  background-and-finish doesn't pin the Activity. */
     private var resumedActivity: WeakReference<Activity>? = null
+
+    /** Application-scoped CoroutineScope for fire-and-forget jobs
+     *  that must outlive any Activity (e.g., the boot fetch of the
+     *  relayer list). [SupervisorJob] so a single failing child
+     *  doesn't cancel the rest. */
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onCreate() {
         super.onCreate()
@@ -73,6 +106,24 @@ class OnymApplication : Application() {
         val clipboard = AndroidClipboardWriter(applicationContext)
         val strings = AndroidStringProvider(applicationContext)
 
+        // Relayer wiring — DataStore-backed selection + GitHub-Releases
+        // fetcher. Bootstrap (load cached + selection from disk) runs
+        // synchronously off the IO dispatcher; start() (network fetch)
+        // is fire-and-forget so app launch never blocks on the network.
+        val relayerStore = DataStorePreferencesRelayerSelectionStore(
+            dataStore = applicationContext.relayerDataStore,
+        )
+        val httpClient = OkHttpClient()
+        val relayerFetcher = GitHubReleasesKnownRelayersFetcher(httpClient = httpClient)
+        val relayerRepository = RelayerRepository(
+            store = relayerStore,
+            fetcher = relayerFetcher,
+        )
+        applicationScope.launch {
+            relayerRepository.bootstrap()
+            relayerRepository.start()
+        }
+
         dependencies = AppDependencies(
             nostrSignerProvider = nostrSignerProvider,
             makeRecoveryPhraseBackupViewModel = { activityProvider ->
@@ -84,6 +135,9 @@ class OnymApplication : Application() {
                     clipboard = clipboard,
                     strings = strings,
                 )
+            },
+            makeRelayerPickerViewModel = {
+                RelayerPickerViewModel(repository = relayerRepository)
             },
         )
     }

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -25,6 +25,8 @@ import androidx.navigation.compose.rememberNavController
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.search.SearchScreen
+import chat.onym.android.settings.RelayerPickerScreen
+import chat.onym.android.settings.RelayerPickerViewModel
 import chat.onym.android.settings.SettingsScreen
 
 /**
@@ -100,10 +102,22 @@ fun RootScreen(dependencies: AppDependencies) {
             composable(Tab.Settings.route) {
                 SettingsScreen(
                     onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
+                    onRelayerClick = { navController.navigate(ROUTE_RELAYER_PICKER) },
                 )
             }
             composable(Tab.Search.route) {
                 SearchScreen()
+            }
+            composable(ROUTE_RELAYER_PICKER) {
+                val vm: RelayerPickerViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeRelayerPickerViewModel() }
+                    },
+                )
+                RelayerPickerScreen(
+                    viewModel = vm,
+                    onBackClick = { navController.popBackStack() },
+                )
             }
             composable(ROUTE_RECOVERY_BACKUP) {
                 // Resolve the host Activity at render time. AppDependencies
@@ -141,4 +155,5 @@ private enum class Tab(val route: String, val labelRes: Int) {
 }
 
 private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
+private const val ROUTE_RELAYER_PICKER = "relayer_picker"
 private val TAB_ROUTES = setOf(Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/chain/KnownRelayersFetcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/KnownRelayersFetcher.kt
@@ -1,0 +1,76 @@
+package chat.onym.android.chain
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+/**
+ * Network seam for "fetch the latest list of relayers". Production
+ * impl ([GitHubReleasesKnownRelayersFetcher]) talks to GitHub's
+ * `releases/latest/download/<asset>` redirect — public, no auth,
+ * no API rate limit. Tests substitute a fake.
+ *
+ * Mirrors `KnownRelayersFetcher` from onym-ios PR #18.
+ */
+interface KnownRelayersFetcher {
+    /**
+     * Fetch the current published list. Throws on any network /
+     * parse failure — callers (`RelayerRepository.start`) are
+     * responsible for keeping the cached list intact on error.
+     */
+    suspend fun fetch(): List<RelayerEndpoint>
+}
+
+/**
+ * Pulls `relayers.json` from the latest GitHub Release of
+ * `onymchat/onym-relayer`. Default URL is the
+ * `releases/latest/download/<asset>` redirect — server-side that
+ * resolves to the asset attached to whichever release is currently
+ * tagged "latest", so publishing a new release with the same asset
+ * filename is the entire deployment story (no app update).
+ *
+ * @param httpClient OkHttp client, injected for tests. Production
+ *        passes a default-configured client; tests pass one built
+ *        with `support/FakeOkHttpClient.kt`.
+ * @param url Override only for tests; the production default is
+ *        load-bearing — see [DEFAULT_URL].
+ */
+class GitHubReleasesKnownRelayersFetcher(
+    private val httpClient: OkHttpClient,
+    private val url: String = DEFAULT_URL,
+) : KnownRelayersFetcher {
+
+    override suspend fun fetch(): List<RelayerEndpoint> = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url.toHttpUrl())
+            .header("Accept", "application/json")
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("GET $url returned HTTP ${response.code}")
+            }
+            val body = response.body?.string() ?: throw IOException("empty response body")
+            try {
+                jsonFormat.decodeFromString(KnownRelayersDocument.serializer(), body).relayers
+            } catch (e: SerializationException) {
+                throw IOException("invalid relayers.json: ${e.message}", e)
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Pinned by [KnownRelayersFetcherTest.defaultURL_pointsAtGitHubReleasesLatestDownload].
+         * Renaming this string silently breaks every install — the
+         * server-side redirect is the entire deployment hot-path.
+         */
+        const val DEFAULT_URL = "https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json"
+
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
@@ -1,0 +1,70 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One published relayer endpoint. Wire format pinned by
+ * [KnownRelayersDocument] — interop with the iOS client + the
+ * server-side `relayers.json` artifact rides on the JSON field
+ * names being exactly `name` / `url` / `network`.
+ *
+ * Mirrors `RelayerEndpoint` from onym-ios PR #18.
+ */
+@Serializable
+data class RelayerEndpoint(
+    val name: String,
+    val url: String,
+    val network: String,
+)
+
+/**
+ * Top-level shape of `relayers.json`, fetched from the latest
+ * GitHub Release of `onymchat/onym-relayer`. `version = 1` today;
+ * future schema changes bump the version and we'd add a converter
+ * (forwards-compat is best-effort — `Json { ignoreUnknownKeys =
+ * true }` already swallows extra fields).
+ */
+@Serializable
+data class KnownRelayersDocument(
+    val version: Int,
+    val relayers: List<RelayerEndpoint>,
+)
+
+/**
+ * What the user picked. Two cases:
+ *
+ *  - [Known] — one of the published [RelayerEndpoint]s the fetcher
+ *    discovered. The picker UI surfaces these as a list.
+ *  - [Custom] — a user-typed URL. Used for private deployments,
+ *    localhost dev, sideloaded networks. URL is opaque to us; we
+ *    only validate that it parses + uses http/https + has a host
+ *    (see `RelayerPickerViewModel.validate`).
+ *
+ * `null` selection means "user hasn't picked yet" — chain code
+ * should refuse to publish until the user picks.
+ *
+ * Mirrors `RelayerSelection` from onym-ios PR #18.
+ */
+sealed class RelayerSelection {
+    abstract val url: String
+
+    data class Known(val endpoint: RelayerEndpoint) : RelayerSelection() {
+        override val url: String get() = endpoint.url
+    }
+
+    data class Custom(override val url: String) : RelayerSelection()
+}
+
+/**
+ * Snapshot the [RelayerRepository] publishes through its StateFlow.
+ * Two parallel pieces of state:
+ *
+ *  - [knownRelayers] — last successful fetch (or empty if never
+ *    fetched / cleared). Cached to disk so the picker has something
+ *    to show before the next start() / refresh() completes.
+ *  - [selection] — user's current pick.
+ */
+data class RelayerState(
+    val knownRelayers: List<RelayerEndpoint>,
+    val selection: RelayerSelection?,
+)

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
@@ -1,0 +1,92 @@
+package chat.onym.android.chain
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns the in-memory view of the relayer URL configuration plus
+ * the corresponding writes to the persistence + network seams.
+ * Same shape as [chat.onym.android.identity.IdentityRepository] —
+ * Mutex + StateFlow.
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds **only** [store] + [fetcher]. No transport, no OnymSDK,
+ *    no Compose, no `Context`.
+ *  - Exposes a [StateFlow] for observation; [setSelection] /
+ *    [start] / [refresh] / [bootstrap] are the suspend mutators.
+ *  - Mutations serialise through a [Mutex]; reads are lock-free
+ *    off the [StateFlow].
+ *
+ * Mirrors `RelayerRepository` from onym-ios PR #18.
+ */
+class RelayerRepository(
+    private val store: RelayerSelectionStore,
+    private val fetcher: KnownRelayersFetcher,
+) {
+    private val mutex = Mutex()
+    private val _snapshots = MutableStateFlow(RelayerState(emptyList(), null))
+
+    /** Hot stream of [RelayerState] snapshots. New collectors get
+     *  the current value immediately, then one new value per
+     *  successful mutation. */
+    val snapshots: StateFlow<RelayerState> = _snapshots.asStateFlow()
+
+    /** `true` after the first [start] call so a re-launch (e.g.,
+     *  Activity recreate) doesn't double-fetch. Wraps inside the
+     *  mutex; never read off it. */
+    private var startInvoked = false
+
+    /**
+     * Hydrate from disk — the cached known list + the user's last
+     * selection. Idempotent. Safe to call from any startup path
+     * (e.g., on `OnymApplication.onCreate` before [start] kicks
+     * off a network fetch).
+     */
+    suspend fun bootstrap() = mutex.withLock {
+        val cached = store.loadCachedKnownRelayers()
+        val sel = store.loadSelection()
+        _snapshots.value = RelayerState(knownRelayers = cached, selection = sel)
+    }
+
+    /**
+     * Fire-and-forget the GitHub-Releases fetch. Idempotent (a
+     * second [start] call returns immediately). Failures are
+     * swallowed — app launch must not crash on a network blip;
+     * the picker shows the cached list until the next [refresh].
+     */
+    suspend fun start() = mutex.withLock {
+        if (startInvoked) return@withLock
+        startInvoked = true
+        runCatching { fetcher.fetch() }.onSuccess { fresh ->
+            store.saveCachedKnownRelayers(fresh)
+            _snapshots.value = _snapshots.value.copy(knownRelayers = fresh)
+        }
+    }
+
+    /**
+     * User-initiated refresh. Same as [start] but ungated by
+     * [startInvoked] — explicit user action gets a fresh fetch
+     * even after the boot fetch already ran. Failures are
+     * propagated to the caller (so a pull-to-refresh UI can show
+     * the error).
+     */
+    suspend fun refresh() {
+        val fresh = fetcher.fetch()  // throws on failure; caller handles
+        mutex.withLock {
+            store.saveCachedKnownRelayers(fresh)
+            _snapshots.value = _snapshots.value.copy(knownRelayers = fresh)
+        }
+    }
+
+    /** Persist the user's pick + push a fresh snapshot. `null`
+     *  clears the selection (chain code refuses to publish until
+     *  the user picks again). */
+    suspend fun setSelection(selection: RelayerSelection?) = mutex.withLock {
+        store.saveSelection(selection)
+        _snapshots.value = _snapshots.value.copy(selection = selection)
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
@@ -1,0 +1,145 @@
+package chat.onym.android.chain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Persistence seam for the relayer URL selection + the cached
+ * known-relayer list. URLs aren't secret material — DataStore
+ * Preferences is plenty; encrypted storage stays for identity
+ * bytes only.
+ *
+ * `suspend` everywhere — DataStore reads return [kotlinx.coroutines.flow.Flow]s
+ * but we only ever care about the latest snapshot, so the impl
+ * collapses every read to `flow.first()`.
+ *
+ * Mirrors `RelayerSelectionStore` from onym-ios PR #18.
+ */
+interface RelayerSelectionStore {
+    /** Returns `null` if no selection persisted yet. */
+    suspend fun loadSelection(): RelayerSelection?
+
+    /** Persist the user's pick. `null` clears it. */
+    suspend fun saveSelection(selection: RelayerSelection?)
+
+    /** Last successfully-fetched list, or `[]` if the fetcher has
+     *  never succeeded on this install. */
+    suspend fun loadCachedKnownRelayers(): List<RelayerEndpoint>
+
+    /** Overwrite the cached list. Empty list is allowed. */
+    suspend fun saveCachedKnownRelayers(relayers: List<RelayerEndpoint>)
+
+    /** Test/utility — wipe everything this store has written. */
+    suspend fun clear()
+}
+
+/**
+ * [DataStore]-backed [RelayerSelectionStore]. Stores both the
+ * selection and the cached known list as JSON strings under
+ * fixed Preferences keys. JSON encoding is permissive on
+ * decoding so a future schema-evolution doesn't trip the read.
+ *
+ * Threading: DataStore handles serialised writes internally; this
+ * class is safe to call from multiple coroutines without external
+ * synchronisation.
+ */
+class DataStorePreferencesRelayerSelectionStore(
+    private val dataStore: DataStore<Preferences>,
+) : RelayerSelectionStore {
+
+    override suspend fun loadSelection(): RelayerSelection? {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_SELECTION] ?: return null
+        return try {
+            jsonFormat.decodeFromString(SelectionRecord.serializer(), raw).toSelection()
+        } catch (_: SerializationException) {
+            null
+        }
+    }
+
+    override suspend fun saveSelection(selection: RelayerSelection?) {
+        dataStore.edit { prefs ->
+            if (selection == null) {
+                prefs.remove(KEY_SELECTION)
+            } else {
+                prefs[KEY_SELECTION] = jsonFormat.encodeToString(
+                    SelectionRecord.serializer(),
+                    SelectionRecord.from(selection),
+                )
+            }
+        }
+    }
+
+    override suspend fun loadCachedKnownRelayers(): List<RelayerEndpoint> {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_CACHED] ?: return emptyList()
+        return try {
+            jsonFormat.decodeFromString(KnownRelayersDocument.serializer(), raw).relayers
+        } catch (_: SerializationException) {
+            emptyList()
+        }
+    }
+
+    override suspend fun saveCachedKnownRelayers(relayers: List<RelayerEndpoint>) {
+        dataStore.edit { prefs ->
+            prefs[KEY_CACHED] = jsonFormat.encodeToString(
+                KnownRelayersDocument.serializer(),
+                KnownRelayersDocument(version = 1, relayers = relayers),
+            )
+        }
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+
+    /** Persistence-only sum type for [RelayerSelection]. We don't
+     *  encode the sealed class directly because kotlinx.serialization's
+     *  default polymorphic encoding adds a `type` discriminator
+     *  that would couple the on-disk format to the Kotlin class
+     *  hierarchy — this hand-rolled record is simpler to evolve. */
+    @kotlinx.serialization.Serializable
+    private data class SelectionRecord(
+        val kind: String,           // "known" or "custom"
+        val url: String,
+        val name: String? = null,   // populated for known
+        val network: String? = null, // populated for known
+    ) {
+        fun toSelection(): RelayerSelection? = when (kind) {
+            "known" -> {
+                val n = name; val net = network
+                if (n != null && net != null) {
+                    RelayerSelection.Known(RelayerEndpoint(name = n, url = url, network = net))
+                } else null
+            }
+            "custom" -> RelayerSelection.Custom(url)
+            else -> null
+        }
+
+        companion object {
+            fun from(selection: RelayerSelection): SelectionRecord = when (selection) {
+                is RelayerSelection.Known -> SelectionRecord(
+                    kind = "known",
+                    url = selection.endpoint.url,
+                    name = selection.endpoint.name,
+                    network = selection.endpoint.network,
+                )
+                is RelayerSelection.Custom -> SelectionRecord(
+                    kind = "custom",
+                    url = selection.url,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        private val KEY_SELECTION = stringPreferencesKey("relayer_selection")
+        private val KEY_CACHED = stringPreferencesKey("relayer_cached_known")
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerPickerScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerPickerScreen.kt
@@ -1,0 +1,258 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerSelection
+
+/**
+ * Picker for the relayer URL. Two sections:
+ *
+ *  - **Known** — entries the [chat.onym.android.chain.KnownRelayersFetcher]
+ *    discovered from the GitHub Releases asset. Tap to select.
+ *  - **Custom** — text field + Save for private deployments /
+ *    localhost dev / sideloaded networks.
+ *
+ * Strings inline (English-only for now per PR #18 scope); when
+ * other Settings strings get translated, lift these into
+ * `res/values/strings.xml` + `values-ru/strings.xml`.
+ *
+ * Mirrors `RelayerPickerView` from onym-ios PR #18.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RelayerPickerScreen(
+    viewModel: RelayerPickerViewModel,
+    onBackClick: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Relayer") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(contentPadding = padding) {
+            item { SectionHeader("KNOWN RELAYERS") }
+            if (state.knownRelayers.isEmpty()) {
+                item { EmptyKnownRow() }
+            } else {
+                items(state.knownRelayers, key = { it.url }) { endpoint ->
+                    val isSelected =
+                        (state.currentSelection as? RelayerSelection.Known)?.endpoint?.url == endpoint.url
+                    KnownRelayerRow(
+                        endpoint = endpoint,
+                        isSelected = isSelected,
+                        onClick = { viewModel.pickKnown(endpoint) },
+                    )
+                }
+            }
+            item { Footer("Discovered from the latest onymchat/onym-relayer release. Pulled in the background; cached locally.") }
+
+            item { Spacer(Modifier.height(20.dp)) }
+
+            item { SectionHeader("CUSTOM") }
+            item {
+                CustomRelayerRow(
+                    draft = state.customDraft,
+                    error = state.customDraftError,
+                    isSelected = state.currentSelection is RelayerSelection.Custom,
+                    onDraftChange = viewModel::customDraftChanged,
+                    onSave = viewModel::saveCustom,
+                )
+            }
+            item { Footer("For private deployments, localhost development, or sideloaded networks. URL must use http or https.") }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp)
+            .padding(top = 16.dp, bottom = 6.dp),
+    )
+}
+
+@Composable
+private fun Footer(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun KnownRelayerRow(
+    endpoint: RelayerEndpoint,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(endpoint.name, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
+            Text(
+                "${endpoint.network} · ${endpoint.url}",
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(RoundedCornerShape(11.dp))
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = "Selected",
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyKnownRow() {
+    Text(
+        "Fetching list…",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
+    )
+}
+
+@Composable
+private fun CustomRelayerRow(
+    draft: String,
+    error: String?,
+    isSelected: Boolean,
+    onDraftChange: (String) -> Unit,
+    onSave: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                "Custom URL",
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                modifier = Modifier.weight(1f),
+            )
+            if (isSelected) {
+                Box(
+                    modifier = Modifier
+                        .size(22.dp)
+                        .clip(RoundedCornerShape(11.dp))
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Filled.Check,
+                        contentDescription = "Selected",
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
+        }
+        OutlinedTextField(
+            value = draft,
+            onValueChange = onDraftChange,
+            placeholder = { Text("https://relayer.example.com") },
+            singleLine = true,
+            isError = error != null,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (error != null) {
+            Text(
+                error,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        Button(
+            onClick = onSave,
+            enabled = draft.isNotBlank(),
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(10.dp),
+            contentPadding = PaddingValues(vertical = 12.dp),
+        ) {
+            Text("Save", fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+private val SettingsIconBoxColor: Color = Color(0xFF34C759)

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerPickerViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerPickerViewModel.kt
@@ -1,0 +1,154 @@
+package chat.onym.android.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerRepository
+import chat.onym.android.chain.RelayerSelection
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * ViewModel for the Relayer picker screen. Holds the **flow** state
+ * (current snapshot mirror + draft + validation error); domain
+ * state lives on [RelayerRepository].
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds **only** [repository] + the [validate] companion.
+ *  - No `Context`, no DataStore, no OkHttp.
+ *  - Intents: [pickKnown], [customDraftChanged], [saveCustom],
+ *    [clearSelection]. Each dispatches to [repository] on
+ *    [viewModelScope].
+ *
+ * Mirrors `RelayerPickerFlow` from onym-ios PR #18.
+ */
+class RelayerPickerViewModel(
+    private val repository: RelayerRepository,
+) : ViewModel() {
+
+    /** Snapshot the screen renders. */
+    data class State(
+        val knownRelayers: List<RelayerEndpoint>,
+        val currentSelection: RelayerSelection?,
+        /** User-typed draft for the Custom row; never round-trips
+         *  through the repository until [saveCustom]. */
+        val customDraft: String,
+        /** Non-null when the draft fails [validate]; `null` when
+         *  the draft is empty (no error yet) or valid. */
+        val customDraftError: String?,
+    )
+
+    private val _state = MutableStateFlow(
+        State(
+            knownRelayers = emptyList(),
+            currentSelection = null,
+            customDraft = "",
+            customDraftError = null,
+        )
+    )
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.snapshots.collect { snapshot ->
+                val current = _state.value
+                // Prefill the draft from the persisted custom URL on
+                // first hydration, but never overwrite an in-flight
+                // user edit (compare draft to the previous selection
+                // string, not the new one).
+                val newDraft = if (
+                    current.customDraft.isEmpty() ||
+                    current.customDraft == (current.currentSelection as? RelayerSelection.Custom)?.url
+                ) {
+                    (snapshot.selection as? RelayerSelection.Custom)?.url ?: current.customDraft
+                } else {
+                    current.customDraft
+                }
+                _state.value = current.copy(
+                    knownRelayers = snapshot.knownRelayers,
+                    currentSelection = snapshot.selection,
+                    customDraft = newDraft,
+                )
+            }
+        }
+    }
+
+    fun pickKnown(endpoint: RelayerEndpoint) {
+        viewModelScope.launch {
+            repository.setSelection(RelayerSelection.Known(endpoint))
+        }
+    }
+
+    fun customDraftChanged(text: String) {
+        _state.value = _state.value.copy(
+            customDraft = text,
+            // Clear stale error as the user types; we re-validate
+            // on Save.
+            customDraftError = null,
+        )
+    }
+
+    /** Validates the current draft and, on success, persists it as
+     *  a [RelayerSelection.Custom]. Sets [State.customDraftError]
+     *  on failure; never touches the repository. */
+    fun saveCustom() {
+        val draft = _state.value.customDraft
+        when (val result = validate(draft)) {
+            is ValidationResult.Valid -> {
+                viewModelScope.launch {
+                    repository.setSelection(RelayerSelection.Custom(result.normalisedUrl))
+                }
+            }
+            is ValidationResult.Invalid -> {
+                _state.value = _state.value.copy(customDraftError = result.reason)
+            }
+        }
+    }
+
+    fun clearSelection() {
+        viewModelScope.launch {
+            repository.setSelection(null)
+        }
+    }
+
+    sealed class ValidationResult {
+        data class Valid(val normalisedUrl: String) : ValidationResult()
+        data class Invalid(val reason: String) : ValidationResult()
+    }
+
+    companion object {
+        /**
+         * URL validation rules — parity with iOS PR #18.
+         *
+         *  - Trim whitespace.
+         *  - Reject empty.
+         *  - Must parse as a URI.
+         *  - Scheme must be `http` or `https` (so `http://localhost:8080`
+         *    works for dev).
+         *  - Host must be non-empty.
+         */
+        internal fun validate(raw: String): ValidationResult {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return ValidationResult.Invalid("URL is empty")
+            val uri = try {
+                URI(trimmed)
+            } catch (_: URISyntaxException) {
+                return ValidationResult.Invalid("URL didn't parse")
+            }
+            val scheme = uri.scheme?.lowercase()
+            if (scheme != "http" && scheme != "https") {
+                return ValidationResult.Invalid("scheme must be http or https")
+            }
+            val host = uri.host
+            if (host.isNullOrBlank()) {
+                return ValidationResult.Invalid("URL has no host")
+            }
+            return ValidationResult.Valid(trimmed)
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeTopAppBar
@@ -53,7 +54,10 @@ import chat.onym.android.R
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(onBackupClick: () -> Unit) {
+fun SettingsScreen(
+    onBackupClick: () -> Unit,
+    onRelayerClick: () -> Unit,
+) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
     )
@@ -101,6 +105,44 @@ fun SettingsScreen(onBackupClick: () -> Unit) {
             item {
                 Text(
                     stringResource(R.string.security_footer_view_recovery_phrase),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                )
+            }
+
+            // Network section — relayer URL config. English-only for
+            // now per the iOS twin (PR #18); lift into res/values/
+            // when a translation pass for Settings lands.
+            item { SectionHeader("NETWORK") }
+            item {
+                ListItem(
+                    headlineContent = { Text("Relayer") },
+                    leadingContent = {
+                        SettingsIconBox(
+                            icon = Icons.Filled.Cloud,
+                            background = Color(0xFF34C759),
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(onClick = onRelayerClick),
+                )
+            }
+            item {
+                Text(
+                    "Where chain operations are submitted. Discovered from GitHub Releases of onymchat/onym-relayer; can be overridden with a custom URL.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeKnownRelayersFetcher.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeKnownRelayersFetcher.kt
@@ -1,0 +1,51 @@
+package chat.onym.android.support
+
+import chat.onym.android.chain.KnownRelayersFetcher
+import chat.onym.android.chain.RelayerEndpoint
+
+/**
+ * Reusable test fake for [KnownRelayersFetcher]. Three modes
+ * mirror the iOS twin (PR #18):
+ *
+ *  - [Mode.Succeeds] — happy-path; returns the supplied list.
+ *  - [Mode.Failing] — error-path; throws the supplied error.
+ *  - [Mode.Scripted] — multi-call; each `fetch()` call pulls the
+ *    next [Result] off the script. Walks past the end → throws.
+ *
+ * Tracks [fetchCallCount] so tests can assert idempotency
+ * properties (e.g., `RelayerRepository.start()` calling fetch only
+ * once across multiple invocations).
+ *
+ * Mirrors `FakeKnownRelayersFetcher` from onym-ios PR #18.
+ */
+class FakeKnownRelayersFetcher(var mode: Mode) : KnownRelayersFetcher {
+
+    sealed class Mode {
+        data class Succeeds(val list: List<RelayerEndpoint>) : Mode()
+        data class Failing(val error: Throwable) : Mode()
+        data class Scripted(val responses: List<Result<List<RelayerEndpoint>>>) : Mode()
+    }
+
+    var fetchCallCount: Int = 0
+        private set
+
+    private var scriptedIndex = 0
+
+    override suspend fun fetch(): List<RelayerEndpoint> {
+        fetchCallCount += 1
+        return when (val m = mode) {
+            is Mode.Succeeds -> m.list
+            is Mode.Failing -> throw m.error
+            is Mode.Scripted -> {
+                if (scriptedIndex >= m.responses.size) {
+                    throw IllegalStateException(
+                        "FakeKnownRelayersFetcher: scripted responses exhausted (${m.responses.size} consumed)"
+                    )
+                }
+                val r = m.responses[scriptedIndex]
+                scriptedIndex += 1
+                r.getOrThrow()
+            }
+        }
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeOkHttpClient.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeOkHttpClient.kt
@@ -1,0 +1,53 @@
+package chat.onym.android.support
+
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * Test scaffolding for "talks to a real HTTP service" tests.
+ *
+ * Builds an [OkHttpClient] with an [Interceptor] that hands every
+ * request to a caller-supplied handler — analogous to iOS's
+ * `StubURLProtocol`. Returns canned [Response] objects per request
+ * URL so tests can pin wire-format expectations without standing
+ * up `MockWebServer` (which has its own thread, port-binding, and
+ * shutdown semantics — overkill for unit tests).
+ *
+ * Reusable beyond this PR: any future "fetch JSON from a service"
+ * test (chain client, push-notification gateway, telemetry) drops
+ * into the same pattern.
+ *
+ * Mirrors `StubURLProtocol` from onym-ios PR #18.
+ */
+object FakeOkHttpClient {
+    /** Build a client whose every request is handled by [handler]. */
+    fun build(handler: (Request) -> Response): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(Interceptor { chain -> handler(chain.request()) })
+            .build()
+
+    /** Canned 200 OK with a JSON body. */
+    fun ok(request: Request, json: String): Response =
+        Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(json.toResponseBody("application/json".toMediaType()))
+            .build()
+
+    /** Canned non-success response with an empty body. */
+    fun status(request: Request, code: Int, message: String = "Error"): Response =
+        Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(message)
+            .body("".toResponseBody("text/plain".toMediaType()))
+            .build()
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryRelayerSelectionStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryRelayerSelectionStore.kt
@@ -1,0 +1,42 @@
+package chat.onym.android.support
+
+import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerSelection
+import chat.onym.android.chain.RelayerSelectionStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Reusable in-memory [RelayerSelectionStore]. Same contract as
+ * [chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore],
+ * no DataStore / no disk — ~10× faster per test, lets repository
+ * tests focus on behaviour rather than persistence plumbing.
+ *
+ * Mirrors `InMemoryRelayerSelectionStore` from onym-ios PR #18.
+ */
+class InMemoryRelayerSelectionStore : RelayerSelectionStore {
+
+    private val mutex = Mutex()
+    private var selection: RelayerSelection? = null
+    private var cached: List<RelayerEndpoint> = emptyList()
+
+    override suspend fun loadSelection(): RelayerSelection? = mutex.withLock { selection }
+
+    override suspend fun saveSelection(selection: RelayerSelection?) {
+        mutex.withLock { this.selection = selection }
+    }
+
+    override suspend fun loadCachedKnownRelayers(): List<RelayerEndpoint> =
+        mutex.withLock { cached }
+
+    override suspend fun saveCachedKnownRelayers(relayers: List<RelayerEndpoint>) {
+        mutex.withLock { this.cached = relayers.toList() }
+    }
+
+    override suspend fun clear() {
+        mutex.withLock {
+            selection = null
+            cached = emptyList()
+        }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/KnownRelayersFetcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/KnownRelayersFetcherTest.kt
@@ -1,0 +1,129 @@
+package chat.onym.android.chain
+
+import chat.onym.android.support.FakeOkHttpClient
+import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Wire-format pin for the GitHub-Releases-backed fetcher. Uses a
+ * hand-rolled OkHttp [okhttp3.Interceptor] (via [FakeOkHttpClient])
+ * to return canned responses per request — no `MockWebServer`.
+ *
+ * Mirrors `KnownRelayersFetcherTests` from onym-ios PR #18.
+ */
+class KnownRelayersFetcherTest {
+
+    @Test
+    fun defaultURL_pointsAtGitHubReleasesLatestDownload() {
+        // Locked against silent rename — server-side this redirect
+        // is the entire deployment story; if the path here drifts,
+        // every install loses the ability to discover relayers.
+        assertEquals(
+            "https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json",
+            GitHubReleasesKnownRelayersFetcher.DEFAULT_URL,
+        )
+    }
+
+    @Test
+    fun fetch_happyPath_parsesTwoRelayerDocument() = runTest {
+        val json = """
+            {
+              "version": 1,
+              "relayers": [
+                { "name": "Onym Official Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" },
+                { "name": "Onym Official Mainnet", "url": "https://relayer.onym.chat",         "network": "public"  }
+              ]
+            }
+        """.trimIndent()
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.ok(req, json) }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        val list = fetcher.fetch()
+        assertEquals(2, list.size)
+        assertEquals(RelayerEndpoint("Onym Official Testnet", "https://relayer-testnet.onym.chat", "testnet"), list[0])
+        assertEquals(RelayerEndpoint("Onym Official Mainnet", "https://relayer.onym.chat", "public"), list[1])
+    }
+
+    @Test
+    fun fetch_emptyRelayersArray_returnsEmptyList() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.ok(req, """{ "version": 1, "relayers": [] }""")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        assertTrue(fetcher.fetch().isEmpty())
+    }
+
+    @Test
+    fun fetch_404_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.status(req, 404, "Not Found")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        val thrown = assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        assertTrue("error message should reference 404", thrown.message?.contains("404") == true)
+    }
+
+    @Test
+    fun fetch_500_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.status(req, 500, "Internal Server Error")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        val thrown = assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        assertTrue(thrown.message?.contains("500") == true)
+    }
+
+    @Test
+    fun fetch_malformedJson_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.ok(req, "not really json {{{")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        Unit
+    }
+
+    @Test
+    fun fetch_missingRelayersField_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.ok(req, """{ "version": 1 }""")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(client)
+
+        assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        Unit
+    }
+
+    @Test
+    fun fetch_requestsTheConfiguredURL() = runTest {
+        var seen: Request? = null
+        val client = FakeOkHttpClient.build { req ->
+            seen = req
+            FakeOkHttpClient.ok(req, """{ "version": 1, "relayers": [] }""")
+        }
+        val fetcher = GitHubReleasesKnownRelayersFetcher(
+            client,
+            url = "https://example.com/custom/relayers.json",
+        )
+
+        fetcher.fetch()
+        assertEquals("https://example.com/custom/relayers.json", seen?.url.toString())
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
@@ -1,0 +1,206 @@
+package chat.onym.android.chain
+
+import chat.onym.android.support.FakeKnownRelayersFetcher
+import chat.onym.android.support.InMemoryRelayerSelectionStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Repository contract against the in-memory fakes. Same shape as
+ * [chat.onym.android.identity.IdentityRepository]'s test pattern —
+ * Mutex + StateFlow emission discipline.
+ *
+ * Mirrors `RelayerRepositoryTests` from onym-ios PR #18.
+ */
+class RelayerRepositoryTest {
+
+    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+    private val mainnet = RelayerEndpoint("Onym Mainnet", "https://relayer.onym.chat", "public")
+
+    // ─── bootstrap ────────────────────────────────────────────────
+
+    @Test
+    fun bootstrap_hydratesCachedAndSelectionFromStore() = runTest {
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveCachedKnownRelayers(listOf(testnet, mainnet))
+            saveSelection(RelayerSelection.Known(testnet))
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Failing(IOException("offline")))
+        val repo = RelayerRepository(store, fetcher)
+
+        repo.bootstrap()
+
+        val state = repo.snapshots.value
+        assertEquals(listOf(testnet, mainnet), state.knownRelayers)
+        assertEquals(RelayerSelection.Known(testnet), state.selection)
+        assertEquals(0, fetcher.fetchCallCount)
+    }
+
+    // ─── start ────────────────────────────────────────────────────
+
+    @Test
+    fun start_persistsAndPushesFreshList() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(testnet, mainnet)))
+        val repo = RelayerRepository(store, fetcher)
+
+        repo.start()
+
+        assertEquals(listOf(testnet, mainnet), store.loadCachedKnownRelayers())
+        assertEquals(listOf(testnet, mainnet), repo.snapshots.value.knownRelayers)
+    }
+
+    @Test
+    fun start_isIdempotent_acrossMultipleCalls() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(testnet)))
+        val repo = RelayerRepository(store, fetcher)
+
+        repo.start()
+        repo.start()
+        repo.start()
+
+        assertEquals(
+            "start() must only fetch once across multiple calls",
+            1,
+            fetcher.fetchCallCount,
+        )
+    }
+
+    @Test
+    fun start_swallowsNetworkErrorsSilently() = runTest {
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveCachedKnownRelayers(listOf(testnet))
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Failing(IOException("offline")))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+
+        // Must NOT throw — app launch can't crash on a network blip.
+        repo.start()
+
+        // Cached list survives the failed fetch.
+        assertEquals(listOf(testnet), repo.snapshots.value.knownRelayers)
+        assertEquals(listOf(testnet), store.loadCachedKnownRelayers())
+    }
+
+    @Test
+    fun start_failureLeavesCachedListIntact() = runTest {
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveCachedKnownRelayers(listOf(mainnet))
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Failing(IOException("dns")))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+
+        repo.start()
+
+        // Selection (none) and known list (cached mainnet) both
+        // unchanged after the failed fetch.
+        assertEquals(listOf(mainnet), repo.snapshots.value.knownRelayers)
+        assertNull(repo.snapshots.value.selection)
+    }
+
+    // ─── refresh ──────────────────────────────────────────────────
+
+    @Test
+    fun refresh_succeeds_persistsAndPushes() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(testnet)))
+        val repo = RelayerRepository(store, fetcher)
+
+        repo.refresh()
+
+        assertEquals(listOf(testnet), repo.snapshots.value.knownRelayers)
+        assertEquals(listOf(testnet), store.loadCachedKnownRelayers())
+    }
+
+    @Test
+    fun refresh_propagatesFailureToCaller() = runTest {
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveCachedKnownRelayers(listOf(testnet))
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Failing(IOException("dns")))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+
+        var thrown: Throwable? = null
+        try { repo.refresh() } catch (t: Throwable) { thrown = t }
+
+        assertTrue("refresh must propagate so pull-to-refresh UI can react", thrown is IOException)
+        // Cached list still intact.
+        assertEquals(listOf(testnet), repo.snapshots.value.knownRelayers)
+    }
+
+    // ─── setSelection ─────────────────────────────────────────────
+
+    @Test
+    fun setSelection_persistsAndPushes() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(emptyList()))
+        val repo = RelayerRepository(store, fetcher)
+
+        repo.setSelection(RelayerSelection.Custom("https://custom.example"))
+
+        assertEquals(
+            RelayerSelection.Custom("https://custom.example"),
+            repo.snapshots.value.selection,
+        )
+        assertEquals(
+            RelayerSelection.Custom("https://custom.example"),
+            store.loadSelection(),
+        )
+    }
+
+    @Test
+    fun setSelection_nullClears() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(emptyList()))
+        val repo = RelayerRepository(store, fetcher)
+        repo.setSelection(RelayerSelection.Custom("https://x.example"))
+
+        repo.setSelection(null)
+
+        assertNull(repo.snapshots.value.selection)
+        assertNull(store.loadSelection())
+    }
+
+    // ─── StateFlow discipline ─────────────────────────────────────
+
+    @Test
+    fun snapshots_initialValue_isEmpty() {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(emptyList()))
+        val repo = RelayerRepository(store, fetcher)
+
+        val s = repo.snapshots.value
+        assertTrue(s.knownRelayers.isEmpty())
+        assertNull(s.selection)
+    }
+
+    @Test
+    fun snapshots_emitsAfterEachSuccessfulMutation() = runTest {
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(testnet)))
+        val repo = RelayerRepository(store, fetcher)
+
+        val initial = repo.snapshots.value
+        repo.start()
+        val afterStart = repo.snapshots.value
+        repo.setSelection(RelayerSelection.Known(testnet))
+        val afterSelection = repo.snapshots.value
+
+        // Three distinct snapshots.
+        assertTrue("start() should change the knownRelayers list",
+            initial.knownRelayers != afterStart.knownRelayers)
+        assertTrue("setSelection() should change selection",
+            afterStart.selection != afterSelection.selection)
+        // Identity sanity.
+        assertSame(repo.snapshots, repo.snapshots)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
@@ -1,0 +1,108 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.chain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * DataStore Preferences round-trip for the selection + cached
+ * known-list seam. Uses [PreferenceDataStoreFactory] against a
+ * per-test temp file so cases don't bleed into each other.
+ *
+ * Mirrors `RelayerSelectionStoreTests` from onym-ios PR #18.
+ */
+class RelayerSelectionStoreTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private lateinit var datastoreScope: CoroutineScope
+    private lateinit var datastoreScopeJob: Job
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var store: DataStorePreferencesRelayerSelectionStore
+
+    @Before
+    fun setUp() {
+        datastoreScopeJob = SupervisorJob()
+        datastoreScope = CoroutineScope(UnconfinedTestDispatcher() + datastoreScopeJob)
+        val file = tempFolder.newFile("relayer-${System.nanoTime()}.preferences_pb")
+        // PreferenceDataStoreFactory expects to own the file — passing
+        // the just-created empty file is fine; DataStore will write
+        // the protobuf header on first write.
+        file.delete()
+        dataStore = PreferenceDataStoreFactory.create(scope = datastoreScope) { file }
+        store = DataStorePreferencesRelayerSelectionStore(dataStore)
+    }
+
+    @After
+    fun tearDown() { datastoreScopeJob.cancel() }
+
+    // ─── selection ─────────────────────────────────────────────────
+
+    @Test
+    fun loadSelection_returnsNullOnFreshStore() = runTest {
+        assertNull(store.loadSelection())
+    }
+
+    @Test
+    fun saveAndLoad_known() = runTest {
+        val ep = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+        store.saveSelection(RelayerSelection.Known(ep))
+        val loaded = store.loadSelection() as RelayerSelection.Known
+        assertEquals(ep, loaded.endpoint)
+    }
+
+    @Test
+    fun saveAndLoad_custom() = runTest {
+        store.saveSelection(RelayerSelection.Custom("https://localhost:8080"))
+        val loaded = store.loadSelection() as RelayerSelection.Custom
+        assertEquals("https://localhost:8080", loaded.url)
+    }
+
+    @Test
+    fun saveSelection_nullClears() = runTest {
+        store.saveSelection(RelayerSelection.Custom("https://x.example"))
+        store.saveSelection(null)
+        assertNull(store.loadSelection())
+    }
+
+    // ─── cached known list ─────────────────────────────────────────
+
+    @Test
+    fun loadCachedKnownRelayers_returnsEmptyOnFreshStore() = runTest {
+        assertTrue(store.loadCachedKnownRelayers().isEmpty())
+    }
+
+    @Test
+    fun saveAndLoad_cachedKnownRelayers() = runTest {
+        val list = listOf(
+            RelayerEndpoint("A", "https://a.example", "testnet"),
+            RelayerEndpoint("B", "https://b.example", "public"),
+        )
+        store.saveCachedKnownRelayers(list)
+        assertEquals(list, store.loadCachedKnownRelayers())
+    }
+
+    @Test
+    fun saveCachedKnownRelayers_overwritesPreviousList() = runTest {
+        store.saveCachedKnownRelayers(listOf(RelayerEndpoint("A", "https://a.example", "testnet")))
+        val newList = listOf(RelayerEndpoint("B", "https://b.example", "public"))
+        store.saveCachedKnownRelayers(newList)
+        assertEquals(newList, store.loadCachedKnownRelayers())
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/settings/RelayerPickerViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/settings/RelayerPickerViewModelTest.kt
@@ -1,0 +1,215 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.settings
+
+import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerRepository
+import chat.onym.android.chain.RelayerSelection
+import chat.onym.android.support.FakeKnownRelayersFetcher
+import chat.onym.android.support.InMemoryRelayerSelectionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Picker ViewModel tests — intents, repository wiring, URL
+ * validation, draft prefill. The ViewModel uses
+ * [androidx.lifecycle.viewModelScope] which dispatches on
+ * `Dispatchers.Main` by default; tests override Main to
+ * [UnconfinedTestDispatcher] for deterministic ordering.
+ *
+ * Mirrors `RelayerPickerFlowTests` from onym-ios PR #18.
+ */
+class RelayerPickerViewModelTest {
+
+    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+    private val mainnet = RelayerEndpoint("Onym Mainnet", "https://relayer.onym.chat", "public")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ─── intents → repository ─────────────────────────────────────
+
+    @Test
+    fun pickKnown_dispatchesToRepository() = runTest {
+        val (repo, vm) = makeViewModel(seedKnown = listOf(testnet, mainnet))
+
+        vm.pickKnown(testnet)
+        yield()
+
+        assertEquals(RelayerSelection.Known(testnet), repo.snapshots.value.selection)
+    }
+
+    @Test
+    fun saveCustom_validInput_dispatchesToRepository() = runTest {
+        val (repo, vm) = makeViewModel()
+        vm.customDraftChanged("https://custom.example/relayer ")  // trailing whitespace
+        yield()
+
+        vm.saveCustom()
+        yield()
+
+        // Whitespace trimmed before persisting.
+        assertEquals(
+            RelayerSelection.Custom("https://custom.example/relayer"),
+            repo.snapshots.value.selection,
+        )
+    }
+
+    @Test
+    fun clearSelection_dispatchesNullToRepository() = runTest {
+        val (repo, vm) = makeViewModel()
+        vm.customDraftChanged("https://x.example")
+        yield()
+        vm.saveCustom(); yield()
+
+        vm.clearSelection()
+        yield()
+
+        assertNull(repo.snapshots.value.selection)
+    }
+
+    // ─── draft management ─────────────────────────────────────────
+
+    @Test
+    fun customDraft_changes_areLocalUntilSave() = runTest {
+        val (repo, vm) = makeViewModel()
+
+        vm.customDraftChanged("https://typing.example")
+        yield()
+
+        // Draft visible on the ViewModel; repo untouched.
+        assertEquals("https://typing.example", vm.state.value.customDraft)
+        assertNull(repo.snapshots.value.selection)
+    }
+
+    @Test
+    fun customDraft_changing_clearsStaleError() = runTest {
+        val (_, vm) = makeViewModel()
+        vm.customDraftChanged("ftp://no.example"); yield()
+        vm.saveCustom(); yield()
+        assertNotNull("error must surface after invalid save", vm.state.value.customDraftError)
+
+        vm.customDraftChanged("ftp://no.example/v2"); yield()
+
+        assertNull("typing should clear the prior error", vm.state.value.customDraftError)
+    }
+
+    @Test
+    fun draft_prefillFromExistingCustomSelection() = runTest {
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveSelection(RelayerSelection.Custom("https://existing.example"))
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(emptyList()))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+
+        val vm = RelayerPickerViewModel(repo)
+        yield()
+
+        assertEquals("https://existing.example", vm.state.value.customDraft)
+    }
+
+    @Test
+    fun draft_isEmptyWhenSelectionIsKnown() = runTest {
+        val (_, vm) = makeViewModel(seedKnown = listOf(testnet))
+        // No prior selection set; draft starts empty.
+
+        assertEquals("", vm.state.value.customDraft)
+    }
+
+    // ─── snapshot mirror ──────────────────────────────────────────
+
+    @Test
+    fun knownRelayers_areMirroredFromRepository() = runTest {
+        val (_, vm) = makeViewModel(seedKnown = listOf(testnet, mainnet))
+
+        assertEquals(listOf(testnet, mainnet), vm.state.value.knownRelayers)
+    }
+
+    // ─── URL validation ───────────────────────────────────────────
+
+    @Test
+    fun validate_rejectsEmpty() {
+        val r = RelayerPickerViewModel.validate("")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_rejectsBlank() {
+        val r = RelayerPickerViewModel.validate("   \t\n  ")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_rejectsGarbage() {
+        val r = RelayerPickerViewModel.validate("not a url at all")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_rejectsFtpScheme() {
+        val r = RelayerPickerViewModel.validate("ftp://relayer.example/")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_rejectsMissingScheme() {
+        val r = RelayerPickerViewModel.validate("relayer.example/path")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_rejectsMissingHost() {
+        val r = RelayerPickerViewModel.validate("https:///path")
+        assertTrue(r is RelayerPickerViewModel.ValidationResult.Invalid)
+    }
+
+    @Test
+    fun validate_acceptsHttpsAndHttpAndLocalhost() {
+        for (good in listOf(
+            "https://relayer.example",
+            "http://localhost:8080",
+            "https://relayer.example/path?x=1",
+        )) {
+            val r = RelayerPickerViewModel.validate(good)
+            assertTrue("expected $good to validate, got $r",
+                r is RelayerPickerViewModel.ValidationResult.Valid)
+        }
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private suspend fun makeViewModel(
+        seedKnown: List<RelayerEndpoint> = emptyList(),
+        seedSelection: RelayerSelection? = null,
+    ): Pair<RelayerRepository, RelayerPickerViewModel> {
+        val store = InMemoryRelayerSelectionStore().apply {
+            if (seedKnown.isNotEmpty()) saveCachedKnownRelayers(seedKnown)
+            if (seedSelection != null) saveSelection(seedSelection)
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(seedKnown))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+        val vm = RelayerPickerViewModel(repo)
+        yield()  // let the init { } collector hydrate
+        return repo to vm
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,14 @@ androidx-navigation-compose = "2.8.5"
 # OkHttp WebSocket — used by NostrRelayConnection. Same library
 # stellar-mls/clients/android uses; built-in `pingInterval` covers
 # the heartbeat so we don't need the iOS CFNetwork-pong workaround.
+# Also used by GitHubReleasesKnownRelayersFetcher (HTTPS GET).
 okhttp = "4.12.0"
+
+# DataStore Preferences — flow-based reads + suspending writes for
+# the Relayer URL selection. Not used for secret material (the
+# encrypted store is `EncryptedSharedPreferences` via
+# `IdentitySecretStore`); URLs aren't secret.
+androidx-datastore = "1.1.1"
 
 # OnymSDK — published to the static Maven repo at
 # raw.githubusercontent.com/onymchat/onym-sdk-kotlin/releases/
@@ -83,6 +90,12 @@ androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-viewmodel-compose" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation-compose" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+# OkHttp test scaffolding — `MockResponse` / `MockWebServer` not used
+# (too heavy for unit tests); we use a hand-rolled `Interceptor` in
+# `support/FakeOkHttpClient.kt` instead. No extra OkHttp test artifact
+# needed.
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
+androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-preferences-core", version.ref = "androidx-datastore" }
 
 # Compose UI test (versions managed by androidx-compose-bom)
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }


### PR DESCRIPTION
## Summary

First piece of the on-chain anchoring path: a user-facing **Network** section in Settings that lets the user pick a relayer URL. The published list of relayers is **discovered at runtime** from the latest GitHub Release of `onymchat/onym-relayer` — when a new release is published with a `relayers.json` asset, every install picks it up automatically without an app update. User can also enter a custom URL (private deployments, localhost dev, sideloaded networks).

This unblocks the chain interactor work — they read `RelayerRepository.snapshots.value.selection?.url` to decide where to POST.

Mirrors [onym-ios#18](https://github.com/onymchat/onym-ios/pull/18) 1:1 in shape; cross-platform `relayers.json` wire format identical.

## What lands

```
app/src/main/kotlin/chat/onym/android/
├── chain/
│   ├── RelayerEndpoint.kt                           ← @Serializable + sealed RelayerSelection + RelayerState
│   ├── RelayerSelectionStore.kt                     ← interface + DataStorePreferencesRelayerSelectionStore impl
│   ├── KnownRelayersFetcher.kt                      ← interface + GitHubReleasesKnownRelayersFetcher (OkHttp)
│   └── RelayerRepository.kt                         ← Mutex + StateFlow<RelayerState>; bootstrap/start/refresh/setSelection
└── settings/
    ├── RelayerPickerViewModel.kt                    ← intents + URL validation + draft prefill
    ├── RelayerPickerScreen.kt                       ← Compose: known list + custom URL TextField + Save
    └── SettingsScreen.kt (modified)                 ← + Network section (Relayer row)

app/src/sharedTest/kotlin/chat/onym/android/support/
├── InMemoryRelayerSelectionStore.kt                 ← reusable fake (Mutex + props)
├── FakeKnownRelayersFetcher.kt                      ← reusable fake (Succeeds / Failing / Scripted) + fetchCallCount
└── FakeOkHttpClient.kt                              ← OkHttp Interceptor wrapper (reusable for any HTTP test)

app/src/test/kotlin/chat/onym/android/
├── chain/RelayerSelectionStoreTest.kt               ← 7 cases against PreferenceDataStoreFactory + TemporaryFolder
├── chain/KnownRelayersFetcherTest.kt                ← 8 cases via FakeOkHttpClient
├── chain/RelayerRepositoryTest.kt                   ← 11 cases against in-memory fakes
└── settings/RelayerPickerViewModelTest.kt           ← 15 cases (intents + validation + prefill)
```

Total: 41 new tests (brief asked for 39; the +2 are extra assertion coverage on already-listed cases).

## Wire format

```json
{
  "version": 1,
  "relayers": [
    { "name": "Onym Official Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" },
    { "name": "Onym Official Mainnet", "url": "https://relayer.onym.chat",         "network": "public"  }
  ]
}
```

Field names exactly as shown — interop with the iOS picker rides on these. Fetched from `https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json` (public redirect, no GitHub API rate limit, always points at the latest release's asset). `KnownRelayersFetcherTest.defaultURL_pointsAtGitHubReleasesLatestDownload` pins this string against silent renames.

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Persistence seam** | `RelayerSelectionStore` (DataStore — URL isn't secret) | `androidx.datastore` + `kotlinx.serialization` only |
| **Network seam** | `KnownRelayersFetcher` | OkHttp + kotlinx.serialization only |
| **Repository** | `RelayerRepository` | both seams + StateFlow |
| **ViewModel** | `RelayerPickerViewModel` | the repository + a String→URL validator |
| **Composable** | `RelayerPickerScreen` | the ViewModel only |
| **OnymSDK** | nothing | nothing |

`SettingsScreen` doesn't hold the repository — it gets `makeRelayerPickerViewModel: () -> RelayerPickerViewModel` from `AppDependencies` (the same factory pattern from prior PRs).

## Lifecycle

1. `OnymApplication.onCreate` constructs `RelayerRepository` once with the prod fetcher + DataStore-backed store.
2. `OnymApplication` launches a coroutine on a `SupervisorJob`-backed application scope: `repo.bootstrap()` (load cached + selection from disk) then `repo.start()` (fire the GitHub-Releases fetch). App launch never blocks on the network; failures are silent.
3. While the fetch is in flight, the picker shows whatever was cached on disk from the last successful run (empty list on first launch).
4. User opens Settings → Network → Relayer; picks a known relayer or types a custom URL.
5. Selection persists to DataStore; future chain code reads `repo.snapshots.value.selection?.url`.

## URL validation

`RelayerPickerViewModel.validate`: trim whitespace → require scheme is `http` or `https` (so `http://localhost:8080` works for dev) → require non-empty host. Rejects empty, blank, garbage, `ftp://`, missing scheme, missing host. Uses `java.net.URI` for parsing.

## The reusable test pattern

PR #16 introduced the `app/src/sharedTest/kotlin/` source set wired into both `test/` and `androidTest/`. This PR adds three more pieces of scaffolding for any future "talks to the chain" / "talks to a remote service" test:

- **`InMemoryRelayerSelectionStore`** — `Mutex`-guarded fake; same contract as `DataStorePreferencesRelayerSelectionStore`, no DataStore plumbing per test.
- **`FakeKnownRelayersFetcher`** — sealed `Mode` covers `Succeeds(list)` / `Failing(error)` / `Scripted(List<Result<…>>)`. Tracks `fetchCallCount` for idempotency assertions.
- **`FakeOkHttpClient`** — generic OkHttp `Interceptor` wrapper that returns canned `Response` objects per request — analogous to iOS's `StubURLProtocol`. Reusable beyond this PR; will power any future "fetch JSON from a service" test.

## Test plan

- [x] `./gradlew :app:assembleDebug` — production builds clean
- [x] `./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.chain.*' --tests 'chat.onym.android.settings.RelayerPickerViewModelTest'` — 41/41 pass
- [x] `./gradlew :app:testDebugUnitTest` — full unit suite green (41 new + pre-existing all pass)
- [x] `python3 scripts/lint-secrets.py` — exit 0
- [ ] Manual smoke: open the app, navigate Settings → Network → Relayer, see "Fetching list…" briefly then the published entries (will be empty until the first `relayers.json` asset is published — at which point the picker auto-populates without a new app release).

## Build deps

- `androidx.datastore:datastore-preferences` 1.1.1 — production + test (Android flavour for the production `Context.relayerDataStore` delegate).
- `androidx.datastore:datastore-preferences-core` 1.1.1 — test-only JVM flavour for `RelayerSelectionStoreTest`'s `PreferenceDataStoreFactory` against a per-test temp file.
- OkHttp + kotlinx.serialization were already present.

## Out of scope (intentionally — match iOS PR #18)

- **The chain client itself.** This PR delivers the URL config; the next PR ports the relayer HTTP client and binds it to `repo.snapshots.value.selection?.url`.
- **TLS pinning.** Stellar-mls's Android probably has cert pinning for production; defer to when production wiring lands.
- **Localization.** Network section header / footer / button labels are English-only inline strings for now (matches iOS PR #18). Lift into `res/values/strings.xml` + `values-ru/` when other Settings strings get translated.
- **Pull-to-refresh in the picker.** `RelayerRepository.refresh()` exists for this; UI hookup is a 5-minute follow-up if user demand surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)