### PR TITLE
settings: anchors picker (per-network, per-governance contract version selection)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -2,6 +2,7 @@ package chat.onym.android
 
 import androidx.fragment.app.FragmentActivity
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
+import chat.onym.android.settings.AnchorsPickerViewModel
 import chat.onym.android.settings.RelayerPickerViewModel
 import chat.onym.android.transport.nostr.NostrEphemeralSignerProvider
 
@@ -33,4 +34,5 @@ class AppDependencies(
     val nostrSignerProvider: NostrEphemeralSignerProvider,
     val makeRecoveryPhraseBackupViewModel: (activityProvider: () -> FragmentActivity) -> RecoveryPhraseBackupViewModel,
     val makeRelayerPickerViewModel: () -> RelayerPickerViewModel,
+    val makeAnchorsPickerViewModel: () -> AnchorsPickerViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -8,7 +8,10 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.FragmentActivity
+import chat.onym.android.chain.ContractsRepository
+import chat.onym.android.chain.DataStorePreferencesAnchorSelectionStore
 import chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore
+import chat.onym.android.chain.GitHubReleasesContractsManifestFetcher
 import chat.onym.android.chain.GitHubReleasesKnownRelayersFetcher
 import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.identity.IdentityRepository
@@ -18,6 +21,7 @@ import chat.onym.android.recovery.AndroidBiometricAuthenticator
 import chat.onym.android.recovery.AndroidClipboardWriter
 import chat.onym.android.recovery.AndroidStringProvider
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
+import chat.onym.android.settings.AnchorsPickerViewModel
 import chat.onym.android.settings.RelayerPickerViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,17 +33,27 @@ import java.lang.ref.WeakReference
 import java.security.Security
 
 /**
- * Single DataStore Preferences instance for non-secret app config
- * (today: relayer URL selection + cached known list). The
- * `preferencesDataStore` delegate guarantees one instance per
- * `Context` per filename across the process — safe to call from
- * anywhere; we only read it from [OnymApplication.onCreate].
+ * DataStore Preferences for the relayer URL selection + cached
+ * known-relayer list. The `preferencesDataStore` delegate
+ * guarantees one instance per `Context` per filename across the
+ * process — safe to call from anywhere; we only read it from
+ * [OnymApplication.onCreate].
  *
  * Identity material continues to live in EncryptedSharedPreferences
  * via [IdentitySecretStore]; URLs aren't secret so DataStore is fine.
  */
 private val Context.relayerDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "chat.onym.android.relayer_prefs",
+)
+
+/**
+ * DataStore Preferences for the anchor (contract version)
+ * selections + cached `contracts-manifest.json`. Separate file from
+ * [relayerDataStore] so each domain's storage layer has its own
+ * blob — easier to reason about + selectively wipe in tests.
+ */
+private val Context.contractsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "chat.onym.android.contracts_prefs",
 )
 
 /**
@@ -106,14 +120,14 @@ class OnymApplication : Application() {
         val clipboard = AndroidClipboardWriter(applicationContext)
         val strings = AndroidStringProvider(applicationContext)
 
-        // Relayer wiring — DataStore-backed selection + GitHub-Releases
-        // fetcher. Bootstrap (load cached + selection from disk) runs
-        // synchronously off the IO dispatcher; start() (network fetch)
-        // is fire-and-forget so app launch never blocks on the network.
+        val httpClient = OkHttpClient()
+
+        // Relayer wiring (PR #17). Bootstrap loads cached + selection
+        // from disk; start() fires the network fetch. Both run on the
+        // application scope so launch never blocks on the network.
         val relayerStore = DataStorePreferencesRelayerSelectionStore(
             dataStore = applicationContext.relayerDataStore,
         )
-        val httpClient = OkHttpClient()
         val relayerFetcher = GitHubReleasesKnownRelayersFetcher(httpClient = httpClient)
         val relayerRepository = RelayerRepository(
             store = relayerStore,
@@ -122,6 +136,22 @@ class OnymApplication : Application() {
         applicationScope.launch {
             relayerRepository.bootstrap()
             relayerRepository.start()
+        }
+
+        // Contracts/anchors wiring — same shape as the relayer block.
+        // Separate DataStore file so the two domains' storage layers
+        // are independent (one less coupling at audit time).
+        val contractsStore = DataStorePreferencesAnchorSelectionStore(
+            dataStore = applicationContext.contractsDataStore,
+        )
+        val contractsFetcher = GitHubReleasesContractsManifestFetcher(httpClient = httpClient)
+        val contractsRepository = ContractsRepository(
+            store = contractsStore,
+            fetcher = contractsFetcher,
+        )
+        applicationScope.launch {
+            contractsRepository.bootstrap()
+            contractsRepository.start()
         }
 
         dependencies = AppDependencies(
@@ -138,6 +168,9 @@ class OnymApplication : Application() {
             },
             makeRelayerPickerViewModel = {
                 RelayerPickerViewModel(repository = relayerRepository)
+            },
+            makeAnchorsPickerViewModel = {
+                AnchorsPickerViewModel(repository = contractsRepository)
             },
         )
     }

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -22,9 +22,15 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.GovernanceType
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.search.SearchScreen
+import chat.onym.android.settings.AnchorsNetworkScreen
+import chat.onym.android.settings.AnchorsPickerViewModel
+import chat.onym.android.settings.AnchorsRootScreen
+import chat.onym.android.settings.AnchorsVersionScreen
 import chat.onym.android.settings.RelayerPickerScreen
 import chat.onym.android.settings.RelayerPickerViewModel
 import chat.onym.android.settings.SettingsScreen
@@ -103,6 +109,7 @@ fun RootScreen(dependencies: AppDependencies) {
                 SettingsScreen(
                     onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
                     onRelayerClick = { navController.navigate(ROUTE_RELAYER_PICKER) },
+                    onAnchorsClick = { navController.navigate(ROUTE_ANCHORS_ROOT) },
                 )
             }
             composable(Tab.Search.route) {
@@ -116,6 +123,54 @@ fun RootScreen(dependencies: AppDependencies) {
                 )
                 RelayerPickerScreen(
                     viewModel = vm,
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
+            composable(ROUTE_ANCHORS_ROOT) {
+                val vm: AnchorsPickerViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeAnchorsPickerViewModel() }
+                    },
+                )
+                AnchorsRootScreen(
+                    viewModel = vm,
+                    onNetworkClick = { net ->
+                        navController.navigate("anchors_network/${net.wireValue}")
+                    },
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
+            composable("anchors_network/{network}") { entry ->
+                val networkArg = entry.arguments?.getString("network") ?: return@composable
+                val network = ContractNetwork.fromWire(networkArg) ?: return@composable
+                val vm: AnchorsPickerViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeAnchorsPickerViewModel() }
+                    },
+                )
+                AnchorsNetworkScreen(
+                    viewModel = vm,
+                    network = network,
+                    onTypeClick = { type ->
+                        navController.navigate("anchors_version/${network.wireValue}/${type.wireValue}")
+                    },
+                    onBackClick = { navController.popBackStack() },
+                )
+            }
+            composable("anchors_version/{network}/{type}") { entry ->
+                val networkArg = entry.arguments?.getString("network") ?: return@composable
+                val typeArg = entry.arguments?.getString("type") ?: return@composable
+                val network = ContractNetwork.fromWire(networkArg) ?: return@composable
+                val type = GovernanceType.fromWire(typeArg) ?: return@composable
+                val vm: AnchorsPickerViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeAnchorsPickerViewModel() }
+                    },
+                )
+                AnchorsVersionScreen(
+                    viewModel = vm,
+                    network = network,
+                    type = type,
                     onBackClick = { navController.popBackStack() },
                 )
             }
@@ -156,4 +211,5 @@ private enum class Tab(val route: String, val labelRes: Int) {
 
 private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
 private const val ROUTE_RELAYER_PICKER = "relayer_picker"
+private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private val TAB_ROUTES = setOf(Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/chain/AnchorSelection.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/AnchorSelection.kt
@@ -1,0 +1,62 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Identifies one selectable contract slot — the `(network,
+ * governanceType)` pair the user picks a release for. Used as the
+ * map key in [AnchorSelectionStore]; serialised to a deterministic
+ * string for the on-disk layout (see
+ * [DataStorePreferencesAnchorSelectionStore]).
+ */
+data class AnchorSelectionKey(
+    val network: ContractNetwork,
+    val type: GovernanceType,
+) {
+    /** `"<network>.<type>"` — used as the JSON-encoded preferences
+     *  map key. Stable across releases; do not change without a
+     *  data migration. */
+    fun storageKey(): String = "${network.wireValue}.${type.wireValue}"
+
+    companion object {
+        fun fromStorageKey(raw: String): AnchorSelectionKey? {
+            val parts = raw.split(".", limit = 2)
+            if (parts.size != 2) return null
+            val net = ContractNetwork.fromWire(parts[0]) ?: return null
+            val type = GovernanceType.fromWire(parts[1]) ?: return null
+            return AnchorSelectionKey(network = net, type = type)
+        }
+    }
+}
+
+/**
+ * Resolved triple a chat carries forever once it's anchored — the
+ * (network, governanceType, contractId) the chat will always update
+ * against, plus the release tag the contract came from for display
+ * and audit.
+ *
+ * **Per-chat binding invariant.** When `ChatGroup` lands (separate
+ * future PR), it carries an [AnchorBinding] copied at create-time
+ * from `ContractsRepository.binding(for = key)`. Settings changes
+ * after that never mutate the chat; the chat is the source of
+ * truth for "which contract do I update".
+ *
+ * Two write paths future code MUST respect:
+ *
+ *  - **Create chat**: read
+ *    `contractsRepository.snapshots.value.binding(for = key)` →
+ *    store as `chat.anchor`.
+ *  - **Update chat**: read `chat.anchor.contractId` +
+ *    `chat.anchor.network` directly. Current settings only seed
+ *    new chats.
+ *
+ * `@Serializable` so future Room storage of `ChatGroup` can
+ * round-trip the anchor without a custom converter.
+ */
+@Serializable
+data class AnchorBinding(
+    val network: ContractNetwork,
+    val governanceType: GovernanceType,
+    val contractId: String,
+    val release: String,
+)

