### PR TITLE
test(relayer): pin PRIMARY strategy in selectUrl_respectsPrimaryStrategy

### DIFF
--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
@@ -303,6 +303,13 @@ class RelayerRepositoryTest {
     fun selectUrl_respectsPrimaryStrategy() = runTest {
         val (repo, _) = makeRepo()
         repo.addEndpoint(a); repo.addEndpoint(b)
+        // PR #20 flipped the default strategy to RANDOM. This test
+        // covers the PRIMARY-strategy resolution path, so promote
+        // explicitly — without it the assertion races RANDOM's
+        // uniform draw and fails ~50% of CI runs (flake caught on
+        // the merged-main run for PR #20:
+        // https://github.com/onymchat/onym-android/actions/runs/25258709184).
+        repo.setStrategy(RelayerStrategy.PRIMARY)
         repo.setPrimary(b.url)
 
         assertEquals(b.url, repo.selectUrl())


### PR DESCRIPTION
## Summary

Fixes the [main-CI failure](https://github.com/onymchat/onym-android/actions/runs/25258709184) from PR #20.

## Root cause

PR #20 flipped the default `RelayerConfiguration.strategy` from `PRIMARY` to `RANDOM`. `RelayerRepositoryTest.selectUrl_respectsPrimaryStrategy` was relying on the old default — after adding two endpoints + setting a primaryUrl, it asserted `selectUrl()` returned the primary's URL, but the strategy was now `RANDOM` and `selectUrl()` was returning a uniform random pick across both endpoints.

Local pre-merge runs happened to land on the primary often enough to pass; the merged-main CI run exposed the flake.

## Fix

Explicitly `repo.setStrategy(RelayerStrategy.PRIMARY)` before setting the primary marker. The test now exercises the PRIMARY-strategy resolution path it was always meant to.

## Verification

- Confirmed flake locally: 3/5 failures on the original test (`--rerun` 5x).
- Confirmed fix is stable: 8/8 successes after the patch (`--rerun` 8x).
- `./gradlew :app:testDebugUnitTest` — full suite green.

## Out of scope

The other `selectUrl_respectsRandomStrategy` test was already explicit (`setStrategy(RANDOM)`) and didn't need a touch-up. The `_fallsBackToFirstWhenPrimaryStaleOrUnset` test was already updated in PR #20 to set PRIMARY explicitly. This was the one that slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)