### PR TITLE
ux: i18n + default-random-preseed + UI tests for relayers and anchors

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/AnchorsUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/AnchorsUITest.kt
@@ -1,0 +1,193 @@
+package chat.onym.android.uitests
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.MainActivity
+import chat.onym.android.UITestRegistry
+import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.ContractEntry
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.ContractRelease
+import chat.onym.android.chain.ContractsManifest
+import chat.onym.android.chain.GovernanceType
+import chat.onym.android.support.FakeContractsManifestFetcher
+import chat.onym.android.support.FakeKnownRelayersFetcher
+import chat.onym.android.support.InMemoryAnchorSelectionStore
+import chat.onym.android.support.InMemoryRelayerSelectionStore
+import chat.onym.android.uitests.screens.AnchorsScreenObjects
+import chat.onym.android.uitests.screens.SettingsScreenObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+
+@RunWith(AndroidJUnit4::class)
+class AnchorsUITest {
+
+    // Two-release fixture; only testnet contracts → mainnet stays
+    // disabled (matches today's manifest reality).
+    private val v002 = ContractRelease(
+        release = "v0.0.2",
+        publishedAt = Instant.parse("2026-05-02T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-2"),
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Democracy, "C-D-2"),
+        ),
+    )
+    private val v001 = ContractRelease(
+        release = "v0.0.1",
+        publishedAt = Instant.parse("2026-05-01T00:00:00Z"),
+        contracts = listOf(
+            ContractEntry(ContractNetwork.Testnet, GovernanceType.Anarchy, "C-A-1"),
+        ),
+    )
+    private val manifest = ContractsManifest(version = 1, releases = listOf(v002, v001))
+
+    private val contractsStore = InMemoryAnchorSelectionStore()
+    /** rawJson must match [manifest] above so the store-side wait
+     *  (`loadCachedManifestBlocking()`) decodes the same shape the
+     *  fetcher returns. The default empty rawJson on the fake would
+     *  decode to 0 releases. */
+    private val manifestRawJson = """
+        {
+          "version": 1,
+          "releases": [
+            {
+              "release": "v0.0.2",
+              "publishedAt": "2026-05-02T00:00:00Z",
+              "contracts": [
+                { "network": "testnet", "type": "anarchy",   "id": "C-A-2" },
+                { "network": "testnet", "type": "democracy", "id": "C-D-2" }
+              ]
+            },
+            {
+              "release": "v0.0.1",
+              "publishedAt": "2026-05-01T00:00:00Z",
+              "contracts": [
+                { "network": "testnet", "type": "anarchy", "id": "C-A-1" }
+              ]
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private val contractsFetcher = FakeContractsManifestFetcher(
+        FakeContractsManifestFetcher.Mode.Succeeds(manifest, rawJson = manifestRawJson)
+    )
+
+    /** Same trick as `RelayerSettingsUITest` — populate the registry
+     *  BEFORE the compose rule launches `MainActivity`. */
+    @get:Rule(order = 0)
+    val registrySetup = object : TestWatcher() {
+        override fun starting(description: Description) {
+            // Seed relayer with one endpoint + hasUserInteracted=true
+            // so the auto-populate path doesn't race with these tests
+            // (which only care about anchors).
+            val relayerStore = InMemoryRelayerSelectionStore().apply {
+                kotlinx.coroutines.runBlocking {
+                    saveConfiguration(
+                        chat.onym.android.chain.RelayerConfiguration(
+                            endpoints = listOf(
+                                chat.onym.android.chain.RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+                            ),
+                            hasUserInteracted = true,
+                        )
+                    )
+                }
+            }
+            UITestRegistry.relayerStore = relayerStore
+            UITestRegistry.relayerFetcher = FakeKnownRelayersFetcher(
+                FakeKnownRelayersFetcher.Mode.Succeeds(emptyList())
+            )
+            UITestRegistry.contractsStore = contractsStore
+            UITestRegistry.contractsFetcher = contractsFetcher
+            UITestRegistry.enabled = true
+            val app = androidx.test.core.app.ApplicationProvider
+                .getApplicationContext<chat.onym.android.OnymApplication>()
+            app.rebuildDependenciesForTest()
+        }
+        override fun finished(description: Description) {
+            UITestRegistry.reset()
+        }
+    }
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun drillDown_pickVersion_persistsViaStore() {
+        val settings = SettingsScreenObject(composeRule)
+        val anchors = AnchorsScreenObjects(composeRule)
+
+        settings.tapAnchorsRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            contractsStore.loadCachedManifestBlocking()?.releases?.size == 2
+        }
+        anchors.tapNetwork(ContractNetwork.Testnet.wireValue)
+        anchors.tapType(GovernanceType.Anarchy.wireValue)
+        anchors.tapVersion("v0.0.1")  // older release; default is v0.0.2
+
+        val key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            contractsStore.loadSelectionsBlocking()[key] == "v0.0.1"
+        }
+        assertEquals("v0.0.1", contractsStore.loadSelectionsBlocking()[key])
+    }
+
+    @Test
+    fun resetToDefault_clearsExplicitPick() {
+        val settings = SettingsScreenObject(composeRule)
+        val anchors = AnchorsScreenObjects(composeRule)
+        settings.tapAnchorsRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            contractsStore.loadCachedManifestBlocking()?.releases?.size == 2
+        }
+        anchors.tapNetwork(ContractNetwork.Testnet.wireValue)
+        anchors.tapType(GovernanceType.Anarchy.wireValue)
+        anchors.tapVersion("v0.0.1")
+        val key = AnchorSelectionKey(ContractNetwork.Testnet, GovernanceType.Anarchy)
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            contractsStore.loadSelectionsBlocking()[key] == "v0.0.1"
+        }
+
+        // After picking the version, the AnchorsVersionScreen pops
+        // back to AnchorsNetworkScreen. Drill straight into the
+        // type row again to land on the version screen + tap reset.
+        anchors.tapType(GovernanceType.Anarchy.wireValue)
+        anchors.tapReset()
+
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            contractsStore.loadSelectionsBlocking()[key] == null
+        }
+        assertNull(contractsStore.loadSelectionsBlocking()[key])
+    }
+
+    @Test
+    fun mainnetRow_disabledWhenNoMainnetContracts() {
+        val settings = SettingsScreenObject(composeRule)
+        val anchors = AnchorsScreenObjects(composeRule)
+        settings.tapAnchorsRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            contractsStore.loadCachedManifestBlocking()?.releases?.size == 2
+        }
+        // Both rows render — but the Mainnet row carries the "No
+        // contracts yet" subtitle and isn't tappable. Assert via the
+        // localized subtitle text.
+        anchors.assertNetworkRowVisible(ContractNetwork.Public.wireValue)
+        composeRule.onNodeWithText("No contracts yet").assertIsDisplayed()
+    }
+}
+
+private fun InMemoryAnchorSelectionStore.loadCachedManifestBlocking(): ContractsManifest? =
+    kotlinx.coroutines.runBlocking { loadCachedManifest() }
+
+private fun InMemoryAnchorSelectionStore.loadSelectionsBlocking(): Map<AnchorSelectionKey, String> =
+    kotlinx.coroutines.runBlocking { loadSelections() }

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/RelayerSettingsUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/RelayerSettingsUITest.kt
@@ -1,0 +1,211 @@
+package chat.onym.android.uitests
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.MainActivity
+import chat.onym.android.UITestRegistry
+import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.support.FakeKnownRelayersFetcher
+import chat.onym.android.support.InMemoryRelayerSelectionStore
+import chat.onym.android.uitests.screens.RelayerSettingsScreenObject
+import chat.onym.android.uitests.screens.SettingsScreenObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end coverage of the multi-relayer settings flow + the
+ * PR #22 default-random-preseed behaviour.
+ *
+ * Test sequence per case:
+ *
+ *  1. `@Before` resets [UITestRegistry] + seeds the in-memory fakes
+ *     with a known published list. `enabled = true` flips
+ *     [chat.onym.android.OnymApplication]'s wiring branch.
+ *  2. The compose rule launches `MainActivity` with the test
+ *     application — `onCreate` reads the registry, wires fakes,
+ *     and `RelayerRepository.start()` runs the auto-populate path
+ *     because the in-memory store starts cold (`hasUserInteracted
+ *     = false`).
+ *  3. Each test drives the UI through the page objects + asserts
+ *     against the fake store's recorded state.
+ *
+ * Fake-only stores (no contracts/anchors needed for these tests)
+ * are seeded with empty manifests so the Anchors row stays
+ * disabled — these tests don't touch it.
+ */
+@RunWith(AndroidJUnit4::class)
+class RelayerSettingsUITest {
+
+    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+    private val mainnet = RelayerEndpoint("Onym Mainnet", "https://relayer.onym.chat", "public")
+
+    private val relayerStore = InMemoryRelayerSelectionStore()
+    private val relayerFetcher = FakeKnownRelayersFetcher(
+        FakeKnownRelayersFetcher.Mode.Succeeds(listOf(testnet, mainnet))
+    )
+    private val contractsStore = chat.onym.android.support.InMemoryAnchorSelectionStore()
+    private val contractsFetcher = chat.onym.android.support.FakeContractsManifestFetcher(
+        chat.onym.android.support.FakeContractsManifestFetcher.Mode.Succeeds(
+            chat.onym.android.chain.ContractsManifest(version = 1, releases = emptyList())
+        )
+    )
+
+    /** Ordered first (`order = 0`) so the registry is populated +
+     *  the cached [chat.onym.android.OnymApplication.dependencies]
+     *  invalidated BEFORE [composeRule] launches `MainActivity`.
+     *  JUnit's default rule ordering is unspecified across JVMs;
+     *  the explicit `order` arg pins it. */
+    @get:Rule(order = 0)
+    val registrySetup = object : TestWatcher() {
+        override fun starting(description: Description) {
+            UITestRegistry.relayerStore = relayerStore
+            UITestRegistry.relayerFetcher = relayerFetcher
+            UITestRegistry.contractsStore = contractsStore
+            UITestRegistry.contractsFetcher = contractsFetcher
+            UITestRegistry.enabled = true
+            val app = androidx.test.core.app.ApplicationProvider
+                .getApplicationContext<chat.onym.android.OnymApplication>()
+            app.rebuildDependenciesForTest()
+        }
+        override fun finished(description: Description) {
+            UITestRegistry.reset()
+        }
+    }
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    // ─── auto-populate ────────────────────────────────────────────
+
+    @Test
+    fun autoPopulate_seedsConfiguredListWithPublishedEntries_onFirstLaunch() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+
+        settings.tapRelayerRow()
+
+        // Wait for the boot fetch to finish and the snapshot to flip
+        // from cold (empty) to auto-populated (testnet + mainnet).
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+        relayer.assertConfigured(testnet.url)
+        relayer.assertConfigured(mainnet.url)
+        // Strategy is RANDOM by default after auto-populate.
+        assertEquals(
+            chat.onym.android.chain.RelayerStrategy.RANDOM,
+            relayerStore.loadConfigurationBlocking().strategy,
+        )
+    }
+
+    // ─── intents ──────────────────────────────────────────────────
+
+    @Test
+    fun markPrimary_persistsViaStore() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+        settings.tapRelayerRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+
+        relayer.tapMarkPrimary(testnet.url)
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().primaryUrl == testnet.url
+        }
+        assertEquals(testnet.url, relayerStore.loadConfigurationBlocking().primaryUrl)
+    }
+
+    @Test
+    fun switchStrategy_toPrimary_persistsViaStore() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+        settings.tapRelayerRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+
+        relayer.tapStrategy("primary")
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().strategy ==
+                chat.onym.android.chain.RelayerStrategy.PRIMARY
+        }
+    }
+
+    @Test
+    fun addCustomUrl_appendsAsCustomEndpoint() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+        settings.tapRelayerRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+
+        relayer.typeCustomUrl("https://custom.example/relayer")
+        relayer.tapAddCustom()
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 3
+        }
+        val endpoints = relayerStore.loadConfigurationBlocking().endpoints
+        assertEquals("custom", endpoints.last().network)
+        assertEquals("https://custom.example/relayer", endpoints.last().url)
+    }
+
+    @Test
+    fun swipeDelete_removesEndpointFromStore() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+        settings.tapRelayerRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+
+        relayer.swipeDelete(mainnet.url)
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 1
+        }
+        assertEquals(testnet.url, relayerStore.loadConfigurationBlocking().endpoints.single().url)
+        assertNull(
+            "removing non-primary keeps primaryUrl null",
+            relayerStore.loadConfigurationBlocking().primaryUrl,
+        )
+    }
+
+    @Test
+    fun deletingPrimary_clearsPrimaryMarker() {
+        val settings = SettingsScreenObject(composeRule)
+        val relayer = RelayerSettingsScreenObject(composeRule)
+        settings.tapRelayerRow()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().endpoints.size == 2
+        }
+        relayer.tapMarkPrimary(testnet.url)
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().primaryUrl == testnet.url
+        }
+
+        relayer.swipeDelete(testnet.url)
+
+        composeRule.waitUntil(timeoutMillis = 2.seconds.inWholeMilliseconds) {
+            relayerStore.loadConfigurationBlocking().primaryUrl == null
+        }
+        assertTrue(
+            "remaining endpoint count drops to 1",
+            relayerStore.loadConfigurationBlocking().endpoints.size == 1,
+        )
+    }
+}
+
+/** `runBlocking { loadConfiguration() }` shorthand — the page objects'
+ *  `waitUntil` callbacks run on the main thread, where `runBlocking`
+ *  is safe (DataStore-shaped suspend fn that resolves locally). */
+private fun InMemoryRelayerSelectionStore.loadConfigurationBlocking(): chat.onym.android.chain.RelayerConfiguration =
+    kotlinx.coroutines.runBlocking { loadConfiguration() }

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/AnchorsScreenObjects.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/AnchorsScreenObjects.kt
@@ -1,0 +1,57 @@
+package chat.onym.android.uitests.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+
+/**
+ * Page object for the Anchors drill-down. Three layers:
+ * Anchors root → Network → Version.
+ */
+class AnchorsScreenObjects(private val rule: ComposeContentTestRule) {
+
+    fun networkRow(network: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("anchors.network.$network")
+
+    fun typeRow(type: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("anchors.type.$type")
+
+    fun versionRow(release: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("anchors.version.$release")
+
+    fun resetRow(): SemanticsNodeInteraction =
+        rule.onNodeWithTag("anchors.version.reset")
+
+    fun tapNetwork(network: String): AnchorsScreenObjects {
+        networkRow(network).performScrollTo().performClick()
+        return this
+    }
+
+    fun tapType(type: String): AnchorsScreenObjects {
+        typeRow(type).performScrollTo().performClick()
+        return this
+    }
+
+    fun tapVersion(release: String): AnchorsScreenObjects {
+        versionRow(release).performScrollTo().performClick()
+        return this
+    }
+
+    fun tapReset(): AnchorsScreenObjects {
+        resetRow().performScrollTo().performClick()
+        return this
+    }
+
+    fun assertNetworkRowVisible(network: String): AnchorsScreenObjects {
+        networkRow(network).performScrollTo().assertIsDisplayed()
+        return this
+    }
+
+    fun assertTypeRowVisible(type: String): AnchorsScreenObjects {
+        typeRow(type).performScrollTo().assertIsDisplayed()
+        return this
+    }
+}

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/RelayerSettingsScreenObject.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/RelayerSettingsScreenObject.kt
@@ -1,0 +1,72 @@
+package chat.onym.android.uitests.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+
+/**
+ * Page object for the Relayer settings screen. Wraps the test-tag
+ * vocabulary the production composables expose
+ * (`relayer.configured.<url>`, `relayer.add.custom.field`, etc.)
+ * so test bodies stay readable even when individual tags drift.
+ */
+class RelayerSettingsScreenObject(private val rule: ComposeContentTestRule) {
+
+    fun configuredRow(url: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("relayer.configured.$url")
+
+    fun primaryButton(url: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("relayer.configured.$url.primary_button")
+
+    fun customField(): SemanticsNodeInteraction = rule.onNodeWithTag("relayer.add.custom.field")
+    fun customAddButton(): SemanticsNodeInteraction = rule.onNodeWithTag("relayer.add.custom.button")
+
+    fun strategyButton(strategy: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("relayer.strategy.${strategy.lowercase()}")
+
+    fun knownAddRow(url: String): SemanticsNodeInteraction =
+        rule.onNodeWithTag("relayer.add.known.$url")
+
+    fun assertConfigured(url: String): RelayerSettingsScreenObject {
+        configuredRow(url).performScrollTo().assertIsDisplayed()
+        return this
+    }
+
+    fun tapMarkPrimary(url: String): RelayerSettingsScreenObject {
+        primaryButton(url).performScrollTo().performClick()
+        return this
+    }
+
+    fun tapStrategy(strategy: String): RelayerSettingsScreenObject {
+        strategyButton(strategy).performScrollTo().performClick()
+        return this
+    }
+
+    fun swipeDelete(url: String): RelayerSettingsScreenObject {
+        configuredRow(url).performScrollTo().performTouchInputSwipeLeft()
+        return this
+    }
+
+    fun typeCustomUrl(url: String): RelayerSettingsScreenObject {
+        customField().performScrollTo().performClick()
+        customField().performTextInput(url)
+        return this
+    }
+
+    fun tapAddCustom(): RelayerSettingsScreenObject {
+        customAddButton().performScrollTo().performClick()
+        return this
+    }
+
+    private fun SemanticsNodeInteraction.performTouchInputSwipeLeft(): SemanticsNodeInteraction {
+        // Compose `performTouchInput { swipeLeft() }` — extracted as
+        // a helper for ergonomics across multiple tests.
+        return performTouchInput { swipeLeft() }
+    }
+}

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
@@ -1,0 +1,19 @@
+package chat.onym.android.uitests.screens
+
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+
+/**
+ * Page object for the root Settings screen. Just the two rows we
+ * navigate into from instrumented tests.
+ */
+class SettingsScreenObject(private val rule: ComposeContentTestRule) {
+    fun tapRelayerRow() {
+        rule.onNodeWithTag("settings.relayer_row").performClick()
+    }
+
+    fun tapAnchorsRow() {
+        rule.onNodeWithTag("settings.anchors_row").performClick()
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -73,10 +73,24 @@ private val Context.contractsDataStore: DataStore<Preferences> by preferencesDat
  */
 class OnymApplication : Application() {
 
-    /** Built once in [onCreate]. Read by [MainActivity] via
-     *  `(application as OnymApplication).dependencies`. */
-    lateinit var dependencies: AppDependencies
-        private set
+    /** Lazy-built so instrumented tests can swap [UITestRegistry]
+     *  fakes in BEFORE the first read (Application.onCreate runs
+     *  once at process start, well before any JUnit `@Rule` body
+     *  executes — building deps eagerly there reads an empty
+     *  registry on every test). MainActivity is the first reader. */
+    @Volatile
+    private var depsLazy: Lazy<AppDependencies> = lazy { buildDependencies() }
+
+    val dependencies: AppDependencies get() = depsLazy.value
+
+    /** Test-only — invalidate the cached [AppDependencies] so the
+     *  next [dependencies] read rebuilds from the current
+     *  [UITestRegistry] state. Called by the registry-setup rule
+     *  in instrumented tests; never used in production. */
+    @androidx.annotation.VisibleForTesting
+    internal fun rebuildDependenciesForTest() {
+        depsLazy = lazy { buildDependencies() }
+    }
 
     /** The currently-resumed Activity, used to host the AndroidX
      *  `BiometricPrompt` dialog fragment. `WeakReference` so a
@@ -112,7 +126,14 @@ class OnymApplication : Application() {
             override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
             override fun onActivityDestroyed(activity: Activity) {}
         })
+        // Dependency wiring happens lazily on first `dependencies`
+        // read (typically MainActivity.onCreate). Bootstrap + start
+        // are kicked off as part of `buildDependencies` so each
+        // rebuild — including instrumented-test rebuilds — fans
+        // bootstrap onto the new repository instances.
+    }
 
+    private fun buildDependencies(): AppDependencies {
         val identityRepository = IdentityRepository(
             store = IdentitySecretStore(applicationContext),
         )
@@ -125,10 +146,23 @@ class OnymApplication : Application() {
         // Relayer wiring (PR #17). Bootstrap loads cached + selection
         // from disk; start() fires the network fetch. Both run on the
         // application scope so launch never blocks on the network.
-        val relayerStore = DataStorePreferencesRelayerSelectionStore(
-            dataStore = applicationContext.relayerDataStore,
-        )
-        val relayerFetcher = GitHubReleasesKnownRelayersFetcher(httpClient = httpClient)
+        // UI-test mode (set by `OnymTestRunner` from androidTest/)
+        // swaps in in-memory fakes seeded by the page-object harness;
+        // production reads from DataStore + OkHttp.
+        val relayerStore = if (UITestRegistry.enabled) {
+            UITestRegistry.relayerStore
+                ?: error("UITestRegistry.enabled but relayerStore not set")
+        } else {
+            DataStorePreferencesRelayerSelectionStore(
+                dataStore = applicationContext.relayerDataStore,
+            )
+        }
+        val relayerFetcher = if (UITestRegistry.enabled) {
+            UITestRegistry.relayerFetcher
+                ?: error("UITestRegistry.enabled but relayerFetcher not set")
+        } else {
+            GitHubReleasesKnownRelayersFetcher(httpClient = httpClient)
+        }
         val relayerRepository = RelayerRepository(
             store = relayerStore,
             fetcher = relayerFetcher,
@@ -141,10 +175,20 @@ class OnymApplication : Application() {
         // Contracts/anchors wiring — same shape as the relayer block.
         // Separate DataStore file so the two domains' storage layers
         // are independent (one less coupling at audit time).
-        val contractsStore = DataStorePreferencesAnchorSelectionStore(
-            dataStore = applicationContext.contractsDataStore,
-        )
-        val contractsFetcher = GitHubReleasesContractsManifestFetcher(httpClient = httpClient)
+        val contractsStore = if (UITestRegistry.enabled) {
+            UITestRegistry.contractsStore
+                ?: error("UITestRegistry.enabled but contractsStore not set")
+        } else {
+            DataStorePreferencesAnchorSelectionStore(
+                dataStore = applicationContext.contractsDataStore,
+            )
+        }
+        val contractsFetcher = if (UITestRegistry.enabled) {
+            UITestRegistry.contractsFetcher
+                ?: error("UITestRegistry.enabled but contractsFetcher not set")
+        } else {
+            GitHubReleasesContractsManifestFetcher(httpClient = httpClient)
+        }
         val contractsRepository = ContractsRepository(
             store = contractsStore,
             fetcher = contractsFetcher,
@@ -154,7 +198,7 @@ class OnymApplication : Application() {
             contractsRepository.start()
         }
 
-        dependencies = AppDependencies(
+        return AppDependencies(
             nostrSignerProvider = nostrSignerProvider,
             makeRecoveryPhraseBackupViewModel = { activityProvider ->
                 RecoveryPhraseBackupViewModel(

--- a/app/src/main/kotlin/chat/onym/android/UITestSupport.kt
+++ b/app/src/main/kotlin/chat/onym/android/UITestSupport.kt
@@ -1,0 +1,64 @@
+package chat.onym.android
+
+import chat.onym.android.chain.AnchorSelectionStore
+import chat.onym.android.chain.ContractsManifestFetcher
+import chat.onym.android.chain.KnownRelayersFetcher
+import chat.onym.android.chain.RelayerSelectionStore
+
+/**
+ * Indirection point that lets instrumented UI tests inject in-memory
+ * fakes for the chain seams without forking the production
+ * [OnymApplication.onCreate] wiring.
+ *
+ * Sequence in an instrumented run:
+ *
+ *  1. The custom `OnymTestRunner` (in `androidTest/`) populates the
+ *     registry fields + flips [enabled] to `true` from
+ *     `Instrumentation.onCreate(args)` — runs **before** the
+ *     application's `onCreate()`.
+ *  2. [OnymApplication.onCreate] checks [enabled]; if `true`, wires
+ *     repositories with the registered fakes instead of production
+ *     [DataStore] / OkHttp impls.
+ *
+ * Production builds compile this file but never read [enabled] as
+ * `true` — the test runner is the only writer. The cost on
+ * production startup is one volatile-boolean read per `onCreate`.
+ *
+ * Mirrors the iOS pattern of `--ui-testing` launch arguments + an
+ * in-process `RelayerRepository` substitution; the Android shape
+ * is a registry because Application can't be parameterised at
+ * launch time.
+ */
+@Suppress("MemberVisibilityCanBePrivate")
+object UITestRegistry {
+    /** When `true`, [OnymApplication.onCreate] wires the seams below
+     *  in place of the production DataStore / OkHttp implementations.
+     *  Set by the test runner before the application initialises. */
+    @Volatile
+    var enabled: Boolean = false
+
+    /** In-memory replacement for
+     *  [chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore]. */
+    var relayerStore: RelayerSelectionStore? = null
+
+    /** In-memory replacement for
+     *  [chat.onym.android.chain.GitHubReleasesKnownRelayersFetcher]. */
+    var relayerFetcher: KnownRelayersFetcher? = null
+
+    /** In-memory replacement for
+     *  [chat.onym.android.chain.DataStorePreferencesAnchorSelectionStore]. */
+    var contractsStore: AnchorSelectionStore? = null
+
+    /** In-memory replacement for
+     *  [chat.onym.android.chain.GitHubReleasesContractsManifestFetcher]. */
+    var contractsFetcher: ContractsManifestFetcher? = null
+
+    /** Reset between tests. Called from `@Before`. */
+    fun reset() {
+        enabled = false
+        relayerStore = null
+        relayerFetcher = null
+        contractsStore = null
+        contractsFetcher = null
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/ContractEntry.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/ContractEntry.kt
@@ -1,5 +1,7 @@
 package chat.onym.android.chain
 
+import androidx.annotation.StringRes
+import chat.onym.android.R
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.time.Instant
@@ -12,9 +14,12 @@ import java.time.format.DateTimeParseException
  * (forwards-compatibility — a future `"futurenet"` we don't know
  * about doesn't break the picker for the networks we do).
  */
-enum class ContractNetwork(val wireValue: String) {
-    Testnet("testnet"),
-    Public("public");
+enum class ContractNetwork(
+    val wireValue: String,
+    @StringRes val displayNameResId: Int,
+) {
+    Testnet("testnet", R.string.network_testnet),
+    Public("public", R.string.network_public);
 
     companion object {
         fun fromWire(value: String): ContractNetwork? =
@@ -30,12 +35,15 @@ enum class ContractNetwork(val wireValue: String) {
  * dropping unknowns at the boundary is correct — the picker
  * couldn't show it anyway.
  */
-enum class GovernanceType(val wireValue: String) {
-    Anarchy("anarchy"),
-    Democracy("democracy"),
-    Oligarchy("oligarchy"),
-    OneOnOne("oneonone"),
-    Tyranny("tyranny");
+enum class GovernanceType(
+    val wireValue: String,
+    @StringRes val displayNameResId: Int,
+) {
+    Anarchy("anarchy", R.string.governance_anarchy),
+    Democracy("democracy", R.string.governance_democracy),
+    Oligarchy("oligarchy", R.string.governance_oligarchy),
+    OneOnOne("oneonone", R.string.governance_oneonone),
+    Tyranny("tyranny", R.string.governance_tyranny);
 
     companion object {
         fun fromWire(value: String): GovernanceType? =

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
@@ -1,5 +1,7 @@
 package chat.onym.android.chain
 
+import androidx.annotation.StringRes
+import chat.onym.android.R
 import kotlinx.serialization.Serializable
 import java.net.URI
 import java.net.URISyntaxException
@@ -61,15 +63,15 @@ data class KnownRelayersDocument(
  *
  * Mirrors `RelayerStrategy` from onym-ios PR #20.
  */
-enum class RelayerStrategy {
+enum class RelayerStrategy(@StringRes val displayNameResId: Int) {
     /** Always use [RelayerConfiguration.primaryUrl] when set; fall
      *  back to the first endpoint when the primary marker is unset
      *  or stale. */
-    PRIMARY,
+    PRIMARY(R.string.relayer_strategy_primary),
 
     /** Uniformly random per request. [RelayerConfiguration.primaryUrl]
      *  is irrelevant in this mode. */
-    RANDOM,
+    RANDOM(R.string.relayer_strategy_random),
 }
 
 /**
@@ -93,7 +95,29 @@ data class RelayerConfiguration(
      *  yet) or stale (primary endpoint was removed but caller
      *  forgot to clear the marker — [selectUrl] tolerates this). */
     val primaryUrl: String? = null,
-    val strategy: RelayerStrategy = RelayerStrategy.PRIMARY,
+    /** Default flipped to [RelayerStrategy.RANDOM] in PR #22 — for
+     *  a fresh install with the auto-populated published list, the
+     *  random strategy spreads requests evenly across the deployed
+     *  relayers. Users who want a single endpoint just delete the
+     *  rest + flip to PRIMARY. */
+    val strategy: RelayerStrategy = RelayerStrategy.RANDOM,
+    /**
+     * `true` once the user has explicitly added/removed an endpoint,
+     * marked a primary, or switched the strategy. Distinguishes
+     * "the user has never touched this" (auto-populate eligible on
+     * the next [chat.onym.android.chain.RelayerRepository.refresh])
+     * from "the user explicitly cleared the list" (don't auto-
+     * repopulate).
+     *
+     * **Backward-compat with PR #20 saves**: kotlinx.serialization
+     * fills missing fields with the default. The default below is
+     * `true` so a PR #20 wire shape (no `hasUserInteracted` field)
+     * decodes as "interacted" — old users with custom URLs don't
+     * get them blown away by re-population from the manifest.
+     * Cold-fresh installs explicitly construct
+     * [RelayerConfiguration.empty] which sets `false`.
+     */
+    val hasUserInteracted: Boolean = true,
 ) {
     /**
      * Resolve the URL for a single chain request. Pure function;
@@ -125,6 +149,19 @@ data class RelayerConfiguration(
             }
             RelayerStrategy.RANDOM -> endpoints.random(random).url
         }
+    }
+
+    companion object {
+        /** Cold-install starting state: no endpoints, no primary,
+         *  RANDOM strategy, **`hasUserInteracted = false`** so the
+         *  next [chat.onym.android.chain.RelayerRepository.refresh]
+         *  fans the published list into [endpoints]. */
+        val empty: RelayerConfiguration = RelayerConfiguration(
+            endpoints = emptyList(),
+            primaryUrl = null,
+            strategy = RelayerStrategy.RANDOM,
+            hasUserInteracted = false,
+        )
     }
 }
 

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
@@ -33,7 +33,12 @@ class RelayerRepository(
     private val _snapshots = MutableStateFlow(
         RelayerState(
             knownRelayers = emptyList(),
-            configuration = RelayerConfiguration(),
+            // Cold-fresh in-memory state until bootstrap() reads disk.
+            // `empty` has hasUserInteracted = false so a first-launch
+            // refresh() seeds the published list. Once disk is loaded
+            // (legacy migration paths set it to true), the snapshot
+            // reflects whatever the user already had.
+            configuration = RelayerConfiguration.empty,
         )
     )
 
@@ -50,13 +55,17 @@ class RelayerRepository(
         _snapshots.value = RelayerState(knownRelayers = cached, configuration = config)
     }
 
-    /** Fire-and-forget the GitHub-Releases fetch. Idempotent. */
+    /** Fire-and-forget the GitHub-Releases fetch. Idempotent.
+     *  Errors swallowed (app launch must not crash on a network
+     *  blip). On success, [autoPopulateIfFreshLocked] seeds the
+     *  configured list with the published entries when the user
+     *  hasn't yet interacted with the picker. */
     suspend fun start() = mutex.withLock {
         if (startInvoked) return@withLock
         startInvoked = true
         runCatching { fetcher.fetch() }.onSuccess { fresh ->
             store.saveCachedKnownRelayers(fresh)
-            _snapshots.value = _snapshots.value.copy(knownRelayers = fresh)
+            applyKnownListAndAutoPopulateLocked(fresh)
         }
     }
 
@@ -65,8 +74,37 @@ class RelayerRepository(
         val fresh = fetcher.fetch()
         mutex.withLock {
             store.saveCachedKnownRelayers(fresh)
-            _snapshots.value = _snapshots.value.copy(knownRelayers = fresh)
+            applyKnownListAndAutoPopulateLocked(fresh)
         }
+    }
+
+    /** Common path for [start] + [refresh]: stash the fetched list,
+     *  and if the user hasn't yet interacted with the picker,
+     *  fan it into the configured endpoints (RANDOM strategy, no
+     *  primary). Once `hasUserInteracted` flips, future fetches
+     *  only update the cached known list — never the configuration. */
+    private suspend fun applyKnownListAndAutoPopulateLocked(fresh: List<RelayerEndpoint>) {
+        val current = _snapshots.value.configuration
+        val updatedConfig = if (!current.hasUserInteracted && fresh.isNotEmpty()) {
+            RelayerConfiguration(
+                endpoints = fresh,
+                primaryUrl = null,
+                strategy = RelayerStrategy.RANDOM,
+                // Sticky — auto-populate runs once per install. From
+                // here on, the user owns the list; subsequent
+                // refreshes only refresh the cached published list.
+                hasUserInteracted = true,
+            )
+        } else {
+            current
+        }
+        if (updatedConfig != current) {
+            store.saveConfiguration(updatedConfig)
+        }
+        _snapshots.value = RelayerState(
+            knownRelayers = fresh,
+            configuration = updatedConfig,
+        )
     }
 
     // ─── list-shaped mutators ─────────────────────────────────────
@@ -129,8 +167,14 @@ class RelayerRepository(
     fun selectUrl(random: Random = Random.Default): String? =
         _snapshots.value.configuration.selectUrl(random)
 
+    /** Common path for every list-shaped mutator. Promotes
+     *  [RelayerConfiguration.hasUserInteracted] to `true` so a
+     *  subsequent [refresh] doesn't blow away the user's choices
+     *  via auto-populate. */
     private suspend fun applyConfigurationLocked(updated: RelayerConfiguration) {
-        store.saveConfiguration(updated)
-        _snapshots.value = _snapshots.value.copy(configuration = updated)
+        val withFlag = if (updated.hasUserInteracted) updated
+                       else updated.copy(hasUserInteracted = true)
+        store.saveConfiguration(withFlag)
+        _snapshots.value = _snapshots.value.copy(configuration = withFlag)
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
@@ -67,15 +67,20 @@ class DataStorePreferencesRelayerSelectionStore(
         if (raw != null) {
             // New-key path. Once migration has run we never look at
             // the legacy key again — migrated installs end up here.
+            // Corrupt blob → fall back to .empty so the next refresh
+            // can auto-populate (the user lost their prior config to
+            // data corruption; auto-populate is a reasonable recovery).
             return try {
                 jsonFormat.decodeFromString(RelayerConfiguration.serializer(), raw)
             } catch (_: SerializationException) {
-                RelayerConfiguration()
+                RelayerConfiguration.empty
             }
         }
         // Cold install OR pre-migration. Try the legacy key once.
+        // `.empty` (hasUserInteracted=false) for a truly cold start
+        // so the first refresh() seeds the published list.
         val legacy = prefs[LEGACY_KEY_SELECTION]
-            ?: return RelayerConfiguration()  // truly cold; no writes
+            ?: return RelayerConfiguration.empty
         return migrateLegacySelection(legacy)
     }
 
@@ -131,16 +136,26 @@ class DataStorePreferencesRelayerSelectionStore(
                 else -> null
             }
             if (endpoint != null) {
+                // PR #17 → PR #22: the user explicitly picked this
+                // endpoint, so flag it as user-interacted (the data
+                // class default already covers this — explicit pass
+                // for clarity). Strategy stays PRIMARY for the
+                // single-endpoint case the user picked.
                 RelayerConfiguration(
                     endpoints = listOf(endpoint),
                     primaryUrl = endpoint.url,
                     strategy = RelayerStrategy.PRIMARY,
+                    hasUserInteracted = true,
                 )
             } else {
-                RelayerConfiguration()  // unknown kind; drop
+                // Unknown kind / corrupt blob → fall back to .empty
+                // so the next refresh seeds the published list (the
+                // user lost their pick to data corruption; auto-
+                // populate is a reasonable recovery).
+                RelayerConfiguration.empty
             }
         } catch (_: SerializationException) {
-            RelayerConfiguration()  // corrupt blob; drop
+            RelayerConfiguration.empty
         }
         // Persist the migrated configuration AND remove the legacy
         // key in a single atomic edit so a subsequent crash + relaunch

--- a/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
@@ -28,10 +28,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
 import chat.onym.android.chain.ContractNetwork
 import chat.onym.android.chain.GovernanceType
 
@@ -54,10 +57,13 @@ fun AnchorsRootScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text("Anchors") },
+                title = { Text(stringResource(R.string.anchors_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
             )
@@ -65,7 +71,7 @@ fun AnchorsRootScreen(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
         LazyColumn(contentPadding = padding) {
-            item { SectionHeader("NETWORK") }
+            item { SectionHeader(stringResource(R.string.anchors_section_network)) }
             items(ContractNetwork.entries) { network ->
                 val available = state.networkAvailability[network] == true
                 NetworkRootRow(
@@ -76,12 +82,7 @@ fun AnchorsRootScreen(
                     } else null,
                 )
             }
-            item {
-                Footer(
-                    "Pick the smart contract version each new chat is anchored to. " +
-                        "Existing chats stay on whatever version they were created with."
-                )
-            }
+            item { Footer(stringResource(R.string.anchors_footer)) }
         }
     }
 }
@@ -101,10 +102,13 @@ fun AnchorsNetworkScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(networkDisplayName(network)) },
+                title = { Text(stringResource(network.displayNameResId)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
             )
@@ -112,7 +116,7 @@ fun AnchorsNetworkScreen(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
         LazyColumn(contentPadding = padding) {
-            item { SectionHeader("GOVERNANCE TYPE") }
+            item { SectionHeader(stringResource(R.string.anchors_section_governance_type)) }
             items(rows, key = { it.type.wireValue }) { row ->
                 GovernanceTypeRow(
                     type = row.type,
@@ -123,12 +127,7 @@ fun AnchorsNetworkScreen(
                     } else null,
                 )
             }
-            item {
-                Footer(
-                    "Each governance type uses a separate contract. The release tag in " +
-                        "parentheses is the version a brand-new chat would be anchored to."
-                )
-            }
+            item { Footer(stringResource(R.string.anchors_network_footer)) }
         }
     }
 }
@@ -146,10 +145,13 @@ fun AnchorsVersionScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text(governanceDisplayName(type)) },
+                title = { Text(stringResource(type.displayNameResId)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
             )
@@ -157,7 +159,7 @@ fun AnchorsVersionScreen(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
         LazyColumn(contentPadding = padding) {
-            item { SectionHeader("RELEASES") }
+            item { SectionHeader(stringResource(R.string.anchors_section_releases)) }
             items(rows, key = { it.release.release }) { row ->
                 VersionRow(
                     label = row.release.release,
@@ -169,7 +171,7 @@ fun AnchorsVersionScreen(
                     },
                 )
             }
-            item { SectionHeader("RESET") }
+            item { SectionHeader(stringResource(R.string.anchors_section_reset)) }
             item {
                 ResetRow(
                     onClick = {
@@ -178,11 +180,7 @@ fun AnchorsVersionScreen(
                     },
                 )
             }
-            item {
-                Footer(
-                    "Reset clears the explicit pick — new chats fall back to the latest published release."
-                )
-            }
+            item { Footer(stringResource(R.string.anchors_reset_footer)) }
         }
     }
 }
@@ -204,15 +202,16 @@ private fun NetworkRootRow(
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .let { if (onClick != null) it.clickable(onClick = onClick) else it }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("anchors.network.${network.wireValue}"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(networkDisplayName(network),
+            Text(stringResource(network.displayNameResId),
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
                 color = titleColor)
             if (!available) {
-                Text("No contracts yet",
+                Text(stringResource(R.string.anchors_no_contracts_yet),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
@@ -241,16 +240,17 @@ private fun GovernanceTypeRow(
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .let { if (onClick != null) it.clickable(onClick = onClick) else it }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("anchors.type.${type.wireValue}"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(governanceDisplayName(type),
+            Text(stringResource(type.displayNameResId),
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
             val subtitle = when {
-                resolvedRelease == null -> "No contract"
-                isExplicit -> "$resolvedRelease (selected)"
-                else -> "$resolvedRelease (latest)"
+                resolvedRelease == null -> stringResource(R.string.anchors_no_contract_for_type)
+                isExplicit -> stringResource(R.string.anchors_subtitle_selected, resolvedRelease)
+                else -> stringResource(R.string.anchors_subtitle_latest, resolvedRelease)
             }
             Text(subtitle,
                 style = MaterialTheme.typography.bodySmall,
@@ -280,7 +280,8 @@ private fun VersionRow(
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("anchors.version.$label"),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
@@ -300,7 +301,7 @@ private fun VersionRow(
             ) {
                 Icon(
                     Icons.Filled.Check,
-                    contentDescription = "Selected",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onPrimary,
                     modifier = Modifier.size(14.dp),
                 )
@@ -318,11 +319,12 @@ private fun ResetRow(onClick: () -> Unit) {
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("anchors.version.reset"),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {
-        Text("Reset to default",
+        Text(stringResource(R.string.anchors_reset_to_default),
             style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
             color = MaterialTheme.colorScheme.primary)
     }
@@ -349,17 +351,4 @@ private fun Footer(text: String) {
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
     )
-}
-
-private fun networkDisplayName(network: ContractNetwork): String = when (network) {
-    ContractNetwork.Testnet -> "Testnet"
-    ContractNetwork.Public -> "Mainnet"
-}
-
-private fun governanceDisplayName(type: GovernanceType): String = when (type) {
-    GovernanceType.Anarchy -> "Anarchy"
-    GovernanceType.Democracy -> "Democracy"
-    GovernanceType.Oligarchy -> "Oligarchy"
-    GovernanceType.OneOnOne -> "One-on-one"
-    GovernanceType.Tyranny -> "Tyranny"
 }

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
@@ -42,11 +42,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
 import chat.onym.android.chain.RelayerEndpoint
 import chat.onym.android.chain.RelayerStrategy
 
@@ -70,10 +73,13 @@ fun RelayerSettingsScreen(
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
-                title = { Text("Relayer") },
+                title = { Text(stringResource(R.string.relayer_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
             )
@@ -83,7 +89,7 @@ fun RelayerSettingsScreen(
         LazyColumn(contentPadding = padding) {
 
             // ─── Strategy ────────────────────────────────────────
-            item { SectionHeader("STRATEGY") }
+            item { SectionHeader(stringResource(R.string.relayer_strategy_label)) }
             item {
                 StrategySelector(
                     strategy = state.configuration.strategy,
@@ -92,20 +98,21 @@ fun RelayerSettingsScreen(
             }
             item {
                 Footer(
-                    when (state.configuration.strategy) {
-                        RelayerStrategy.PRIMARY -> "Always use the primary endpoint. Falls back to the first " +
-                            "configured endpoint if no primary is set or the primary was removed."
-                        RelayerStrategy.RANDOM -> "Pick a random endpoint per request. Distributes load evenly."
-                    }
+                    stringResource(
+                        when (state.configuration.strategy) {
+                            RelayerStrategy.PRIMARY -> R.string.relayer_strategy_footer_primary
+                            RelayerStrategy.RANDOM -> R.string.relayer_strategy_footer_random
+                        }
+                    )
                 )
             }
 
             // ─── Configured ──────────────────────────────────────
-            item { SectionHeader("CONFIGURED") }
+            item { SectionHeader(stringResource(R.string.relayer_section_configured)) }
             if (state.configuration.endpoints.isEmpty()) {
                 item {
                     Text(
-                        "No endpoints configured. Add one below.",
+                        stringResource(R.string.relayer_empty_configured),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
@@ -129,12 +136,14 @@ fun RelayerSettingsScreen(
             }
 
             // ─── Add from Published List ─────────────────────────
-            item { SectionHeader("ADD FROM PUBLISHED LIST") }
+            item { SectionHeader(stringResource(R.string.relayer_section_add_known)) }
             if (state.unconfiguredKnownList.isEmpty()) {
                 item {
                     Text(
-                        if (state.configuration.endpoints.isEmpty()) "Fetching list…"
-                        else "All published relayers are already configured.",
+                        stringResource(
+                            if (state.configuration.endpoints.isEmpty()) R.string.relayer_known_fetching
+                            else R.string.relayer_known_all_added
+                        ),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
@@ -150,7 +159,7 @@ fun RelayerSettingsScreen(
             }
 
             // ─── Add Custom URL ──────────────────────────────────
-            item { SectionHeader("ADD CUSTOM URL") }
+            item { SectionHeader(stringResource(R.string.relayer_section_add_custom)) }
             item {
                 CustomAddRow(
                     draft = state.customDraft,
@@ -159,12 +168,7 @@ fun RelayerSettingsScreen(
                     onAdd = viewModel::tappedAddCustom,
                 )
             }
-            item {
-                Footer(
-                    "For private deployments, localhost development, or sideloaded networks. " +
-                        "URL must use http or https."
-                )
-            }
+            item { Footer(stringResource(R.string.relayer_custom_footer)) }
         }
     }
 }
@@ -180,7 +184,8 @@ private fun StrategySelector(
     SingleChoiceSegmentedButtonRow(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .testTag(TAG_STRATEGY_PICKER),
     ) {
         val options = listOf(RelayerStrategy.PRIMARY, RelayerStrategy.RANDOM)
         options.forEachIndexed { index, opt ->
@@ -188,13 +193,9 @@ private fun StrategySelector(
                 selected = opt == strategy,
                 onClick = { onChange(opt) },
                 shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
+                modifier = Modifier.testTag("relayer.strategy.${opt.name.lowercase()}"),
             ) {
-                Text(
-                    when (opt) {
-                        RelayerStrategy.PRIMARY -> "Primary"
-                        RelayerStrategy.RANDOM -> "Random"
-                    }
-                )
+                Text(stringResource(opt.displayNameResId))
             }
         }
     }
@@ -233,7 +234,8 @@ private fun SwipeableEndpointRow(
         enableDismissFromStartToEnd = false,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .testTag("relayer.configured.${endpoint.url}"),
     ) {
         EndpointRow(endpoint = endpoint, isPrimary = isPrimary, onTogglePrimary = onTogglePrimary)
     }
@@ -251,7 +253,7 @@ private fun DeleteBackground() {
     ) {
         Icon(
             Icons.Filled.Delete,
-            contentDescription = "Delete",
+            contentDescription = stringResource(R.string.relayer_row_delete),
             tint = MaterialTheme.colorScheme.onErrorContainer,
         )
     }
@@ -272,10 +274,16 @@ private fun EndpointRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        IconButton(onClick = onTogglePrimary) {
+        IconButton(
+            onClick = onTogglePrimary,
+            modifier = Modifier.testTag("relayer.configured.${endpoint.url}.primary_button"),
+        ) {
             Icon(
                 imageVector = if (isPrimary) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                contentDescription = if (isPrimary) "Primary endpoint" else "Mark as primary",
+                contentDescription = stringResource(
+                    if (isPrimary) R.string.relayer_row_primary_label
+                    else R.string.relayer_row_mark_primary
+                ),
                 tint = if (isPrimary) Color(0xFFFF9500)
                        else MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -324,14 +332,15 @@ private fun KnownRelayerAddRow(endpoint: RelayerEndpoint, onClick: () -> Unit) {
             .padding(horizontal = 16.dp, vertical = 4.dp)
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .padding(horizontal = 12.dp, vertical = 10.dp),
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .testTag("relayer.add.known.${endpoint.url}"),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         IconButton(onClick = onClick) {
             Icon(
                 Icons.Filled.Add,
-                contentDescription = "Add",
+                contentDescription = stringResource(R.string.relayer_custom_add),
                 tint = MaterialTheme.colorScheme.primary,
             )
         }
@@ -373,7 +382,9 @@ private fun CustomAddRow(
             singleLine = true,
             isError = error != null,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TAG_CUSTOM_FIELD),
         )
         if (error != null) {
             Text(
@@ -385,14 +396,23 @@ private fun CustomAddRow(
         Button(
             onClick = onAdd,
             enabled = draft.isNotBlank(),
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(TAG_CUSTOM_BUTTON),
             shape = RoundedCornerShape(10.dp),
             contentPadding = PaddingValues(vertical = 12.dp),
         ) {
-            Text("Add", fontWeight = FontWeight.SemiBold)
+            Text(stringResource(R.string.relayer_custom_add), fontWeight = FontWeight.SemiBold)
         }
     }
 }
+
+// Test tags exposed for instrumented UI tests under
+// app/src/androidTest/.../uitests. Stable across releases — UI test
+// fakes pin against these strings.
+const val TAG_STRATEGY_PICKER = "relayer.strategy.picker"
+const val TAG_CUSTOM_FIELD = "relayer.add.custom.field"
+const val TAG_CUSTOM_BUTTON = "relayer.add.custom.button"
 
 @Composable
 private fun SectionHeader(text: String) {

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import chat.onym.android.R
@@ -113,13 +114,13 @@ fun SettingsScreen(
                 )
             }
 
-            // Network section — relayer URL config. English-only for
-            // now per the iOS twin (PR #18); lift into res/values/
-            // when a translation pass for Settings lands.
-            item { SectionHeader("NETWORK") }
+            // Network section — relayer URL config + anchor contract
+            // versions. Localized via res/values/ + values-ru/ per
+            // PR #21's catalog work.
+            item { SectionHeader(stringResource(R.string.settings_network)) }
             item {
                 ListItem(
-                    headlineContent = { Text("Relayer") },
+                    headlineContent = { Text(stringResource(R.string.relayer_title)) },
                     leadingContent = {
                         SettingsIconBox(
                             icon = Icons.Filled.Cloud,
@@ -139,20 +140,13 @@ fun SettingsScreen(
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onRelayerClick),
-                )
-            }
-            item {
-                Text(
-                    "Where chain operations are submitted. Discovered from GitHub Releases of onymchat/onym-relayer; can be overridden with a custom URL.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                        .clickable(onClick = onRelayerClick)
+                        .testTag("settings.relayer_row"),
                 )
             }
             item {
                 ListItem(
-                    headlineContent = { Text("Anchors") },
+                    headlineContent = { Text(stringResource(R.string.anchors_title)) },
                     leadingContent = {
                         SettingsIconBox(
                             icon = Icons.Filled.Anchor,
@@ -172,12 +166,13 @@ fun SettingsScreen(
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onAnchorsClick),
+                        .clickable(onClick = onAnchorsClick)
+                        .testTag("settings.anchors_row"),
                 )
             }
             item {
                 Text(
-                    "Smart-contract version each new chat is anchored to. Picks per (network, governance type); existing chats stay on whatever they were created with.",
+                    stringResource(R.string.settings_network_footer),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -70,4 +70,55 @@
     <string name="security_footer_view_recovery_phrase">Просмотрите свою фразу восстановления из 12 слов. Она понадобится для восстановления личности на новом устройстве.</string>
     <string name="search_placeholder_body">Поиск появится в одном из следующих обновлений.</string>
 
+    <!-- ─── Settings → Network section (umbrella) ────────────────── -->
+    <string name="settings_network">Сеть</string>
+    <string name="settings_network_footer">Выберите релеер, который отправляет транзакции, и версию контракта для якорения новых чатов. Существующие чаты сохраняют контракт, с которым были созданы.</string>
+
+    <!-- ─── Settings → Relayer screen ────────────────────────────── -->
+    <string name="relayer_title">Релеер</string>
+    <string name="relayer_strategy_label">Стратегия</string>
+    <string name="relayer_strategy_primary">Основной</string>
+    <string name="relayer_strategy_random">Случайный</string>
+    <string name="relayer_strategy_footer_primary">Всегда использовать основной релеер. Если основной не выбран, используется первый из настроенных.</string>
+    <string name="relayer_strategy_footer_random">Выбирать случайный релеер для каждого запроса. Полезно для распределения нагрузки между резервными деплоями.</string>
+    <string name="relayer_section_configured">Настроенные</string>
+    <string name="relayer_section_add_known">Добавить из опубликованного списка</string>
+    <string name="relayer_section_add_custom">Добавить свой URL</string>
+    <string name="relayer_empty_configured">Релееры не настроены. Добавьте ниже.</string>
+    <string name="relayer_known_all_added">Все опубликованные релееры добавлены.</string>
+    <string name="relayer_known_fetching">Загружаю список…</string>
+    <string name="relayer_known_footer">Публикуется проектом onym-relayer. Нажмите, чтобы добавить.</string>
+    <string name="relayer_custom_footer">Используйте свой деплой, localhost или любой релеер, отсутствующий в опубликованном списке.</string>
+    <string name="relayer_custom_invalid">Введите корректный URL вида https://</string>
+    <string name="relayer_custom_add">Добавить</string>
+    <string name="relayer_row_primary_label">Основной релеер</string>
+    <string name="relayer_row_mark_primary">Сделать основным</string>
+    <string name="relayer_row_delete">Удалить</string>
+
+    <!-- ─── Settings → Anchors screen ────────────────────────────── -->
+    <string name="anchors_title">Якоря</string>
+    <string name="anchors_footer">Выберите версию контракта для якорения состояния группы в блокчейне. Выбор для каждой пары (сеть, тип) применяется к новым чатам; существующие чаты сохраняют контракт, с которым были созданы.</string>
+    <string name="anchors_no_contracts_yet">Контрактов пока нет</string>
+    <string name="anchors_no_contract_for_type">Нет контракта</string>
+    <string name="anchors_reset_to_default">Сбросить к значению по умолчанию (последняя версия)</string>
+    <string name="anchors_section_network">Сеть</string>
+    <string name="anchors_section_governance_type">Тип управления</string>
+    <string name="anchors_section_releases">Версии</string>
+    <string name="anchors_section_reset">Сброс</string>
+    <string name="anchors_subtitle_selected">%1$s (выбрано)</string>
+    <string name="anchors_subtitle_latest">%1$s (последняя)</string>
+    <string name="anchors_network_footer">Каждый тип управления использует отдельный контракт. Тег версии в скобках — это версия, к которой будет привязан новый чат.</string>
+    <string name="anchors_reset_footer">Сброс очищает явный выбор — новые чаты используют последнюю опубликованную версию.</string>
+
+    <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
+    <string name="network_testnet">Тестовая сеть</string>
+    <string name="network_public">Основная сеть</string>
+
+    <!-- ─── GovernanceType.displayName ───────────────────────────── -->
+    <string name="governance_anarchy">Анархия</string>
+    <string name="governance_democracy">Демократия</string>
+    <string name="governance_oligarchy">Олигархия</string>
+    <string name="governance_oneonone">Один на один</string>
+    <string name="governance_tyranny">Тирания</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,56 @@
     <string name="security_footer_view_recovery_phrase">View your 12-word recovery phrase. You will need it to restore your identity on a new device.</string>
     <string name="search_placeholder_body">Search lands in a later chunk.</string>
 
+    <!-- ─── Settings → Network section (umbrella) ────────────────── -->
+    <!-- Mirrors the chain-UI catalog from onym-ios PR #21. -->
+    <string name="settings_network">Network</string>
+    <string name="settings_network_footer">Choose the relayer that submits transactions and which contract version anchors new chats. Existing chats keep the contract they were created with.</string>
+
+    <!-- ─── Settings → Relayer screen ────────────────────────────── -->
+    <string name="relayer_title">Relayer</string>
+    <string name="relayer_strategy_label">Strategy</string>
+    <string name="relayer_strategy_primary">Primary</string>
+    <string name="relayer_strategy_random">Random</string>
+    <string name="relayer_strategy_footer_primary">Always use the primary relayer. If no primary is set, the first configured relayer is used.</string>
+    <string name="relayer_strategy_footer_random">Pick a random relayer for each request. Useful for spreading load across redundant deployments.</string>
+    <string name="relayer_section_configured">Configured</string>
+    <string name="relayer_section_add_known">Add from Published List</string>
+    <string name="relayer_section_add_custom">Add Custom URL</string>
+    <string name="relayer_empty_configured">No relayers configured. Add one below.</string>
+    <string name="relayer_known_all_added">All published relayers added.</string>
+    <string name="relayer_known_fetching">Fetching list…</string>
+    <string name="relayer_known_footer">Published by the onym-relayer project. Tap to add.</string>
+    <string name="relayer_custom_footer">Use a private deployment, localhost, or any relayer not in the published list.</string>
+    <string name="relayer_custom_invalid">Enter a valid https:// URL</string>
+    <string name="relayer_custom_add">Add</string>
+    <string name="relayer_row_primary_label">Primary endpoint</string>
+    <string name="relayer_row_mark_primary">Mark as primary</string>
+    <string name="relayer_row_delete">Delete</string>
+
+    <!-- ─── Settings → Anchors screen ────────────────────────────── -->
+    <string name="anchors_title">Anchors</string>
+    <string name="anchors_footer">Choose the contract version used to anchor on-chain group state. Selection per (network, governance type) pins to new chats; existing chats keep the contract they were created with.</string>
+    <string name="anchors_no_contracts_yet">No contracts yet</string>
+    <string name="anchors_no_contract_for_type">No contract</string>
+    <string name="anchors_reset_to_default">Reset to Default (latest)</string>
+    <string name="anchors_section_network">Network</string>
+    <string name="anchors_section_governance_type">Governance type</string>
+    <string name="anchors_section_releases">Releases</string>
+    <string name="anchors_section_reset">Reset</string>
+    <string name="anchors_subtitle_selected">%1$s (selected)</string>
+    <string name="anchors_subtitle_latest">%1$s (latest)</string>
+    <string name="anchors_network_footer">Each governance type uses a separate contract. The release tag in parentheses is the version a brand-new chat would be anchored to.</string>
+    <string name="anchors_reset_footer">Reset clears the explicit pick — new chats fall back to the latest published release.</string>
+
+    <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
+    <string name="network_testnet">Testnet</string>
+    <string name="network_public">Mainnet</string>
+
+    <!-- ─── GovernanceType.displayName ───────────────────────────── -->
+    <string name="governance_anarchy">Anarchy</string>
+    <string name="governance_democracy">Democracy</string>
+    <string name="governance_oligarchy">Oligarchy</string>
+    <string name="governance_oneonone">One-on-one</string>
+    <string name="governance_tyranny">Tyranny</string>
+
 </resources>

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryRelayerSelectionStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryRelayerSelectionStore.kt
@@ -21,7 +21,7 @@ class InMemoryRelayerSelectionStore : RelayerSelectionStore {
     private var cached: List<RelayerEndpoint> = emptyList()
 
     override suspend fun loadConfiguration(): RelayerConfiguration =
-        mutex.withLock { configuration ?: RelayerConfiguration() }
+        mutex.withLock { configuration ?: RelayerConfiguration.empty }
 
     override suspend fun saveConfiguration(configuration: RelayerConfiguration) {
         mutex.withLock { this.configuration = configuration }

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerConfigurationTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerConfigurationTest.kt
@@ -2,6 +2,7 @@ package chat.onym.android.chain
 
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -152,5 +153,69 @@ class RelayerConfigurationTest {
         assertEquals("custom", ep.network)
         assertEquals("relayer.example.com", ep.name)
         assertEquals("https://relayer.example.com:9443/path", ep.url)
+    }
+
+    // ─── PR #22 defaults + hasUserInteracted backward-compat ──────
+
+    @Test
+    fun empty_factory_returnsRandomStrategyAndUntouchedFlag() {
+        val empty = RelayerConfiguration.empty
+        assertTrue(empty.endpoints.isEmpty())
+        assertNull(empty.primaryUrl)
+        assertEquals(RelayerStrategy.RANDOM, empty.strategy)
+        assertFalse(
+            "fresh-install state must not be flagged as user-touched (would suppress auto-populate)",
+            empty.hasUserInteracted,
+        )
+    }
+
+    @Test
+    fun defaultStrategy_isRandom_forCold_constructed_configuration() {
+        // The data class default flipped from PRIMARY → RANDOM in
+        // PR #22 to match the auto-populate behaviour: a fresh
+        // install with the published list spread across endpoints
+        // wants Random by default.
+        val cfg = RelayerConfiguration()
+        assertEquals(RelayerStrategy.RANDOM, cfg.strategy)
+    }
+
+    @Test
+    fun serialization_roundtripPreservesHasUserInteracted() {
+        val touched = RelayerConfiguration(
+            endpoints = listOf(a),
+            strategy = RelayerStrategy.PRIMARY,
+            hasUserInteracted = true,
+        )
+        val untouched = RelayerConfiguration.empty
+
+        val json = Json { encodeDefaults = true }
+        for (original in listOf(touched, untouched)) {
+            val encoded = json.encodeToString(RelayerConfiguration.serializer(), original)
+            val decoded = json.decodeFromString(RelayerConfiguration.serializer(), encoded)
+            assertEquals(original, decoded)
+            assertEquals(original.hasUserInteracted, decoded.hasUserInteracted)
+        }
+    }
+
+    @Test
+    fun serialization_decodingPR20WireShape_yieldsHasUserInteractedTrue() {
+        // PR #20 saved configurations without `hasUserInteracted`.
+        // Backward-compat default is `true` so already-configured
+        // users don't lose their custom URLs to auto-populate.
+        val pr20Json = """
+            {
+              "endpoints": [
+                { "name": "Onym Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" }
+              ],
+              "primaryUrl": "https://relayer-testnet.onym.chat",
+              "strategy": "PRIMARY"
+            }
+        """.trimIndent()
+        val decoded = Json { ignoreUnknownKeys = true }
+            .decodeFromString(RelayerConfiguration.serializer(), pr20Json)
+        assertTrue(
+            "PR #20 saves must decode as `hasUserInteracted = true` so refresh() doesn't blow them away",
+            decoded.hasUserInteracted,
+        )
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
@@ -4,6 +4,7 @@ import chat.onym.android.support.FakeKnownRelayersFetcher
 import chat.onym.android.support.InMemoryRelayerSelectionStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -70,6 +71,106 @@ class RelayerRepositoryTest {
         repo.start()  // must not throw
 
         assertEquals(listOf(a), repo.snapshots.value.knownRelayers)
+    }
+
+    // ─── PR #22: auto-populate on first launch ────────────────────
+
+    @Test
+    fun start_autoPopulates_whenColdConfigAndFetchedListNonEmpty() = runTest {
+        // Cold-fresh install: no saved configuration. start() must
+        // fan the published list into endpoints, sticking
+        // hasUserInteracted=true so subsequent fetches don't churn.
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a, b)))
+        val (repo, store) = makeRepo(fetcher = fetcher)
+        repo.bootstrap()  // loads RelayerConfiguration() from empty store
+
+        repo.start()
+
+        val cfg = repo.snapshots.value.configuration
+        assertEquals(listOf(a, b), cfg.endpoints)
+        assertNull(cfg.primaryUrl)
+        assertEquals(RelayerStrategy.RANDOM, cfg.strategy)
+        assertTrue("auto-populate must mark the configuration as user-touched", cfg.hasUserInteracted)
+        // Persisted to disk too.
+        assertEquals(listOf(a, b), store.loadConfiguration().endpoints)
+    }
+
+    @Test
+    fun start_doesNotAutoPopulate_whenUserHasAlreadyInteracted() = runTest {
+        // Pre-existing PR #20-era configuration with the user's
+        // custom endpoint. start() loads the published list but
+        // must NOT touch the configured endpoints.
+        val store = InMemoryRelayerSelectionStore().apply {
+            saveConfiguration(
+                RelayerConfiguration(
+                    endpoints = listOf(custom),
+                    strategy = RelayerStrategy.PRIMARY,
+                    primaryUrl = custom.url,
+                    hasUserInteracted = true,
+                )
+            )
+        }
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a, b)))
+        val (repo, _) = makeRepo(store, fetcher)
+        repo.bootstrap()
+
+        repo.start()
+
+        val cfg = repo.snapshots.value.configuration
+        assertEquals(listOf(custom), cfg.endpoints)
+        assertEquals(custom.url, cfg.primaryUrl)
+        assertEquals(RelayerStrategy.PRIMARY, cfg.strategy)
+    }
+
+    @Test
+    fun start_doesNotAutoPopulate_whenFetchedListIsEmpty() = runTest {
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(emptyList()))
+        val (repo, _) = makeRepo(fetcher = fetcher)
+        repo.bootstrap()
+
+        repo.start()
+
+        val cfg = repo.snapshots.value.configuration
+        assertTrue(cfg.endpoints.isEmpty())
+        assertFalse(
+            "no fetched list → no auto-populate → flag stays false (next refresh can still populate)",
+            cfg.hasUserInteracted,
+        )
+    }
+
+    @Test
+    fun refresh_runsAutoPopulateWhenFlagStillFalse() = runTest {
+        // Boot fetch failed (offline at launch); user opens the
+        // picker and hits a refresh — the same auto-populate path
+        // fires.
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Failing(IOException("offline")))
+        val (repo, _) = makeRepo(fetcher = fetcher)
+        repo.bootstrap()
+        repo.start()  // failed silently; flag still false
+
+        // Now point the fetcher at a successful response and refresh.
+        fetcher.mode = FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a, b))
+        repo.refresh()
+
+        val cfg = repo.snapshots.value.configuration
+        assertEquals(listOf(a, b), cfg.endpoints)
+        assertTrue(cfg.hasUserInteracted)
+    }
+
+    @Test
+    fun mutators_promoteHasUserInteractedFromFalseToTrue() = runTest {
+        // Cold config (hasUserInteracted = false). Each list-shaped
+        // mutator must flip the flag — guards against a stale future
+        // refresh fanning the published list back over the user's
+        // explicit edits.
+        val (repo, store) = makeRepo()
+        repo.bootstrap()
+        assertFalse(repo.snapshots.value.configuration.hasUserInteracted)
+
+        repo.addEndpoint(custom)
+
+        assertTrue(repo.snapshots.value.configuration.hasUserInteracted)
+        assertTrue(store.loadConfiguration().hasUserInteracted)
     }
 
     // ─── addEndpoint ──────────────────────────────────────────────
@@ -229,6 +330,11 @@ class RelayerRepositoryTest {
     fun selectUrl_primary_fallsBackToFirstWhenPrimaryStaleOrUnset() = runTest {
         val (repo, _) = makeRepo()
         repo.addEndpoint(a); repo.addEndpoint(b)
+        // Default strategy flipped to RANDOM in PR #22 — explicitly
+        // set PRIMARY so this test still exercises the fall-back-to-
+        // first path. (User-flow-wise: hits this when the user toggles
+        // back to Primary after the default-random fan-in.)
+        repo.setStrategy(RelayerStrategy.PRIMARY)
         // No setPrimary call → primaryUrl is null → fall through to first.
         assertEquals(a.url, repo.selectUrl())
     }

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
@@ -56,7 +56,10 @@ class RelayerSelectionStoreTest {
 
     @Test
     fun loadConfiguration_returnsEmptyOnFreshStore() = runTest {
-        assertEquals(RelayerConfiguration(), store.loadConfiguration())
+        // Cold-fresh store returns RelayerConfiguration.empty
+        // (hasUserInteracted=false) so the next refresh seeds the
+        // published list. PR #22 default.
+        assertEquals(RelayerConfiguration.empty, store.loadConfiguration())
     }
 
     @Test
@@ -78,7 +81,7 @@ class RelayerSelectionStoreTest {
         store.saveConfiguration(
             RelayerConfiguration(endpoints = listOf(testnet), primaryUrl = testnet.url)
         )
-        val updated = RelayerConfiguration()
+        val updated = RelayerConfiguration(endpoints = listOf(testnet))
         store.saveConfiguration(updated)
         assertEquals(updated, store.loadConfiguration())
     }
@@ -125,10 +128,25 @@ class RelayerSelectionStoreTest {
         writeLegacy("not really json {{")
 
         val migrated = store.loadConfiguration()
-        assertEquals(RelayerConfiguration(), migrated)
+        // Corrupt blob → fall back to .empty so the next refresh
+        // can auto-populate (the user lost their PR #17 pick to
+        // data corruption; auto-populate is a reasonable recovery).
+        assertEquals(RelayerConfiguration.empty, migrated)
         // Legacy key cleared so subsequent loads don't keep retrying.
         val prefs = dataStore.data.first()
         assertNull(prefs[stringPreferencesKey("relayer_selection")])
+    }
+
+    @Test
+    fun migration_legacyKnown_setsHasUserInteractedTrue() = runTest {
+        // PR #17 user explicitly picked the endpoint — migrating
+        // them as `hasUserInteracted = true` preserves their pick
+        // against a refresh that would otherwise auto-populate the
+        // published list.
+        writeLegacy("""{"kind":"known","url":"https://relayer-testnet.onym.chat","name":"Onym Testnet","network":"testnet"}""")
+
+        val migrated = store.loadConfiguration()
+        assertTrue("legacy migration must set hasUserInteracted=true", migrated.hasUserInteracted)
     }
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/i18n/StringsCompletenessTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/i18n/StringsCompletenessTest.kt
@@ -1,0 +1,114 @@
+package chat.onym.android.i18n
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Pin the en + ru `strings.xml` files to the same set of keys so a
+ * future regression that adds a string in code without translating
+ * it is caught at unit-test time (the AGP `MissingTranslation` lint
+ * already catches it at build time, but lint runs on the full
+ * project — this test runs in the JVM-test path so misses surface
+ * earlier on `:app:testDebugUnitTest`).
+ *
+ * Mirrors `LocalizationCatalogTests` from onym-ios PR #21.
+ */
+class StringsCompletenessTest {
+
+    @Test
+    fun `every English string has a Russian translation`() {
+        val enKeys = readStringKeys(File(EN_PATH))
+        val ruKeys = readStringKeys(File(RU_PATH))
+
+        // EN has app_name with translatable="false" — that's the
+        // only en-only entry; mirror the iOS catalog exclusion.
+        val enWithoutNonTranslatable = enKeys - "app_name"
+
+        val missingInRu = enWithoutNonTranslatable - ruKeys
+        val extraInRu = ruKeys - enKeys
+
+        assertTrue(
+            "Russian strings.xml is missing translations for: ${missingInRu.sorted()}",
+            missingInRu.isEmpty(),
+        )
+        assertTrue(
+            "Russian strings.xml has keys not in English: ${extraInRu.sorted()}",
+            extraInRu.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `every plural in English has a Russian counterpart`() {
+        val enPlurals = readPluralKeys(File(EN_PATH))
+        val ruPlurals = readPluralKeys(File(RU_PATH))
+        assertEquals(enPlurals, ruPlurals)
+    }
+
+    @Test
+    fun `chain UI keys are present in both locales`() {
+        // Sanity: PR #21's chain-UI catalog work landed every
+        // load-bearing relayer / anchors / network / governance key.
+        val mustHave = listOf(
+            "relayer_title", "relayer_strategy_label", "relayer_strategy_primary",
+            "relayer_strategy_random", "relayer_strategy_footer_primary",
+            "relayer_strategy_footer_random", "relayer_section_configured",
+            "relayer_section_add_known", "relayer_section_add_custom",
+            "relayer_empty_configured", "relayer_known_all_added",
+            "relayer_known_fetching", "relayer_custom_invalid",
+            "anchors_title", "anchors_footer", "anchors_no_contracts_yet",
+            "anchors_no_contract_for_type", "anchors_reset_to_default",
+            "settings_network", "settings_network_footer",
+            "network_testnet", "network_public",
+            "governance_anarchy", "governance_democracy", "governance_oligarchy",
+            "governance_oneonone", "governance_tyranny",
+        )
+        val enKeys = readStringKeys(File(EN_PATH))
+        val ruKeys = readStringKeys(File(RU_PATH))
+        for (key in mustHave) {
+            assertTrue("$key missing from values/strings.xml", key in enKeys)
+            assertTrue("$key missing from values-ru/strings.xml", key in ruKeys)
+        }
+    }
+
+    private fun readStringKeys(file: File): Set<String> {
+        assertNotNull("file must exist: ${file.absolutePath}", file.takeIf { it.exists() })
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+        val nodes = doc.getElementsByTagName("string")
+        val out = mutableSetOf<String>()
+        for (i in 0 until nodes.length) {
+            val el = nodes.item(i) as Element
+            val name = el.getAttribute("name") ?: continue
+            // `translatable="false"` strings (e.g. `app_name`) are
+            // intentionally en-only; exclude from the comparison.
+            if (el.getAttribute("translatable") == "false") continue
+            if (name.isNotBlank()) out.add(name)
+        }
+        return out
+    }
+
+    private fun readPluralKeys(file: File): Set<String> {
+        val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+        val nodes = doc.getElementsByTagName("plurals")
+        val out = mutableSetOf<String>()
+        for (i in 0 until nodes.length) {
+            val el = nodes.item(i) as Element
+            val name = el.getAttribute("name") ?: continue
+            if (name.isNotBlank()) out.add(name)
+        }
+        return out
+    }
+
+    private companion object {
+        // Paths are relative to the Gradle module root (the `:app`
+        // module), which is what the testDebugUnitTest task launches
+        // from. If a future migration changes the layout, update
+        // these constants to match.
+        private const val EN_PATH = "src/main/res/values/strings.xml"
+        private const val RU_PATH = "src/main/res/values-ru/strings.xml"
+    }
+}


### PR DESCRIPTION
## Summary

Catches Android up to two iOS landings:

- **iOS PR #21 ([link](https://github.com/onymchat/onym-ios/pull/21))** — i18n: localized the chain UI end-to-end into the catalog (en + ru) + added a catalog-completeness test.
- **iOS PR #22** (in flight; spec from this PR's brief) — random strategy is now the default; the configured-relayer list auto-populates from the GitHub manifest on first launch (user can still delete or override); plus end-to-end UI tests for both flows.

The three landings ride together because the UI tests assert against the new defaults.

## What changes

### L1: Localization

- 28 new keys in `app/src/main/res/values/strings.xml` + `values-ru/strings.xml` covering Settings → Network section + Relayer screen + Anchors screen + every `RelayerStrategy` / `ContractNetwork` / `GovernanceType` `displayName` string.
- `RelayerStrategy`, `ContractNetwork`, `GovernanceType` enums now expose `@StringRes val displayNameResId: Int`. Composables resolve via `stringResource(enum.displayNameResId)` — works in any `@Composable` scope without needing a `Context` parameter.
- `RelayerSettingsScreen` / `AnchorsScreen` / `SettingsScreen` swap inline English literals for `stringResource()` lookups. The private `networkDisplayName` / `governanceDisplayName` helpers in `AnchorsScreen` are deleted (replaced by `stringResource(network.displayNameResId)` / `stringResource(type.displayNameResId)`).
- `StringsCompletenessTest` (3 JVM cases) parses both `strings.xml` files via `DocumentBuilderFactory` and asserts: every English key has a Russian translation, every plural has a Russian counterpart, the load-bearing chain-UI key set is present in both locales. Catches future drift on the JVM-test fast path; the AGP `MissingTranslation` lint gate already catches it at build time.

### L2: Default-random + auto-preseed

- `RelayerConfiguration` default `strategy` flipped `PRIMARY` → `RANDOM`.
- New `hasUserInteracted: Boolean = true` field. The `true` default is **load-bearing** for backward compat: PR #20 wire-shape configurations (no field) decode as "interacted" so users with custom URLs don't get them blown away by re-population. Cold-fresh installs use the new `RelayerConfiguration.empty` (`hasUserInteracted = false`).
- `RelayerRepository.applyKnownListAndAutoPopulateLocked`: when `refresh()` / `start()` lands and `!hasUserInteracted && fresh.isNotEmpty()`, fans the published list into `endpoints` + sets `RANDOM` strategy + flips the flag sticky-true. Subsequent fetches only refresh the cached known list — never the configuration.
- All list-shaped mutators (`addEndpoint` / `removeEndpoint` / `setPrimary` / `setStrategy`) promote `hasUserInteracted` via the shared `applyConfigurationLocked` helper.
- `DataStorePreferencesRelayerSelectionStore` + `InMemoryRelayerSelectionStore` return `RelayerConfiguration.empty` on cold-fresh load + corrupt blob → next refresh seeds the list.
- PR #17 legacy migration explicitly sets `hasUserInteracted = true` (the user explicitly picked that endpoint in PR #17 → don't auto-overwrite).
- 10 new unit cases (`RelayerConfigurationTest` +4, `RelayerRepositoryTest` +5, `RelayerSelectionStoreTest` +1) cover the defaults flip, hasUserInteracted promotion semantics, and migration sticky-true.

### L3: Compose UI tests

- `testTag` modifiers on every load-bearing composable. Stable across releases; UI-test fakes pin against these strings:
  - `relayer.configured.<url>`, `relayer.configured.<url>.primary_button`
  - `relayer.add.custom.field`, `relayer.add.custom.button`
  - `relayer.strategy.picker`, `relayer.strategy.<primary|random>`
  - `relayer.add.known.<url>`
  - `anchors.network.<network>`, `anchors.type.<type>`, `anchors.version.<release>`, `anchors.version.reset`
  - `settings.relayer_row`, `settings.anchors_row`
- **`UITestRegistry`** (top-level production object) lets instrumented tests inject in-memory fakes via `@Volatile` fields read by `OnymApplication.buildDependencies`. Production reads `if (UITestRegistry.enabled) fake!! else productionImpl()`. Cost on production startup is one volatile-bool read per `onCreate`.
- `OnymApplication.dependencies` became lazy + invalidate-able via `internal rebuildDependenciesForTest()`. `Application.onCreate` runs **once** at process start, well before any JUnit `@Rule` body — wiring eagerly there reads an empty registry every test. The lazy + invalidate pattern lets the test rule populate the registry + invalidate the cache before the compose rule launches `MainActivity`.
- Page objects in `app/src/androidTest/.../uitests/screens/`:
  - `RelayerSettingsScreenObject` — strategy buttons, configured rows, swipe-delete, custom-URL field.
  - `AnchorsScreenObjects` — three-level drill-down navigation.
  - `SettingsScreenObject` — root-screen row taps.
- 9 instrumented test cases:
  - **`RelayerSettingsUITest` (6)** — auto-populate seeds the configured list with published entries on first launch + strategy is `RANDOM`; mark-primary persists; switch strategy to `PRIMARY` persists; add custom URL appends as a custom endpoint; swipe-delete removes endpoint; deleting the primary clears the primary marker.
  - **`AnchorsUITest` (3)** — drill Network → Type → Version + pick persists via store; reset-to-default clears explicit pick; Mainnet row disabled when no mainnet contracts published.
- `@get:Rule(order = 0)` `TestWatcher` populates the registry + calls `rebuildDependenciesForTest()` BEFORE the `@get:Rule(order = 1)` `composeRule` launches `MainActivity`. JUnit 4.13's explicit `order` arg pins the sequence (default rule ordering is unspecified).

## Architecture compliance

Unchanged — all changes ride above the seam interfaces. `UITestRegistry` is a thin indirection point in `chat.onym.android` (composition-root level), reads only by `OnymApplication.buildDependencies`. OnymSDK is not invoked.

## Test plan

- [x] `./gradlew :app:assembleDebug` — production builds clean
- [x] `./gradlew :app:lintDebug` — `MissingTranslation` gate green for the 28 new keys
- [x] `./gradlew :app:testDebugUnitTest` — full JVM suite green; +3 new i18n + +10 chain test cases all pass
- [x] `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=chat.onym.android.uitests.RelayerSettingsUITest` — 6/6 on Pixel 9 Pro AVD (API 36)
- [x] `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=chat.onym.android.uitests.AnchorsUITest` — 3/3
- [x] `python3 scripts/lint-secrets.py` — exit 0

## Out of scope (intentionally — match iOS PRs)

- Reordering the configured relayer list.
- Localising error messages from the chain layer (interactor wrap-up — do when error UI surfaces).
- Health-aware random routing.
- Telemetry / analytics on which relayer was picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)