--- a/app/src/main/kotlin/chat/onym/android/chain/AnchorSelectionStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/AnchorSelectionStore.kt
@@ -1,0 +1,105 @@
+package chat.onym.android.chain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Persistence seam for the anchor (contract version) selection +
+ * the cached contracts manifest. URLs / contract IDs aren't secret
+ * material — DataStore Preferences is plenty.
+ *
+ * Two pieces of state:
+ *
+ *  - **Selections**: `Map<AnchorSelectionKey, String>` — release
+ *    tag the user picked for each `(network, type)` slot. Empty
+ *    map means "no explicit selections; default-to-latest applies
+ *    everywhere" — see [ContractsRepository.binding].
+ *  - **Cached manifest**: the raw `contracts-manifest.json` body
+ *    the fetcher last successfully retrieved. Stored as the raw
+ *    JSON string + decoded on load (no double-encoding round
+ *    trip through the typed [ContractsManifest]).
+ */
+interface AnchorSelectionStore {
+    suspend fun loadSelections(): Map<AnchorSelectionKey, String>
+    suspend fun saveSelections(selections: Map<AnchorSelectionKey, String>)
+    suspend fun loadCachedManifest(): ContractsManifest?
+    suspend fun saveCachedManifest(rawJson: String)
+    suspend fun clear()
+}
+
+/**
+ * [DataStore]-backed [AnchorSelectionStore]. Selections persist
+ * as a single JSON-encoded `Map<String, String>` preference (the
+ * map keys are [AnchorSelectionKey.storageKey] strings — DataStore
+ * Preferences doesn't natively support `Map<...>`, and a JSON blob
+ * is simpler than flattening to N preference keys + cleaning up
+ * stale ones on selection delete).
+ *
+ * Cached manifest persists as the raw JSON body the fetcher
+ * received — decoded on load, no re-encode round trip.
+ */
+class DataStorePreferencesAnchorSelectionStore(
+    private val dataStore: DataStore<Preferences>,
+) : AnchorSelectionStore {
+
+    override suspend fun loadSelections(): Map<AnchorSelectionKey, String> {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_SELECTIONS] ?: return emptyMap()
+        return try {
+            jsonFormat
+                .decodeFromString(MAP_SERIALIZER, raw)
+                .mapNotNull { (k, v) ->
+                    AnchorSelectionKey.fromStorageKey(k)?.let { it to v }
+                }
+                .toMap()
+        } catch (_: SerializationException) {
+            emptyMap()
+        }
+    }
+
+    override suspend fun saveSelections(selections: Map<AnchorSelectionKey, String>) {
+        dataStore.edit { prefs ->
+            if (selections.isEmpty()) {
+                prefs.remove(KEY_SELECTIONS)
+            } else {
+                val stringified = selections.mapKeys { (k, _) -> k.storageKey() }
+                prefs[KEY_SELECTIONS] = jsonFormat.encodeToString(MAP_SERIALIZER, stringified)
+            }
+        }
+    }
+
+    override suspend fun loadCachedManifest(): ContractsManifest? {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_CACHED_MANIFEST] ?: return null
+        return try {
+            val rawManifest = jsonFormat.decodeFromString(RawContractsManifest.serializer(), raw)
+            ContractsManifest.fromRaw(rawManifest)
+        } catch (_: SerializationException) {
+            null
+        }
+    }
+
+    override suspend fun saveCachedManifest(rawJson: String) {
+        dataStore.edit { prefs ->
+            prefs[KEY_CACHED_MANIFEST] = rawJson
+        }
+    }
+
+    override suspend fun clear() {
+        dataStore.edit { it.clear() }
+    }
+
+    private companion object {
+        private val KEY_SELECTIONS = stringPreferencesKey("anchor_selections")
+        private val KEY_CACHED_MANIFEST = stringPreferencesKey("contracts_manifest_cached")
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+        private val MAP_SERIALIZER = MapSerializer(String.serializer(), String.serializer())
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/ContractEntry.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/ContractEntry.kt
@@ -1,0 +1,148 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.time.Instant
+import java.time.format.DateTimeParseException
+
+/**
+ * Soroban network the contract was deployed against. Wire format
+ * uses lowercase tags — `"testnet"` / `"public"` (Stellar's name
+ * for mainnet). Anything else is dropped at the fetcher boundary
+ * (forwards-compatibility — a future `"futurenet"` we don't know
+ * about doesn't break the picker for the networks we do).
+ */
+enum class ContractNetwork(val wireValue: String) {
+    Testnet("testnet"),
+    Public("public");
+
+    companion object {
+        fun fromWire(value: String): ContractNetwork? =
+            entries.firstOrNull { it.wireValue == value }
+    }
+}
+
+/**
+ * Governance scheme the contract implements. The five known kinds
+ * line up with the SDK modules (`Anarchy` / `OneOnOne` /
+ * `Tyranny` / `Democracy` / `Oligarchy`); a future sixth scheme
+ * would also need new ZK proof code in the SDK, so silently
+ * dropping unknowns at the boundary is correct — the picker
+ * couldn't show it anyway.
+ */
+enum class GovernanceType(val wireValue: String) {
+    Anarchy("anarchy"),
+    Democracy("democracy"),
+    Oligarchy("oligarchy"),
+    OneOnOne("oneonone"),
+    Tyranny("tyranny");
+
+    companion object {
+        fun fromWire(value: String): GovernanceType? =
+            entries.firstOrNull { it.wireValue == value }
+    }
+}
+
+/**
+ * One contract deployment: a `(network, type)` pair pointing at a
+ * Soroban contract address. The version (release tag) lives on
+ * the parent [ContractRelease].
+ */
+data class ContractEntry(
+    val network: ContractNetwork,
+    val type: GovernanceType,
+    val id: String,
+)
+
+/**
+ * One published release of `onymchat/onym-contracts`. `release` is
+ * the tag (e.g. `"v0.0.2"`); `publishedAt` orders releases (newest
+ * `publishedAt` wins the "default to latest" resolution rule);
+ * `contracts` is the list of `(network, type, id)` triples
+ * deployed in this release.
+ */
+data class ContractRelease(
+    val release: String,
+    val publishedAt: Instant,
+    val contracts: List<ContractEntry>,
+)
+
+/**
+ * Top-level shape of `contracts-manifest.json`. The `releases[]`
+ * array is the union of all historical releases, newest-first by
+ * convention but [ContractsManifest.Companion.fromRaw] re-sorts
+ * defensively. Manifest is regenerated and re-attached to the
+ * latest release on every new release of `onymchat/onym-contracts`
+ * (CI step in the contracts repo).
+ *
+ * Mirrors the iOS twin's `ContractsManifest`.
+ */
+data class ContractsManifest(
+    val version: Int,
+    val releases: List<ContractRelease>,
+) {
+    companion object {
+        /**
+         * Decode a [RawContractsManifest] (string-typed, tolerates
+         * unknown enum values), drop any contract entry whose
+         * `network` or `type` doesn't match a known case, drop any
+         * release whose `publishedAt` doesn't parse, and re-sort
+         * by [Instant.compareTo] descending.
+         *
+         * This is the boundary that turns the wire format into the
+         * typed domain — every consumer downstream (repository,
+         * ViewModel, screens) sees only valid `ContractNetwork` /
+         * `GovernanceType` values.
+         */
+        internal fun fromRaw(raw: RawContractsManifest): ContractsManifest {
+            val typedReleases = raw.releases.mapNotNull { rawRelease ->
+                val publishedAt = try {
+                    Instant.parse(rawRelease.publishedAt)
+                } catch (_: DateTimeParseException) {
+                    return@mapNotNull null
+                }
+                val typedContracts = rawRelease.contracts.mapNotNull { rawEntry ->
+                    val network = ContractNetwork.fromWire(rawEntry.network)
+                        ?: return@mapNotNull null
+                    val type = GovernanceType.fromWire(rawEntry.type)
+                        ?: return@mapNotNull null
+                    ContractEntry(network = network, type = type, id = rawEntry.id)
+                }
+                ContractRelease(
+                    release = rawRelease.release,
+                    publishedAt = publishedAt,
+                    contracts = typedContracts,
+                )
+            }.sortedByDescending { it.publishedAt }
+            return ContractsManifest(version = raw.version, releases = typedReleases)
+        }
+    }
+}
+
+// ─── Raw wire-format types (kotlinx.serialization throws on unknown
+//     enum values, so we decode strings and map to enums above) ────
+
+/**
+ * Wire-format counterpart of [ContractsManifest]. String-typed for
+ * `network` / `type` so unknown values can be filtered rather
+ * than throwing during decode.
+ */
+@Serializable
+internal data class RawContractsManifest(
+    val version: Int,
+    val releases: List<RawContractRelease> = emptyList(),
+)
+
+@Serializable
+internal data class RawContractRelease(
+    val release: String,
+    @SerialName("publishedAt") val publishedAt: String,
+    val contracts: List<RawContractEntry> = emptyList(),
+)
+
+@Serializable
+internal data class RawContractEntry(
+    val network: String,
+    val type: String,
+    val id: String,
+)

--- a/app/src/main/kotlin/chat/onym/android/chain/ContractsManifestFetcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/ContractsManifestFetcher.kt
@@ -1,0 +1,78 @@
+package chat.onym.android.chain
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+/**
+ * Network seam for "fetch the current contracts manifest". Same
+ * shape as [chat.onym.android.chain.KnownRelayersFetcher] from
+ * PR #17 — production impl talks to GitHub's
+ * `releases/latest/download/<asset>` redirect (public, no auth,
+ * no API rate limit), tests substitute a fake.
+ */
+interface ContractsManifestFetcher {
+    /**
+     * Returns the typed manifest plus the raw JSON body. Callers
+     * (i.e. [ContractsRepository]) cache the raw JSON to disk so
+     * subsequent decodes don't have to re-encode the typed value.
+     */
+    suspend fun fetch(): FetchResult
+
+    /** Typed manifest + raw JSON pair. */
+    data class FetchResult(val manifest: ContractsManifest, val rawJson: String)
+}
+
+/**
+ * Pulls `contracts-manifest.json` from the latest GitHub Release
+ * of `onymchat/onym-contracts`. Default URL is the
+ * `releases/latest/download/<asset>` redirect — server-side that
+ * resolves to whatever release is currently tagged "latest", so
+ * publishing a new release with the same asset filename + the CI
+ * step that re-attaches the regenerated manifest is the entire
+ * deployment story (no app update).
+ *
+ * @param httpClient OkHttp client, injected for tests.
+ * @param url Override only for tests; the production default is
+ *        load-bearing — see [DEFAULT_URL].
+ */
+class GitHubReleasesContractsManifestFetcher(
+    private val httpClient: OkHttpClient,
+    private val url: String = DEFAULT_URL,
+) : ContractsManifestFetcher {
+
+    override suspend fun fetch(): ContractsManifestFetcher.FetchResult = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url.toHttpUrl())
+            .header("Accept", "application/json")
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("GET $url returned HTTP ${response.code}")
+            }
+            val body = response.body?.string() ?: throw IOException("empty response body")
+            val raw = try {
+                jsonFormat.decodeFromString(RawContractsManifest.serializer(), body)
+            } catch (e: SerializationException) {
+                throw IOException("invalid contracts-manifest.json: ${e.message}", e)
+            }
+            ContractsManifestFetcher.FetchResult(
+                manifest = ContractsManifest.fromRaw(raw),
+                rawJson = body,
+            )
+        }
+    }
+
+    companion object {
+        /** Pinned by `ContractsManifestFetcherTest.defaultURL_…` —
+         *  renaming silently breaks every install. */
+        const val DEFAULT_URL = "https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json"
+
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/ContractsRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/ContractsRepository.kt
@@ -1,0 +1,150 @@
+package chat.onym.android.chain
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Snapshot the [ContractsRepository] publishes. Two parallel pieces
+ * of state plus a derived resolver:
+ *
+ *  - [manifest] — last successful fetch (or null until one lands).
+ *  - [selections] — user's explicit picks per `(network, type)`
+ *    slot. Empty map means "no explicit selections — default-to-
+ *    latest applies everywhere".
+ *
+ * [binding] is the load-bearing read path: chat-creation code calls
+ * `state.binding(forKey)` to resolve the triple a brand-new chat
+ * will carry forever. See the rules in the function's KDoc.
+ */
+data class ContractsState(
+    val manifest: ContractsManifest?,
+    val selections: Map<AnchorSelectionKey, String>,
+) {
+    /**
+     * Resolve the [AnchorBinding] for [forKey] — the triple a
+     * brand-new chat with this `(network, type)` slot would carry.
+     *
+     * Three rules, in order:
+     *
+     * 1. **Explicit selection wins** — if [selections] has an
+     *    entry for [forKey] AND the manifest has a release with
+     *    that tag AND that release has a contract for this
+     *    `(network, type)` → return it.
+     * 2. **Default to latest** — otherwise, find the latest
+     *    release (highest `publishedAt`) that has a contract for
+     *    this slot → return it.
+     * 3. **No contract** — otherwise, return `null`. UI surfaces
+     *    this as a disabled row ("No contracts yet" — typically
+     *    the case for Mainnet on the day this PR lands).
+     */
+    fun binding(forKey: AnchorSelectionKey): AnchorBinding? {
+        val mf = manifest ?: return null
+        val explicitTag = selections[forKey]
+        if (explicitTag != null) {
+            val release = mf.releases.firstOrNull { it.release == explicitTag }
+            val contract = release?.contracts?.firstOrNull {
+                it.network == forKey.network && it.type == forKey.type
+            }
+            if (release != null && contract != null) {
+                return AnchorBinding(
+                    network = forKey.network,
+                    governanceType = forKey.type,
+                    contractId = contract.id,
+                    release = release.release,
+                )
+            }
+            // Fall through — explicit pick was stale; the user gets
+            // default-to-latest behaviour until they re-pick.
+        }
+        // Releases are pre-sorted newest-first by ContractsManifest.fromRaw.
+        for (release in mf.releases) {
+            val contract = release.contracts.firstOrNull {
+                it.network == forKey.network && it.type == forKey.type
+            }
+            if (contract != null) {
+                return AnchorBinding(
+                    network = forKey.network,
+                    governanceType = forKey.type,
+                    contractId = contract.id,
+                    release = release.release,
+                )
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * Owns the contracts-manifest cache + the user's anchor selections.
+ * Same shape as [chat.onym.android.identity.IdentityRepository] —
+ * Mutex + StateFlow.
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds **only** [store] + [fetcher]. No transport, no OnymSDK,
+ *    no Compose, no `Context`.
+ *  - Exposes a [StateFlow] of [ContractsState] for observation.
+ *    [bootstrap] / [start] / [refresh] / [setSelection] /
+ *    [clearSelection] are the suspend mutators.
+ */
+class ContractsRepository(
+    private val store: AnchorSelectionStore,
+    private val fetcher: ContractsManifestFetcher,
+) {
+    private val mutex = Mutex()
+    private val _snapshots = MutableStateFlow(
+        ContractsState(manifest = null, selections = emptyMap())
+    )
+
+    val snapshots: StateFlow<ContractsState> = _snapshots.asStateFlow()
+
+    private var startInvoked = false
+
+    /** Hydrate from disk — cached manifest + selections. Idempotent. */
+    suspend fun bootstrap() = mutex.withLock {
+        val cached = store.loadCachedManifest()
+        val sel = store.loadSelections()
+        _snapshots.value = ContractsState(manifest = cached, selections = sel)
+    }
+
+    /** Fire-and-forget the GitHub-Releases fetch. Idempotent — a
+     *  second [start] returns immediately. Failures swallowed. */
+    suspend fun start() = mutex.withLock {
+        if (startInvoked) return@withLock
+        startInvoked = true
+        runCatching { fetcher.fetch() }.onSuccess { result ->
+            store.saveCachedManifest(result.rawJson)
+            _snapshots.value = _snapshots.value.copy(manifest = result.manifest)
+        }
+    }
+
+    /** User-initiated refresh. Failures propagate so a pull-to-
+     *  refresh UI can show the error. */
+    suspend fun refresh() {
+        val result = fetcher.fetch()
+        mutex.withLock {
+            store.saveCachedManifest(result.rawJson)
+            _snapshots.value = _snapshots.value.copy(manifest = result.manifest)
+        }
+    }
+
+    /** Pick a release tag for a slot. Persists + pushes. */
+    suspend fun setSelection(key: AnchorSelectionKey, releaseTag: String) = mutex.withLock {
+        val updated = _snapshots.value.selections + (key to releaseTag)
+        store.saveSelections(updated)
+        _snapshots.value = _snapshots.value.copy(selections = updated)
+    }
+
+    /** "Reset to default" for a slot — clear the explicit pick so
+     *  default-to-latest takes over. No-op if no pick existed. */
+    suspend fun clearSelection(key: AnchorSelectionKey) = mutex.withLock {
+        val current = _snapshots.value.selections
+        if (key !in current) return@withLock
+        val updated = current - key
+        store.saveSelections(updated)
+        _snapshots.value = _snapshots.value.copy(selections = updated)
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/AnchorsPickerViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AnchorsPickerViewModel.kt
@@ -1,0 +1,145 @@
+package chat.onym.android.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.chain.AnchorBinding
+import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.ContractEntry
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.ContractRelease
+import chat.onym.android.chain.ContractsRepository
+import chat.onym.android.chain.GovernanceType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the Anchors drill-down. Holds **flow** state
+ * (snapshot mirror); domain state lives on [ContractsRepository].
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds **only** [repository].
+ *  - No `Context`, no DataStore, no OkHttp.
+ *  - Stateless w.r.t. navigation — Compose's NavController owns
+ *    the back stack; this ViewModel just answers per-screen
+ *    queries against the snapshot.
+ */
+class AnchorsPickerViewModel(
+    private val repository: ContractsRepository,
+) : ViewModel() {
+
+    /** Top-level state mirror. */
+    data class State(
+        val hasManifest: Boolean,
+        val networkAvailability: Map<ContractNetwork, Boolean>,
+    )
+
+    private val _state = MutableStateFlow(
+        State(
+            hasManifest = false,
+            networkAvailability = ContractNetwork.entries.associateWith { false },
+        )
+    )
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.snapshots.collect { snapshot ->
+                val mf = snapshot.manifest
+                _state.value = State(
+                    hasManifest = mf != null,
+                    networkAvailability = ContractNetwork.entries.associateWith { network ->
+                        mf?.releases?.any { release ->
+                            release.contracts.any { it.network == network }
+                        } == true
+                    },
+                )
+            }
+        }
+    }
+
+    // ─── Network screen ───────────────────────────────────────────
+
+    /** Per-row data for the Network screen — one row per
+     *  [GovernanceType]. */
+    data class NetworkRow(
+        val type: GovernanceType,
+        val resolvedRelease: String?,    // null if no contract for this slot
+        val isExplicit: Boolean,         // true if user picked; false if defaulted
+    )
+
+    /** Snapshot the Network screen renders. Recomputed on every
+     *  call against the current [ContractsRepository] snapshot;
+     *  composables can call this from their `remember` block. */
+    fun networkRows(network: ContractNetwork): List<NetworkRow> {
+        val snapshot = repository.snapshots.value
+        return GovernanceType.entries.map { type ->
+            val key = AnchorSelectionKey(network = network, type = type)
+            val binding = snapshot.binding(forKey = key)
+            NetworkRow(
+                type = type,
+                resolvedRelease = binding?.release,
+                isExplicit = key in snapshot.selections,
+            )
+        }
+    }
+
+    // ─── Version screen ───────────────────────────────────────────
+
+    /** Per-row data for the Version screen — one row per release
+     *  that has a contract for this `(network, type)` slot. */
+    data class VersionRow(
+        val release: ContractRelease,
+        val entry: ContractEntry,
+        val isCurrentlySelected: Boolean,    // matches resolved binding
+        val isExplicitPick: Boolean,         // matches explicit selection (not defaulted)
+    )
+
+    fun versionRows(network: ContractNetwork, type: GovernanceType): List<VersionRow> {
+        val snapshot = repository.snapshots.value
+        val mf = snapshot.manifest ?: return emptyList()
+        val key = AnchorSelectionKey(network = network, type = type)
+        val resolved = snapshot.binding(forKey = key)
+        val explicitTag = snapshot.selections[key]
+        return mf.releases.mapNotNull { release ->
+            val entry = release.contracts.firstOrNull {
+                it.network == network && it.type == type
+            } ?: return@mapNotNull null
+            VersionRow(
+                release = release,
+                entry = entry,
+                isCurrentlySelected = release.release == resolved?.release,
+                isExplicitPick = release.release == explicitTag,
+            )
+        }
+    }
+
+    /** Read-only resolution helper — the binding a brand-new chat
+     *  with this slot would carry today. UI uses it for the
+     *  "currently resolved" subtitle. */
+    fun currentBinding(network: ContractNetwork, type: GovernanceType): AnchorBinding? =
+        repository.snapshots.value.binding(
+            forKey = AnchorSelectionKey(network = network, type = type)
+        )
+
+    // ─── Intents ──────────────────────────────────────────────────
+
+    fun pickVersion(network: ContractNetwork, type: GovernanceType, releaseTag: String) {
+        viewModelScope.launch {
+            repository.setSelection(
+                key = AnchorSelectionKey(network = network, type = type),
+                releaseTag = releaseTag,
+            )
+        }
+    }
+
+    fun resetToDefault(network: ContractNetwork, type: GovernanceType) {
+        viewModelScope.launch {
+            repository.clearSelection(
+                key = AnchorSelectionKey(network = network, type = type),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
@@ -1,0 +1,365 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.GovernanceType
+
+/**
+ * Three-level drill-down for the Anchors picker. Composables
+ * receive the navigate callbacks from `RootScreen` rather than a
+ * `NavController` — keeps the screens unit-testable in isolation.
+ *
+ * Strings inline (English-only for now per the brief / iOS twin).
+ */
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnchorsRootScreen(
+    viewModel: AnchorsPickerViewModel,
+    onNetworkClick: (ContractNetwork) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Anchors") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(contentPadding = padding) {
+            item { SectionHeader("NETWORK") }
+            items(ContractNetwork.entries) { network ->
+                val available = state.networkAvailability[network] == true
+                NetworkRootRow(
+                    network = network,
+                    available = available,
+                    onClick = if (available) {
+                        { onNetworkClick(network) }
+                    } else null,
+                )
+            }
+            item {
+                Footer(
+                    "Pick the smart contract version each new chat is anchored to. " +
+                        "Existing chats stay on whatever version they were created with."
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnchorsNetworkScreen(
+    viewModel: AnchorsPickerViewModel,
+    network: ContractNetwork,
+    onTypeClick: (GovernanceType) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    // Re-collect on each repo snapshot so the resolved-release labels
+    // stay live as the user picks versions in the deeper screen.
+    viewModel.state.collectAsStateWithLifecycle()
+    val rows = viewModel.networkRows(network)
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(networkDisplayName(network)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(contentPadding = padding) {
+            item { SectionHeader("GOVERNANCE TYPE") }
+            items(rows, key = { it.type.wireValue }) { row ->
+                GovernanceTypeRow(
+                    type = row.type,
+                    resolvedRelease = row.resolvedRelease,
+                    isExplicit = row.isExplicit,
+                    onClick = if (row.resolvedRelease != null) {
+                        { onTypeClick(row.type) }
+                    } else null,
+                )
+            }
+            item {
+                Footer(
+                    "Each governance type uses a separate contract. The release tag in " +
+                        "parentheses is the version a brand-new chat would be anchored to."
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AnchorsVersionScreen(
+    viewModel: AnchorsPickerViewModel,
+    network: ContractNetwork,
+    type: GovernanceType,
+    onBackClick: () -> Unit,
+) {
+    viewModel.state.collectAsStateWithLifecycle()
+    val rows = viewModel.versionRows(network, type)
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(governanceDisplayName(type)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(contentPadding = padding) {
+            item { SectionHeader("RELEASES") }
+            items(rows, key = { it.release.release }) { row ->
+                VersionRow(
+                    label = row.release.release,
+                    contractId = row.entry.id,
+                    isCurrentlySelected = row.isCurrentlySelected,
+                    onClick = {
+                        viewModel.pickVersion(network, type, row.release.release)
+                        onBackClick()
+                    },
+                )
+            }
+            item { SectionHeader("RESET") }
+            item {
+                ResetRow(
+                    onClick = {
+                        viewModel.resetToDefault(network, type)
+                        onBackClick()
+                    },
+                )
+            }
+            item {
+                Footer(
+                    "Reset clears the explicit pick — new chats fall back to the latest published release."
+                )
+            }
+        }
+    }
+}
+
+// ─── pieces ─────────────────────────────────────────────────────
+
+@Composable
+private fun NetworkRootRow(
+    network: ContractNetwork,
+    available: Boolean,
+    onClick: (() -> Unit)?,
+) {
+    val titleColor = if (available) MaterialTheme.colorScheme.onSurface
+                     else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(networkDisplayName(network),
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                color = titleColor)
+            if (!available) {
+                Text("No contracts yet",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        if (available) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun GovernanceTypeRow(
+    type: GovernanceType,
+    resolvedRelease: String?,
+    isExplicit: Boolean,
+    onClick: (() -> Unit)?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(governanceDisplayName(type),
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
+            val subtitle = when {
+                resolvedRelease == null -> "No contract"
+                isExplicit -> "$resolvedRelease (selected)"
+                else -> "$resolvedRelease (latest)"
+            }
+            Text(subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        if (onClick != null) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VersionRow(
+    label: String,
+    contractId: String,
+    isCurrentlySelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(label,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
+            Text(contractId,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        if (isCurrentlySelected) {
+            Box(
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(RoundedCornerShape(11.dp))
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = "Selected",
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResetRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Text("Reset to default",
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+            color = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp)
+            .padding(top = 16.dp, bottom = 6.dp),
+    )
+}
+
+@Composable
+private fun Footer(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+    )
+}
+
+private fun networkDisplayName(network: ContractNetwork): String = when (network) {
+    ContractNetwork.Testnet -> "Testnet"
+    ContractNetwork.Public -> "Mainnet"
+}
+
+private fun governanceDisplayName(type: GovernanceType): String = when (type) {
+    GovernanceType.Anarchy -> "Anarchy"
+    GovernanceType.Democracy -> "Democracy"
+    GovernanceType.Oligarchy -> "Oligarchy"
+    GovernanceType.OneOnOne -> "One-on-one"
+    GovernanceType.Tyranny -> "Tyranny"
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material3.Icon
@@ -57,6 +58,7 @@ import chat.onym.android.R
 fun SettingsScreen(
     onBackupClick: () -> Unit,
     onRelayerClick: () -> Unit,
+    onAnchorsClick: () -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
@@ -143,6 +145,39 @@ fun SettingsScreen(
             item {
                 Text(
                     "Where chain operations are submitted. Discovered from GitHub Releases of onymchat/onym-relayer; can be overridden with a custom URL.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                )
+            }
+            item {
+                ListItem(
+                    headlineContent = { Text("Anchors") },
+                    leadingContent = {
+                        SettingsIconBox(
+                            icon = Icons.Filled.Anchor,
+                            background = Color(0xFF5856D6),
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(onClick = onAnchorsClick),
+                )
+            }
+            item {
+                Text(
+                    "Smart-contract version each new chat is anchored to. Picks per (network, governance type); existing chats stay on whatever they were created with.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeContractsManifestFetcher.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeContractsManifestFetcher.kt
@@ -1,0 +1,53 @@
+package chat.onym.android.support
+
+import chat.onym.android.chain.ContractsManifest
+import chat.onym.android.chain.ContractsManifestFetcher
+
+/**
+ * Reusable test fake for [ContractsManifestFetcher]. Three modes
+ * mirror [FakeKnownRelayersFetcher] from PR #17.
+ */
+class FakeContractsManifestFetcher(var mode: Mode) : ContractsManifestFetcher {
+
+    sealed class Mode {
+        /** Return [manifest] paired with [rawJson] (defaults to a
+         *  trivial JSON literal — the repository persists it via
+         *  the store but tests rarely care about the exact bytes). */
+        data class Succeeds(
+            val manifest: ContractsManifest,
+            val rawJson: String = """{"version":1,"releases":[]}""",
+        ) : Mode()
+
+        data class Failing(val error: Throwable) : Mode()
+
+        data class Scripted(
+            val responses: List<Result<ContractsManifestFetcher.FetchResult>>,
+        ) : Mode()
+    }
+
+    var fetchCallCount: Int = 0
+        private set
+
+    private var scriptedIndex = 0
+
+    override suspend fun fetch(): ContractsManifestFetcher.FetchResult {
+        fetchCallCount += 1
+        return when (val m = mode) {
+            is Mode.Succeeds -> ContractsManifestFetcher.FetchResult(
+                manifest = m.manifest,
+                rawJson = m.rawJson,
+            )
+            is Mode.Failing -> throw m.error
+            is Mode.Scripted -> {
+                if (scriptedIndex >= m.responses.size) {
+                    throw IllegalStateException(
+                        "FakeContractsManifestFetcher: scripted responses exhausted (${m.responses.size} consumed)"
+                    )
+                }
+                val r = m.responses[scriptedIndex]
+                scriptedIndex += 1
+                r.getOrThrow()
+            }
+        }
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryAnchorSelectionStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryAnchorSelectionStore.kt
@@ -1,0 +1,58 @@
+package chat.onym.android.support
+
+import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.AnchorSelectionStore
+import chat.onym.android.chain.ContractsManifest
+import chat.onym.android.chain.RawContractsManifest
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Reusable in-memory [AnchorSelectionStore]. Same contract as
+ * [chat.onym.android.chain.DataStorePreferencesAnchorSelectionStore],
+ * no DataStore / no disk — fast tests of the
+ * [chat.onym.android.chain.ContractsRepository] semantics without
+ * the persistence-plumbing tax.
+ *
+ * Caches the manifest as the raw JSON the fetcher returned (same
+ * model the production store uses) so the round-trip path matches:
+ * load decodes through [ContractsManifest.fromRaw] and drops
+ * unknown enum values exactly like production.
+ */
+class InMemoryAnchorSelectionStore : AnchorSelectionStore {
+
+    private val mutex = Mutex()
+    private var selections: Map<AnchorSelectionKey, String> = emptyMap()
+    private var cachedManifestJson: String? = null
+
+    override suspend fun loadSelections(): Map<AnchorSelectionKey, String> =
+        mutex.withLock { selections }
+
+    override suspend fun saveSelections(selections: Map<AnchorSelectionKey, String>) {
+        mutex.withLock { this.selections = selections.toMap() }
+    }
+
+    override suspend fun loadCachedManifest(): ContractsManifest? = mutex.withLock {
+        val raw = cachedManifestJson ?: return@withLock null
+        return try {
+            val rawManifest = Json { ignoreUnknownKeys = true }
+                .decodeFromString(RawContractsManifest.serializer(), raw)
+            ContractsManifest.fromRaw(rawManifest)
+        } catch (_: SerializationException) {
+            null
+        }
+    }
+
+    override suspend fun saveCachedManifest(rawJson: String) {
+        mutex.withLock { cachedManifestJson = rawJson }
+    }
+
+    override suspend fun clear() {
+        mutex.withLock {
+            selections = emptyMap()
+            cachedManifestJson = null
+        }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/AnchorSelectionStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/AnchorSelectionStoreTest.kt
@@ -1,0 +1,120 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.chain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * DataStore round-trip for the anchor selections + cached manifest
+ * seam. Same `PreferenceDataStoreFactory` + `TemporaryFolder`
+ * pattern as [RelayerSelectionStoreTest].
+ */
+class AnchorSelectionStoreTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private lateinit var datastoreScopeJob: Job
+    private lateinit var datastoreScope: CoroutineScope
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var store: DataStorePreferencesAnchorSelectionStore
+
+    private val k1 = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+    private val k2 = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Democracy)
+
+    @Before
+    fun setUp() {
+        datastoreScopeJob = SupervisorJob()
+        datastoreScope = CoroutineScope(UnconfinedTestDispatcher() + datastoreScopeJob)
+        val file = tempFolder.newFile("anchors-${System.nanoTime()}.preferences_pb")
+        file.delete()
+        dataStore = PreferenceDataStoreFactory.create(scope = datastoreScope) { file }
+        store = DataStorePreferencesAnchorSelectionStore(dataStore)
+    }
+
+    @After
+    fun tearDown() { datastoreScopeJob.cancel() }
+
+    // ─── selections ────────────────────────────────────────────────
+
+    @Test
+    fun loadSelections_returnsEmptyOnFreshStore() = runTest {
+        assertTrue(store.loadSelections().isEmpty())
+    }
+
+    @Test
+    fun saveAndLoad_singleSelection() = runTest {
+        store.saveSelections(mapOf(k1 to "v0.0.2"))
+        val loaded = store.loadSelections()
+        assertEquals(mapOf(k1 to "v0.0.2"), loaded)
+    }
+
+    @Test
+    fun saveAndLoad_multipleSelections() = runTest {
+        store.saveSelections(mapOf(k1 to "v0.0.2", k2 to "v0.0.1"))
+        assertEquals(mapOf(k1 to "v0.0.2", k2 to "v0.0.1"), store.loadSelections())
+    }
+
+    @Test
+    fun saveSelections_overwritesPreviousMap() = runTest {
+        store.saveSelections(mapOf(k1 to "v0.0.1"))
+        store.saveSelections(mapOf(k1 to "v0.0.2", k2 to "v0.0.2"))
+        assertEquals(mapOf(k1 to "v0.0.2", k2 to "v0.0.2"), store.loadSelections())
+    }
+
+    @Test
+    fun saveSelections_emptyClearsAll() = runTest {
+        store.saveSelections(mapOf(k1 to "v0.0.2"))
+        store.saveSelections(emptyMap())
+        assertTrue(store.loadSelections().isEmpty())
+    }
+
+    // ─── cached manifest ───────────────────────────────────────────
+
+    @Test
+    fun loadCachedManifest_returnsNullOnFreshStore() = runTest {
+        assertNull(store.loadCachedManifest())
+    }
+
+    @Test
+    fun saveAndLoad_cachedManifest_decodesUnknownDropped() = runTest {
+        // Includes an unknown network ("futurenet") that must be
+        // dropped on load through ContractsManifest.fromRaw.
+        val raw = """
+            {
+              "version": 1,
+              "releases": [
+                {
+                  "release": "v0.0.2",
+                  "publishedAt": "2026-05-01T15:29:00Z",
+                  "contracts": [
+                    { "network": "testnet",   "type": "anarchy", "id": "C-A-2" },
+                    { "network": "futurenet", "type": "anarchy", "id": "C-A-FUTURE" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        store.saveCachedManifest(raw)
+        val loaded = store.loadCachedManifest()
+        assertNotNull(loaded)
+        assertEquals(1, loaded!!.releases.single().contracts.size)
+        assertEquals(ContractNetwork.Testnet, loaded.releases.single().contracts.single().network)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/ContractEntryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/ContractEntryTest.kt
@@ -1,0 +1,135 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Wire-format → typed-domain mapping for [ContractsManifest]. The
+ * raw decoder ([RawContractsManifest]) tolerates unknown enum
+ * values (kotlinx.serialization throws on enums by default); the
+ * typed [ContractsManifest.fromRaw] mapping then drops contract
+ * entries whose `network` or `type` doesn't match a known case.
+ */
+class ContractEntryTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_happyPath_twoReleaseFixture() {
+        val src = """
+            {
+              "version": 1,
+              "releases": [
+                {
+                  "release": "v0.0.2",
+                  "publishedAt": "2026-05-01T15:29:00Z",
+                  "contracts": [
+                    { "network": "testnet", "type": "anarchy",   "id": "C-A-2" },
+                    { "network": "testnet", "type": "democracy", "id": "C-D-2" }
+                  ]
+                },
+                {
+                  "release": "v0.0.1",
+                  "publishedAt": "2026-05-01T11:43:00Z",
+                  "contracts": [
+                    { "network": "testnet", "type": "anarchy", "id": "C-A-1" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val raw = json.decodeFromString(RawContractsManifest.serializer(), src)
+        val typed = ContractsManifest.fromRaw(raw)
+
+        assertEquals(2, typed.releases.size)
+        // Sorted newest-first by publishedAt.
+        assertEquals("v0.0.2", typed.releases[0].release)
+        assertEquals("v0.0.1", typed.releases[1].release)
+        assertEquals(Instant.parse("2026-05-01T15:29:00Z"), typed.releases[0].publishedAt)
+        assertEquals(2, typed.releases[0].contracts.size)
+        val anarchy = typed.releases[0].contracts.first {
+            it.network == ContractNetwork.Testnet && it.type == GovernanceType.Anarchy
+        }
+        assertEquals("C-A-2", anarchy.id)
+    }
+
+    @Test
+    fun decode_unknownNetwork_dropsEntry() {
+        val src = """
+            {
+              "version": 1,
+              "releases": [
+                {
+                  "release": "v0.0.2",
+                  "publishedAt": "2026-05-01T15:29:00Z",
+                  "contracts": [
+                    { "network": "futurenet", "type": "anarchy",   "id": "C-A-FUTURE" },
+                    { "network": "testnet",   "type": "democracy", "id": "C-D-2" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val typed = ContractsManifest.fromRaw(json.decodeFromString(RawContractsManifest.serializer(), src))
+        assertEquals(1, typed.releases.single().contracts.size)
+        assertEquals(GovernanceType.Democracy, typed.releases.single().contracts.single().type)
+    }
+
+    @Test
+    fun decode_unknownType_dropsEntry() {
+        val src = """
+            {
+              "version": 1,
+              "releases": [
+                {
+                  "release": "v0.0.2",
+                  "publishedAt": "2026-05-01T15:29:00Z",
+                  "contracts": [
+                    { "network": "testnet", "type": "monarchy", "id": "C-M" },
+                    { "network": "testnet", "type": "tyranny",  "id": "C-T-2" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val typed = ContractsManifest.fromRaw(json.decodeFromString(RawContractsManifest.serializer(), src))
+        assertEquals(1, typed.releases.single().contracts.size)
+        assertEquals(GovernanceType.Tyranny, typed.releases.single().contracts.single().type)
+    }
+
+    @Test
+    fun decode_outOfOrderReleases_areReSorted() {
+        val src = """
+            {
+              "version": 1,
+              "releases": [
+                { "release": "v0.0.1", "publishedAt": "2026-05-01T11:43:00Z", "contracts": [] },
+                { "release": "v0.0.3", "publishedAt": "2026-05-02T08:00:00Z", "contracts": [] },
+                { "release": "v0.0.2", "publishedAt": "2026-05-01T15:29:00Z", "contracts": [] }
+              ]
+            }
+        """.trimIndent()
+        val typed = ContractsManifest.fromRaw(json.decodeFromString(RawContractsManifest.serializer(), src))
+        assertEquals(listOf("v0.0.3", "v0.0.2", "v0.0.1"), typed.releases.map { it.release })
+    }
+
+    @Test
+    fun decode_unparseablePublishedAt_dropsRelease() {
+        val src = """
+            {
+              "version": 1,
+              "releases": [
+                { "release": "v0.0.bad", "publishedAt": "not a date", "contracts": [] },
+                { "release": "v0.0.2",   "publishedAt": "2026-05-01T15:29:00Z", "contracts": [] }
+              ]
+            }
+        """.trimIndent()
+        val typed = ContractsManifest.fromRaw(json.decodeFromString(RawContractsManifest.serializer(), src))
+        assertEquals(1, typed.releases.size)
+        assertEquals("v0.0.2", typed.releases.single().release)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/ContractsManifestFetcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/ContractsManifestFetcherTest.kt
@@ -1,0 +1,117 @@
+package chat.onym.android.chain
+
+import chat.onym.android.support.FakeOkHttpClient
+import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * Wire-format pin for the GitHub-Releases-backed contracts manifest
+ * fetcher. Reuses [FakeOkHttpClient] from PR #17's sharedTest.
+ */
+class ContractsManifestFetcherTest {
+
+    @Test
+    fun defaultURL_pointsAtGitHubReleasesLatestDownload() {
+        // Locked against silent rename — the redirect IS the
+        // deployment story; renaming this URL silently breaks
+        // every install.
+        assertEquals(
+            "https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json",
+            GitHubReleasesContractsManifestFetcher.DEFAULT_URL,
+        )
+    }
+
+    @Test
+    fun fetch_happyPath_returnsTypedManifestPlusRawJson() = runTest {
+        val rawJson = """
+            {
+              "version": 1,
+              "releases": [
+                {
+                  "release": "v0.0.2",
+                  "publishedAt": "2026-05-01T15:29:00Z",
+                  "contracts": [
+                    { "network": "testnet", "type": "anarchy", "id": "C-A-2" }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.ok(req, rawJson) }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+
+        val result = fetcher.fetch()
+        assertEquals(rawJson, result.rawJson)
+        assertEquals(1, result.manifest.releases.size)
+        assertEquals("v0.0.2", result.manifest.releases.single().release)
+    }
+
+    @Test
+    fun fetch_emptyReleasesArray_returnsEmptyManifest() = runTest {
+        val client = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.ok(req, """{ "version": 1, "releases": [] }""")
+        }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+        assertTrue(fetcher.fetch().manifest.releases.isEmpty())
+    }
+
+    @Test
+    fun fetch_404_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.status(req, 404) }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+        val thrown = assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        assertTrue(thrown.message?.contains("404") == true)
+    }
+
+    @Test
+    fun fetch_500_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.status(req, 500) }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+        assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        Unit
+    }
+
+    @Test
+    fun fetch_malformedJson_throwsIOException() = runTest {
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.ok(req, "not json {{{") }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+        assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { fetcher.fetch() }
+        }
+        Unit
+    }
+
+    @Test
+    fun fetch_missingReleasesField_returnsEmptyManifest() = runTest {
+        // RawContractsManifest defaults `releases` to emptyList, so
+        // a `{ "version": 1 }` body decodes successfully → 0
+        // releases. (Distinct from the malformed-JSON case.)
+        val client = FakeOkHttpClient.build { req -> FakeOkHttpClient.ok(req, """{ "version": 1 }""") }
+        val fetcher = GitHubReleasesContractsManifestFetcher(client)
+        assertTrue(fetcher.fetch().manifest.releases.isEmpty())
+    }
+
+    @Test
+    fun fetch_requestsTheConfiguredURL() = runTest {
+        var seen: Request? = null
+        val client = FakeOkHttpClient.build { req ->
+            seen = req
+            FakeOkHttpClient.ok(req, """{ "version": 1, "releases": [] }""")
+        }
+        val fetcher = GitHubReleasesContractsManifestFetcher(
+            client,
+            url = "https://example.com/custom/contracts-manifest.json",
+        )
+        fetcher.fetch()
+        assertEquals("https://example.com/custom/contracts-manifest.json", seen?.url.toString())
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/ContractsRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/ContractsRepositoryTest.kt
@@ -1,0 +1,205 @@
+package chat.onym.android.chain
+
+import chat.onym.android.support.FakeContractsManifestFetcher
+import chat.onym.android.support.InMemoryAnchorSelectionStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import java.time.Instant
+
+/**
+ * Repository contract + the load-bearing `binding(forKey)`
+ * resolution rules (explicit → default-to-latest → null).
+ */
+class ContractsRepositoryTest {
+
+    private val testnetAnarchyKey = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+    private val testnetDemocracyKey = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Democracy)
+    private val mainnetAnarchyKey = AnchorSelectionKey(ContractNetwork.Public, GovernanceType.Anarchy)
+
+    private val v002 = ContractRelease(
+        release = "v0.0.2",
+        publishedAt = Instant.parse("2026-05-02T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-2"),
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Democracy, "C-D-2"),
+        ),
+    )
+    private val v001 = ContractRelease(
+        release = "v0.0.1",
+        publishedAt = Instant.parse("2026-05-01T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-1"),
+        ),
+    )
+    private val twoReleases = ContractsManifest(version = 1, releases = listOf(v002, v001))
+
+    // ─── binding(forKey) resolution ────────────────────────────────
+
+    @Test
+    fun binding_explicitSelectionWins() {
+        val state = ContractsState(
+            manifest = twoReleases,
+            selections = mapOf(testnetAnarchyKey to "v0.0.1"),
+        )
+        val binding = state.binding(testnetAnarchyKey)
+        assertEquals("v0.0.1", binding?.release)
+        assertEquals("C-A-1", binding?.contractId)
+    }
+
+    @Test
+    fun binding_defaultToLatestWhenNoExplicitPick() {
+        val state = ContractsState(manifest = twoReleases, selections = emptyMap())
+        val binding = state.binding(testnetAnarchyKey)
+        assertEquals("v0.0.2", binding?.release)
+        assertEquals("C-A-2", binding?.contractId)
+    }
+
+    @Test
+    fun binding_defaultToLatestWhenExplicitPickIsStale() {
+        // User picked a tag that's no longer in the manifest (release
+        // was withdrawn, or the user upgraded to a manifest version
+        // before the pick existed) → fall through to default-to-latest.
+        val state = ContractsState(
+            manifest = twoReleases,
+            selections = mapOf(testnetAnarchyKey to "v9.9.9"),
+        )
+        val binding = state.binding(testnetAnarchyKey)
+        assertEquals("v0.0.2", binding?.release)
+    }
+
+    @Test
+    fun binding_returnsNullWhenNoContractForKey() {
+        // No contract for (testnet, oligarchy) in either release.
+        val state = ContractsState(manifest = twoReleases, selections = emptyMap())
+        val key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Oligarchy)
+        assertNull(state.binding(key))
+    }
+
+    @Test
+    fun binding_returnsNullWhenManifestIsNull() {
+        val state = ContractsState(manifest = null, selections = emptyMap())
+        assertNull(state.binding(testnetAnarchyKey))
+    }
+
+    @Test
+    fun binding_returnsNullForMainnetWhenOnlyTestnetContractsPublished() {
+        // Today's reality — Mainnet stays disabled until a contract
+        // ships.
+        val state = ContractsState(manifest = twoReleases, selections = emptyMap())
+        assertNull(state.binding(mainnetAnarchyKey))
+    }
+
+    // ─── lifecycle ────────────────────────────────────────────────
+
+    @Test
+    fun bootstrap_hydratesSelectionsAndCachedManifest() = runTest {
+        val store = InMemoryAnchorSelectionStore().apply {
+            saveCachedManifest(simpleManifestJson())
+            saveSelections(mapOf(testnetAnarchyKey to "v0.0.1"))
+        }
+        val fetcher = FakeContractsManifestFetcher(
+            FakeContractsManifestFetcher.Mode.Failing(IOException("offline")),
+        )
+        val repo = ContractsRepository(store, fetcher)
+
+        repo.bootstrap()
+
+        val state = repo.snapshots.value
+        assertEquals(mapOf(testnetAnarchyKey to "v0.0.1"), state.selections)
+        assertEquals(2, state.manifest?.releases?.size)
+        assertEquals(0, fetcher.fetchCallCount)
+    }
+
+    @Test
+    fun start_isIdempotent_acrossMultipleCalls() = runTest {
+        val fetcher = FakeContractsManifestFetcher(
+            FakeContractsManifestFetcher.Mode.Succeeds(twoReleases),
+        )
+        val repo = ContractsRepository(InMemoryAnchorSelectionStore(), fetcher)
+
+        repo.start(); repo.start(); repo.start()
+
+        assertEquals(1, fetcher.fetchCallCount)
+    }
+
+    @Test
+    fun start_swallowsErrorsSilentlyAndKeepsCachedManifest() = runTest {
+        val store = InMemoryAnchorSelectionStore().apply {
+            saveCachedManifest(simpleManifestJson())
+        }
+        val fetcher = FakeContractsManifestFetcher(
+            FakeContractsManifestFetcher.Mode.Failing(IOException("offline")),
+        )
+        val repo = ContractsRepository(store, fetcher)
+        repo.bootstrap()
+
+        repo.start()  // must not throw
+
+        assertEquals(2, repo.snapshots.value.manifest?.releases?.size)
+    }
+
+    @Test
+    fun setSelection_persistsAndPushes() = runTest {
+        val store = InMemoryAnchorSelectionStore()
+        val fetcher = FakeContractsManifestFetcher(
+            FakeContractsManifestFetcher.Mode.Succeeds(twoReleases),
+        )
+        val repo = ContractsRepository(store, fetcher)
+        repo.start()
+
+        repo.setSelection(testnetDemocracyKey, "v0.0.2")
+
+        assertEquals("v0.0.2", store.loadSelections()[testnetDemocracyKey])
+        assertEquals("v0.0.2", repo.snapshots.value.selections[testnetDemocracyKey])
+        // binding resolves through the new selection.
+        assertEquals("v0.0.2", repo.snapshots.value.binding(testnetDemocracyKey)?.release)
+    }
+
+    @Test
+    fun clearSelection_resetsToDefaultLatest() = runTest {
+        val store = InMemoryAnchorSelectionStore()
+        val fetcher = FakeContractsManifestFetcher(
+            FakeContractsManifestFetcher.Mode.Succeeds(twoReleases),
+        )
+        val repo = ContractsRepository(store, fetcher)
+        repo.start()
+        repo.setSelection(testnetAnarchyKey, "v0.0.1")
+        assertEquals("v0.0.1", repo.snapshots.value.binding(testnetAnarchyKey)?.release)
+
+        repo.clearSelection(testnetAnarchyKey)
+
+        assertTrue("explicit pick must be cleared from store",
+            store.loadSelections()[testnetAnarchyKey] == null)
+        // Default-to-latest now applies again.
+        assertEquals("v0.0.2", repo.snapshots.value.binding(testnetAnarchyKey)?.release)
+    }
+
+    // Build a small valid contracts-manifest JSON the in-memory
+    // store can decode through ContractsManifest.fromRaw.
+    private fun simpleManifestJson(): String = """
+        {
+          "version": 1,
+          "releases": [
+            {
+              "release": "v0.0.2",
+              "publishedAt": "2026-05-02T00:00:00Z",
+              "contracts": [
+                { "network": "testnet", "type": "anarchy",   "id": "C-A-2" },
+                { "network": "testnet", "type": "democracy", "id": "C-D-2" }
+              ]
+            },
+            {
+              "release": "v0.0.1",
+              "publishedAt": "2026-05-01T00:00:00Z",
+              "contracts": [
+                { "network": "testnet", "type": "anarchy", "id": "C-A-1" }
+              ]
+            }
+          ]
+        }
+    """.trimIndent()
+}

--- a/app/src/test/kotlin/chat/onym/android/settings/AnchorsPickerViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/settings/AnchorsPickerViewModelTest.kt
@@ -1,0 +1,183 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.settings
+
+import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.ContractEntry
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.ContractRelease
+import chat.onym.android.chain.ContractsManifest
+import chat.onym.android.chain.ContractsRepository
+import chat.onym.android.chain.GovernanceType
+import chat.onym.android.support.FakeContractsManifestFetcher
+import chat.onym.android.support.InMemoryAnchorSelectionStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+class AnchorsPickerViewModelTest {
+
+    private val v002 = ContractRelease(
+        release = "v0.0.2",
+        publishedAt = Instant.parse("2026-05-02T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-2"),
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Democracy, "C-D-2"),
+        ),
+    )
+    private val v001 = ContractRelease(
+        release = "v0.0.1",
+        publishedAt = Instant.parse("2026-05-01T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-1"),
+        ),
+    )
+    private val twoReleases = ContractsManifest(version = 1, releases = listOf(v002, v001))
+
+    @Before fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+    @After  fun tearDown() { Dispatchers.resetMain() }
+
+    // ─── state mirror ─────────────────────────────────────────────
+
+    @Test
+    fun state_indicatesNoManifestUntilStartLands() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = null)
+
+        val s = vm.state.value
+        assertFalse(s.hasManifest)
+        // Both networks unavailable when no manifest.
+        assertEquals(false, s.networkAvailability[ContractNetwork.Testnet])
+        assertEquals(false, s.networkAvailability[ContractNetwork.Public])
+    }
+
+    @Test
+    fun state_indicatesTestnetAvailableMainnetNot_whenOnlyTestnetContractsPublished() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = twoReleases)
+
+        val s = vm.state.value
+        assertTrue(s.hasManifest)
+        assertEquals(true, s.networkAvailability[ContractNetwork.Testnet])
+        assertEquals(
+            "Mainnet row stays disabled until a public-network contract ships",
+            false, s.networkAvailability[ContractNetwork.Public],
+        )
+    }
+
+    // ─── networkRows ──────────────────────────────────────────────
+
+    @Test
+    fun networkRows_subtitleSaysLatestWhenNoExplicitPick() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = twoReleases)
+        val rows = vm.networkRows(ContractNetwork.Testnet)
+
+        val anarchy = rows.first { it.type == GovernanceType.Anarchy }
+        assertEquals("v0.0.2", anarchy.resolvedRelease)
+        assertFalse(anarchy.isExplicit)
+    }
+
+    @Test
+    fun networkRows_subtitleSaysSelectedWhenExplicitPickInPlace() = runTest {
+        val (repo, vm) = makeViewModel(seedManifest = twoReleases)
+        repo.setSelection(
+            key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy),
+            releaseTag = "v0.0.1",
+        )
+        yield()
+
+        val rows = vm.networkRows(ContractNetwork.Testnet)
+        val anarchy = rows.first { it.type == GovernanceType.Anarchy }
+        assertEquals("v0.0.1", anarchy.resolvedRelease)
+        assertTrue(anarchy.isExplicit)
+    }
+
+    @Test
+    fun networkRows_resolvedReleaseIsNullWhenNoContractForSlot() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = twoReleases)
+        val rows = vm.networkRows(ContractNetwork.Testnet)
+        val oligarchy = rows.first { it.type == GovernanceType.Oligarchy }
+        assertNull("no contract for (testnet, oligarchy) in this fixture", oligarchy.resolvedRelease)
+    }
+
+    // ─── versionRows ──────────────────────────────────────────────
+
+    @Test
+    fun versionRows_listsOnlyReleasesThatContainContractForSlot() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = twoReleases)
+        val rowsAnarchy = vm.versionRows(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        // Both v0.0.2 and v0.0.1 carry a testnet/anarchy contract.
+        assertEquals(listOf("v0.0.2", "v0.0.1"), rowsAnarchy.map { it.release.release })
+
+        val rowsDemocracy = vm.versionRows(ContractNetwork.Testnet, GovernanceType.Democracy)
+        // Only v0.0.2 has a testnet/democracy contract.
+        assertEquals(listOf("v0.0.2"), rowsDemocracy.map { it.release.release })
+    }
+
+    @Test
+    fun versionRows_marksLatestAsCurrentlySelectedWhenNoExplicitPick() = runTest {
+        val (_, vm) = makeViewModel(seedManifest = twoReleases)
+        val rows = vm.versionRows(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        val v002Row = rows.first { it.release.release == "v0.0.2" }
+        val v001Row = rows.first { it.release.release == "v0.0.1" }
+        assertTrue(v002Row.isCurrentlySelected)
+        assertFalse(v002Row.isExplicitPick)
+        assertFalse(v001Row.isCurrentlySelected)
+    }
+
+    // ─── intents ──────────────────────────────────────────────────
+
+    @Test
+    fun pickVersion_persistsViaRepository() = runTest {
+        val (repo, vm) = makeViewModel(seedManifest = twoReleases)
+        vm.pickVersion(ContractNetwork.Testnet, GovernanceType.Anarchy, "v0.0.1")
+        yield()
+
+        val key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        assertEquals("v0.0.1", repo.snapshots.value.selections[key])
+    }
+
+    @Test
+    fun resetToDefault_clearsExplicitPick() = runTest {
+        val (repo, vm) = makeViewModel(seedManifest = twoReleases)
+        vm.pickVersion(ContractNetwork.Testnet, GovernanceType.Anarchy, "v0.0.1")
+        yield()
+
+        vm.resetToDefault(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        yield()
+
+        val key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        assertNull(repo.snapshots.value.selections[key])
+        // Default-to-latest now applies.
+        assertEquals("v0.0.2", repo.snapshots.value.binding(key)?.release)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private suspend fun makeViewModel(
+        seedManifest: ContractsManifest?,
+    ): Pair<ContractsRepository, AnchorsPickerViewModel> {
+        val store = InMemoryAnchorSelectionStore()
+        val fetcher = if (seedManifest != null) {
+            FakeContractsManifestFetcher(FakeContractsManifestFetcher.Mode.Succeeds(seedManifest))
+        } else {
+            FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Failing(IllegalStateException("not started"))
+            )
+        }
+        val repo = ContractsRepository(store, fetcher)
+        if (seedManifest != null) repo.start()
+        val vm = AnchorsPickerViewModel(repo)
+        yield()
+        return repo to vm
+    }
+}


### PR DESCRIPTION
## Summary

New "Anchors" row in Settings → Network. Tapping it pushes a 3-level drill-down: **Network** (Testnet | Mainnet) → **Governance type** (anarchy | democracy | oligarchy | oneonone | tyranny) → **Version** (release tags from `onymchat/onym-contracts`). Selection per `(network, type)` is exactly one. The repository resolves to a concrete `AnchorBinding` (network + type + contractId + release tag) that future chat-creation code reads when anchoring a brand-new chat.

Mirrors the iOS twin (in-flight on `settings/anchors-config` over in `onym-ios`).

## What lands

```
app/src/main/kotlin/chat/onym/android/
├── chain/
│   ├── ContractEntry.kt                      ← enums (ContractNetwork, GovernanceType) + RawContractsManifest + ContractsManifest
│   ├── AnchorSelection.kt                    ← AnchorSelectionKey + AnchorBinding (the value type chats will carry)
│   ├── AnchorSelectionStore.kt               ← interface + DataStorePreferencesAnchorSelectionStore
│   ├── ContractsManifestFetcher.kt           ← interface + GitHubReleasesContractsManifestFetcher (OkHttp)
│   └── ContractsRepository.kt                ← Mutex + StateFlow<ContractsState> + binding(forKey) resolver
└── settings/
    ├── AnchorsPickerViewModel.kt             ← stateless; per-screen helpers
    ├── AnchorsScreen.kt                      ← three composables (Root / Network / Version) for the drill-down
    └── SettingsScreen.kt (modified)          ← +Anchors row inside Network section

app/src/sharedTest/kotlin/chat/onym/android/support/
├── InMemoryAnchorSelectionStore.kt           ← reusable fake
└── FakeContractsManifestFetcher.kt           ← reusable fake (Succeeds / Failing / Scripted) + fetchCallCount

app/src/test/kotlin/chat/onym/android/
├── chain/ContractEntryTest.kt                ← 5 cases (raw → typed mapping; unknown enums dropped)
├── chain/AnchorSelectionStoreTest.kt         ← 7 cases against PreferenceDataStoreFactory + TemporaryFolder
├── chain/ContractsManifestFetcherTest.kt     ← 8 cases via FakeOkHttpClient
├── chain/ContractsRepositoryTest.kt          ← 11 cases incl. all binding(forKey) rules
└── settings/AnchorsPickerViewModelTest.kt    ← 9 cases (state mirror + intents + drill-down rows)
```

Total: 40 new tests (brief asked for ~36; +4 are extra coverage on already-listed cases).

## Wire format

```json
{
  "version": 1,
  "releases": [
    {
      "release": "v0.0.2",
      "publishedAt": "2026-05-01T15:29:00Z",
      "contracts": [
        { "network": "testnet", "type": "anarchy",   "id": "CDWY…RO2UMV" },
        { "network": "testnet", "type": "democracy", "id": "CBEB…ZPHIAC" },
        { "network": "testnet", "type": "oligarchy", "id": "CBHY…J46COU" },
        { "network": "testnet", "type": "oneonone",  "id": "CAHX…FO6OEB" },
        { "network": "testnet", "type": "tyranny",   "id": "CC6Y…45CFO3" }
      ]
    },
    { "release": "v0.0.1", "publishedAt": "...", "contracts": [...] }
  ]
}
```

Field names exactly as shown — interop with iOS rides on these. Fetched from `https://github.com/onymchat/onym-contracts/releases/latest/download/contracts-manifest.json` (public redirect, no GitHub API rate limit). `ContractsManifestFetcherTest.defaultURL_pointsAtGitHubReleasesLatestDownload` pins the URL string against silent renames.

## The per-chat binding invariant (load-bearing)

When `ChatGroup` lands (separate future PR), it carries:

```kotlin
data class ChatGroup(/* ... */, val anchor: AnchorBinding)

@Serializable
data class AnchorBinding(
    val network: ContractNetwork,
    val governanceType: GovernanceType,
    val contractId: String,
    val release: String,
)
```

Two write paths future code MUST respect:
- **Create chat**: read `contractsRepository.snapshots.value.binding(forKey = key)` → store as `chat.anchor`. Settings changes after this never mutate the chat.
- **Update chat**: read `chat.anchor.contractId` + `chat.anchor.network` directly. The chat is the source of truth for "which contract do I update".

This PR ships `AnchorBinding` as a public `@Serializable` data class so the future Chat PR can pick it up without redefining.

## Selection resolution rules

`ContractsState.binding(forKey)`:

1. **Explicit selection wins** — if the user has a pick AND the manifest has a release with that tag AND that release has a contract for `(network, type)` → return it.
2. **Default to latest** — otherwise, find the latest release (highest `publishedAt`) that has a contract for the slot → return it.
3. **No contract** — otherwise, return `null` (UI surfaces this as a disabled row, e.g. Mainnet today).

The "default to latest" rule means a brand-new install with no selections persists nothing, but every chain interactor still gets a usable binding the moment the manifest loads.

## Architecture compliance

| Layer | What this PR adds | Touches |
|---|---|---|
| **Persistence seam** | `AnchorSelectionStore` (DataStore — selections + URLs aren't secret) | `androidx.datastore` + `kotlinx.serialization` only |
| **Network seam** | `ContractsManifestFetcher` | OkHttp + kotlinx.serialization only |
| **Repository** | `ContractsRepository` | both seams + StateFlow |
| **ViewModel** | `AnchorsPickerViewModel` | the repository only |
| **Composable** | `AnchorsScreen` (three composables) | the ViewModel only |
| **OnymSDK** | nothing | nothing |

Separate `contractsDataStore` file (`chat.onym.android.contracts_prefs`) so the relayer + contracts storage layers stay independent — easier to reason about + selectively wipe in tests.

## Lifecycle

1. `OnymApplication.onCreate` constructs `ContractsRepository` with the prod fetcher + DataStore-backed store.
2. Same fire-and-forget pattern as `RelayerRepository`: `bootstrap()` (load cached + selections from disk) then `start()` (fire the network fetch) on the application scope. App launch never blocks; failures silent.
3. While fetch is in flight, the picker shows whatever was cached on disk (empty on first launch).
4. User opens Settings → Network → Anchors → drills down.

## UI — 3-level drill-down

- **Anchors root** — list of two rows (Testnet, Mainnet). Mainnet shows "No contracts yet" + disabled while no manifest entries exist for it.
- **Network** (e.g. tap Testnet) — five rows, one per governance type. Each row shows the resolved release tag with subtitle "(latest)" if defaulted or "(selected)" if explicitly picked.
- **Version** (e.g. tap Anarchy) — releases that have a contract for this slot, newest-first. Tap to select; checkmark on current; pop back. "Reset to default" row at the bottom clears the explicit pick (which makes "default to latest" kick in).

Navigation Compose routes:
- `anchors_root`
- `anchors_network/{network}`
- `anchors_version/{network}/{type}`

## The reusable test pattern (continues sharedTest source set)

- **`InMemoryAnchorSelectionStore`** — Mutex-guarded fake with the same contract as the DataStore impl. Decodes the cached manifest through the same `ContractsManifest.fromRaw` boundary so unknown enums get dropped exactly like production.
- **`FakeContractsManifestFetcher`** — `Succeeds(manifest, rawJson)` / `Failing(error)` / `Scripted(List<Result<…>>)` + `fetchCallCount` for idempotency assertions.
- Reuses `FakeOkHttpClient` from PR #17 for the fetcher tests.

## Test plan

- [x] `./gradlew :app:assembleDebug` — production builds clean
- [x] `./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.chain.*' --tests 'chat.onym.android.settings.AnchorsPickerViewModelTest'` — 40/40 pass
- [x] `./gradlew :app:testDebugUnitTest` — full unit suite green
- [x] `python3 scripts/lint-secrets.py` — exit 0

## Out of scope (intentionally — match iOS scope)

- **`ChatGroup` itself.** This PR ships `AnchorBinding` as the public value type chats will carry; `ChatGroup` lands with the chat-creation PR.
- **The chain/relayer client.** Submitting transactions is a separate PR.
- **Mainnet.** No public-network contracts published yet — Mainnet row stays disabled. Lights up automatically once a contract appears in a release.
- **Localization.** Section / button labels are English-only inline strings for now; lift into `res/values/` when a Settings translation pass lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)