### PR TITLE
fix(relayer): plural networks schema + fetch-status gating so picker stops spinning

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/AnchorsUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/AnchorsUITest.kt
@@ -96,7 +96,7 @@ class AnchorsUITest {
                     saveConfiguration(
                         chat.onym.android.chain.RelayerConfiguration(
                             endpoints = listOf(
-                                chat.onym.android.chain.RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+                                chat.onym.android.chain.RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", listOf("testnet"))
                             ),
                             hasUserInteracted = true,
                         )

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/RelayerSettingsUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/RelayerSettingsUITest.kt
@@ -44,8 +44,8 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 class RelayerSettingsUITest {
 
-    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
-    private val mainnet = RelayerEndpoint("Onym Mainnet", "https://relayer.onym.chat", "public")
+    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", listOf("testnet"))
+    private val mainnet = RelayerEndpoint("Onym Mainnet", "https://relayer.onym.chat", listOf("public"))
 
     private val relayerStore = InMemoryRelayerSelectionStore()
     private val relayerFetcher = FakeKnownRelayersFetcher(
@@ -155,7 +155,7 @@ class RelayerSettingsUITest {
             relayerStore.loadConfigurationBlocking().endpoints.size == 3
         }
         val endpoints = relayerStore.loadConfigurationBlocking().endpoints
-        assertEquals("custom", endpoints.last().network)
+        assertEquals(listOf("custom"), endpoints.last().networks)
         assertEquals("https://custom.example/relayer", endpoints.last().url)
     }
 

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -14,6 +14,7 @@ import chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore
 import chat.onym.android.chain.GitHubReleasesContractsManifestFetcher
 import chat.onym.android.chain.GitHubReleasesKnownRelayersFetcher
 import chat.onym.android.chain.RelayerRepository
+import chat.onym.android.chain.relayerFetchErrorMessageResolver
 import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.identity.IdentitySecretStore
 import chat.onym.android.identity.OnymNostrSignerProvider
@@ -166,6 +167,7 @@ class OnymApplication : Application() {
         val relayerRepository = RelayerRepository(
             store = relayerStore,
             fetcher = relayerFetcher,
+            errorMessageResolver = relayerFetchErrorMessageResolver(applicationContext.resources),
         )
         applicationScope.launch {
             relayerRepository.bootstrap()

--- a/app/src/main/kotlin/chat/onym/android/chain/KnownRelayersFetcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/KnownRelayersFetcher.kt
@@ -51,14 +51,19 @@ class GitHubReleasesKnownRelayersFetcher(
             .header("Accept", "application/json")
             .build()
         httpClient.newCall(request).execute().use { response ->
+            // Typed errors so the repository can map each kind to a
+            // distinct localised user-facing message
+            // ([RelayersFetchError]). Network-layer failures stay as
+            // raw [IOException]; only HTTP-status + JSON-decode get
+            // wrapped here.
             if (!response.isSuccessful) {
-                throw IOException("GET $url returned HTTP ${response.code}")
+                throw RelayersFetchError.BadStatus(response.code)
             }
             val body = response.body?.string() ?: throw IOException("empty response body")
             try {
                 jsonFormat.decodeFromString(KnownRelayersDocument.serializer(), body).relayers
             } catch (e: SerializationException) {
-                throw IOException("invalid relayers.json: ${e.message}", e)
+                throw RelayersFetchError.MalformedDocument(e)
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerEndpoint.kt
@@ -2,35 +2,57 @@ package chat.onym.android.chain
 
 import androidx.annotation.StringRes
 import chat.onym.android.R
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import java.net.URI
 import java.net.URISyntaxException
 import kotlin.random.Random
 
 /**
- * One published relayer endpoint. Wire format pinned by
- * [KnownRelayersDocument] — interop with the iOS client + the
- * server-side `relayers.json` artifact rides on the JSON field
- * names being exactly `name` / `url` / `network`.
+ * One published relayer endpoint. Wire format:
  *
- * The `network` field is `"testnet"` / `"public"` for published
- * relayers and `"custom"` for user-typed URLs (synthesised via
- * [RelayerEndpoint.Companion.custom]).
+ * ```json
+ * { "name": "Onym Official",
+ *   "url": "https://relayer.onym.chat",
+ *   "networks": ["testnet", "public"] }
+ * ```
  *
- * Mirrors `RelayerEndpoint` from onym-ios PR #18 / PR #20.
+ * The `networks` field is a list because a single deployment can
+ * serve multiple Stellar networks (this is what the published
+ * `relayers.json` actually emits).
+ *
+ * **Backward-compat with PR #20 / PR #22 saves.** Old saved
+ * configurations used a singular `network: String` field. The
+ * custom [RelayerEndpointSerializer] decodes both shapes — singular
+ * is promoted to a one-element list at decode time. Encoder always
+ * emits the plural shape, so a future load reads only the new
+ * format.
+ *
+ * The "custom" endpoint type (user-typed URLs not in the published
+ * list) carries `networks = listOf("custom")` — a sentinel the UI
+ * uses to colour the network badge differently.
+ *
+ * Mirrors `RelayerEndpoint` from onym-ios PR #18 / PR #20 / PR #23.
  */
-@Serializable
+@Serializable(with = RelayerEndpointSerializer::class)
 data class RelayerEndpoint(
     val name: String,
     val url: String,
-    val network: String,
+    val networks: List<String>,
 ) {
     companion object {
+        /** Sentinel network tag for user-typed URLs. */
+        const val CUSTOM_NETWORK = "custom"
+
         /**
-         * Build a "custom" endpoint from a user-typed URL. Network
-         * tag is fixed at `"custom"`; name defaults to the URL host
-         * (or the raw URL if the host can't be parsed — defensive
-         * fallback; the ViewModel rejects malformed URLs upstream).
+         * Build a "custom" endpoint from a user-typed URL. Networks
+         * is the single-element `[CUSTOM_NETWORK]` sentinel; name
+         * defaults to the URL host (or the raw URL if the host
+         * can't be parsed — defensive fallback; the ViewModel
+         * rejects malformed URLs upstream).
          */
         fun custom(url: String): RelayerEndpoint {
             val host = try {
@@ -41,9 +63,62 @@ data class RelayerEndpoint(
             return RelayerEndpoint(
                 name = host ?: url,
                 url = url,
-                network = "custom",
+                networks = listOf(CUSTOM_NETWORK),
             )
         }
+    }
+}
+
+/**
+ * Hand-rolled serializer that reads both the new `networks: [...]`
+ * shape (the current published format + every save going forward)
+ * AND the legacy singular `network: "..."` shape (PR #20 / PR #22
+ * saved configurations on disk). Encoder always emits the plural
+ * shape; the legacy field is never written by this version.
+ *
+ * Surrogate trick: declare an internal `@Serializable` data class
+ * with both fields nullable, decode through it, then merge into
+ * the typed [RelayerEndpoint]. Avoids hand-rolling the decoder
+ * structurally — kotlinx.serialization handles the JSON traversal
+ * and missing-field defaults.
+ *
+ * Pinned by `RelayerEndpointSchemaTest`.
+ */
+internal object RelayerEndpointSerializer : KSerializer<RelayerEndpoint> {
+
+    @Serializable
+    internal data class Surrogate(
+        val name: String,
+        val url: String,
+        // Plural — the new wire shape. Optional so legacy decode doesn't fail.
+        val networks: List<String>? = null,
+        // Legacy singular — read on decode to backfill `networks`,
+        // never written on encode.
+        val network: String? = null,
+    )
+
+    override val descriptor: SerialDescriptor = Surrogate.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): RelayerEndpoint {
+        val s = Surrogate.serializer().deserialize(decoder)
+        // Prefer plural; fall back to promoting singular; otherwise
+        // empty list (a published-but-unspecified endpoint — would
+        // render with no badges).
+        val networks = s.networks ?: listOfNotNull(s.network)
+        return RelayerEndpoint(name = s.name, url = s.url, networks = networks)
+    }
+
+    override fun serialize(encoder: Encoder, value: RelayerEndpoint) {
+        Surrogate.serializer().serialize(
+            encoder,
+            Surrogate(
+                name = value.name,
+                url = value.url,
+                networks = value.networks,
+                // Always null — never write the legacy singular field.
+                network = null,
+            ),
+        )
     }
 }
 
@@ -166,18 +241,74 @@ data class RelayerConfiguration(
 }
 
 /**
+ * Status of the most recent (or in-flight) fetch of the published
+ * relayers list. Drives the UI's "Add from Published List" gating
+ * — the picker shows a spinner / error / empty-state copy depending
+ * on this enum, replacing the PR #20 logic that gated everything
+ * on `knownList.isEmpty` (which spun forever after a failed fetch).
+ *
+ * Mirrors `RelayerFetchStatus` from onym-ios PR #23.
+ */
+sealed interface RelayerFetchStatus {
+    /** No fetch has been attempted yet. UI shows the spinner. */
+    data object Idle : RelayerFetchStatus
+
+    /** A fetch is in flight. UI shows the spinner if the cached
+     *  list is empty, or the cached list (with optional staleness
+     *  badge later) if it's not. */
+    data object Fetching : RelayerFetchStatus
+
+    /** Last fetch succeeded. UI shows the published list, or a
+     *  "no published relayers yet" message if the list is empty. */
+    data object Success : RelayerFetchStatus
+
+    /** Last fetch failed. [message] is a localised user-facing
+     *  string. UI surfaces it with a Try Again button. */
+    data class Failed(val message: String) : RelayerFetchStatus
+}
+
+/**
+ * Sealed taxonomy of fetch failures, raised by the
+ * [KnownRelayersFetcher] implementation when something goes wrong
+ * before the typed [RelayerEndpoint] list lands. Used by the
+ * repository to map to a localised user-facing message.
+ *
+ * Mirrors `KnownRelayersFetchError` from onym-ios PR #23.
+ */
+sealed class RelayersFetchError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+    /** Server returned a non-2xx response. */
+    class BadStatus(val code: Int) : RelayersFetchError("server returned HTTP $code")
+
+    /** JSON decoding of the response body failed (schema drift). */
+    class MalformedDocument(cause: Throwable) :
+        RelayersFetchError("response body didn't match the expected schema", cause)
+}
+
+/**
  * Snapshot the [RelayerRepository] publishes through its StateFlow.
- * Two parallel pieces of state:
+ * Three pieces of state:
  *
  *  - [knownRelayers] — last successful fetch (or empty if never
  *    fetched / cleared). Cached to disk so the picker has something
  *    to show before the next start() / refresh() completes.
  *  - [configuration] — the user's multi-endpoint config + strategy.
+ *  - [fetchStatus] — drives the "Add from Published List" UI gate.
  */
 data class RelayerState(
     val knownRelayers: List<RelayerEndpoint>,
     val configuration: RelayerConfiguration,
+    val fetchStatus: RelayerFetchStatus,
 ) {
     /** Convenience pass-through to [RelayerConfiguration.selectUrl]. */
     fun selectUrl(random: Random = Random.Default): String? = configuration.selectUrl(random)
+
+    companion object {
+        /** Cold-start in-memory state until the repository's
+         *  bootstrap reads from disk + start kicks off a fetch. */
+        val empty: RelayerState = RelayerState(
+            knownRelayers = emptyList(),
+            configuration = RelayerConfiguration.empty,
+            fetchStatus = RelayerFetchStatus.Idle,
+        )
+    }
 }

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerErrorMessages.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerErrorMessages.kt
@@ -1,0 +1,31 @@
+package chat.onym.android.chain
+
+import android.content.res.Resources
+import chat.onym.android.R
+import java.io.IOException
+
+/**
+ * Resource-backed `(Throwable) -> String` factory injected into
+ * [RelayerRepository] so the repo stays Compose / Context-free.
+ * Production wires this from `OnymApplication` with
+ * `applicationContext.resources`; tests can substitute a fake
+ * lambda directly.
+ *
+ * Mirrors the iOS `localizedMessage(error:)` helper from PR #23.
+ */
+fun relayerFetchErrorMessageResolver(resources: Resources): (Throwable) -> String = { error ->
+    when (error) {
+        is RelayersFetchError.BadStatus ->
+            resources.getString(R.string.relayer_fetch_failed_status, error.code)
+        is RelayersFetchError.MalformedDocument ->
+            resources.getString(R.string.relayer_fetch_failed_malformed)
+        // IOException covers the OkHttp network-layer cases (no
+        // route to host, DNS, TLS, timeout, etc.). A generic
+        // catch-all falls back to the same offline message — better
+        // than leaking a Throwable.message that mentions OkHttp.
+        is IOException ->
+            resources.getString(R.string.relayer_fetch_failed_offline)
+        else ->
+            resources.getString(R.string.relayer_fetch_failed_offline)
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerRepository.kt
@@ -15,32 +15,30 @@ import kotlin.random.Random
  *
  * Touch-surface compliance:
  *
- *  - Holds **only** [store] + [fetcher]. No transport, no OnymSDK,
- *    no Compose, no `Context`.
+ *  - Holds **only** [store] + [fetcher] + [errorMessageResolver].
+ *    No transport, no OnymSDK, no Compose, no `Context`.
  *  - Exposes a [StateFlow] for observation; [addEndpoint] /
  *    [removeEndpoint] / [setPrimary] / [setStrategy] / [start] /
  *    [refresh] / [bootstrap] are the suspend mutators.
  *  - Mutations serialise through a [Mutex]; reads are lock-free
- *    off the [StateFlow].
+ *    off the [StateFlow]. The mutex is **not** held across
+ *    [fetcher.fetch] — the network call runs on its own
+ *    coroutine continuation.
  *
- * Mirrors `RelayerRepository` from onym-ios PR #20.
+ * Mirrors `RelayerRepository` from onym-ios PR #20 / PR #23.
  */
 class RelayerRepository(
     private val store: RelayerSelectionStore,
     private val fetcher: KnownRelayersFetcher,
+    /** Maps a fetch failure to a user-facing localised string. The
+     *  default returns the throwable's message — production wires a
+     *  resource-backed implementation through `OnymApplication`;
+     *  tests typically pass `{ it.message ?: "" }` or a controlled
+     *  fixture. */
+    private val errorMessageResolver: (Throwable) -> String = { it.message ?: "" },
 ) {
     private val mutex = Mutex()
-    private val _snapshots = MutableStateFlow(
-        RelayerState(
-            knownRelayers = emptyList(),
-            // Cold-fresh in-memory state until bootstrap() reads disk.
-            // `empty` has hasUserInteracted = false so a first-launch
-            // refresh() seeds the published list. Once disk is loaded
-            // (legacy migration paths set it to true), the snapshot
-            // reflects whatever the user already had.
-            configuration = RelayerConfiguration.empty,
-        )
-    )
+    private val _snapshots = MutableStateFlow(RelayerState.empty)
 
     val snapshots: StateFlow<RelayerState> = _snapshots.asStateFlow()
 
@@ -48,41 +46,71 @@ class RelayerRepository(
 
     /** Hydrate from disk — cached known list + persisted multi-
      *  endpoint configuration (or migrate from the PR #17 single-
-     *  selection blob). Idempotent. */
+     *  selection blob). Idempotent. Preserves the in-memory
+     *  [RelayerFetchStatus] (which is `Idle` until the first
+     *  [start] / [refresh]). */
     suspend fun bootstrap() = mutex.withLock {
         val cached = store.loadCachedKnownRelayers()
         val config = store.loadConfiguration()
-        _snapshots.value = RelayerState(knownRelayers = cached, configuration = config)
+        _snapshots.value = _snapshots.value.copy(
+            knownRelayers = cached,
+            configuration = config,
+        )
     }
 
     /** Fire-and-forget the GitHub-Releases fetch. Idempotent.
      *  Errors swallowed (app launch must not crash on a network
-     *  blip). On success, [autoPopulateIfFreshLocked] seeds the
-     *  configured list with the published entries when the user
-     *  hasn't yet interacted with the picker. */
-    suspend fun start() = mutex.withLock {
-        if (startInvoked) return@withLock
-        startInvoked = true
-        runCatching { fetcher.fetch() }.onSuccess { fresh ->
-            store.saveCachedKnownRelayers(fresh)
-            applyKnownListAndAutoPopulateLocked(fresh)
+     *  blip); the [RelayerFetchStatus.Failed] snapshot is still
+     *  published before the swallow so the picker UI can react. */
+    suspend fun start() {
+        val shouldFetch = mutex.withLock {
+            if (startInvoked) false
+            else { startInvoked = true; true }
+        }
+        if (shouldFetch) {
+            runCatching { refreshInternal() }
         }
     }
 
-    /** User-initiated refresh; failures propagate. */
+    /** User-initiated refresh; failures propagate to the caller AND
+     *  a [RelayerFetchStatus.Failed] snapshot is published. */
     suspend fun refresh() {
-        val fresh = fetcher.fetch()
+        refreshInternal()
+    }
+
+    /** Shared body of [start] + [refresh]. Publishes [RelayerFetchStatus.Fetching]
+     *  → fetch → publishes [RelayerFetchStatus.Success] (via
+     *  [applyKnownListAndAutoPopulateLocked]) OR
+     *  [RelayerFetchStatus.Failed] then rethrows. */
+    private suspend fun refreshInternal() {
+        mutex.withLock {
+            _snapshots.value = _snapshots.value.copy(fetchStatus = RelayerFetchStatus.Fetching)
+        }
+        val fresh = try {
+            fetcher.fetch()
+        } catch (e: Throwable) {
+            mutex.withLock {
+                _snapshots.value = _snapshots.value.copy(
+                    fetchStatus = RelayerFetchStatus.Failed(errorMessageResolver(e)),
+                )
+            }
+            throw e
+        }
         mutex.withLock {
             store.saveCachedKnownRelayers(fresh)
             applyKnownListAndAutoPopulateLocked(fresh)
+            _snapshots.value = _snapshots.value.copy(fetchStatus = RelayerFetchStatus.Success)
         }
     }
 
-    /** Common path for [start] + [refresh]: stash the fetched list,
-     *  and if the user hasn't yet interacted with the picker,
-     *  fan it into the configured endpoints (RANDOM strategy, no
-     *  primary). Once `hasUserInteracted` flips, future fetches
-     *  only update the cached known list — never the configuration. */
+    /** Common path called by [refreshInternal] under the mutex:
+     *  stash the fetched list, and if the user hasn't yet
+     *  interacted with the picker, fan it into the configured
+     *  endpoints (RANDOM strategy, no primary). Once
+     *  [RelayerConfiguration.hasUserInteracted] flips, future
+     *  fetches only update the cached known list — never the
+     *  configuration. Preserves the current [RelayerFetchStatus]
+     *  via `.copy()`; the caller sets it explicitly afterwards. */
     private suspend fun applyKnownListAndAutoPopulateLocked(fresh: List<RelayerEndpoint>) {
         val current = _snapshots.value.configuration
         val updatedConfig = if (!current.hasUserInteracted && fresh.isNotEmpty()) {
@@ -101,7 +129,7 @@ class RelayerRepository(
         if (updatedConfig != current) {
             store.saveConfiguration(updatedConfig)
         }
-        _snapshots.value = RelayerState(
+        _snapshots.value = _snapshots.value.copy(
             knownRelayers = fresh,
             configuration = updatedConfig,
         )
@@ -110,7 +138,7 @@ class RelayerRepository(
     // ─── list-shaped mutators ─────────────────────────────────────
 
     /** Add (or replace metadata for) an endpoint, keyed by URL. If
-     *  the URL is already configured, the metadata (name, network)
+     *  the URL is already configured, the metadata (name, networks)
      *  is updated in place — useful when the same URL is added
      *  first as a custom and then "rediscovered" in the published
      *  list, or vice versa. Insertion order preserved for new

--- a/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/RelayerSelectionStore.kt
@@ -129,7 +129,9 @@ class DataStorePreferencesRelayerSelectionStore(
                 "known" -> {
                     val n = record.name; val net = record.network
                     if (n != null && net != null) {
-                        RelayerEndpoint(name = n, url = record.url, network = net)
+                        // PR #23 schema change: singular `network`
+                        // becomes a one-element [networks] list.
+                        RelayerEndpoint(name = n, url = record.url, networks = listOf(net))
                     } else null
                 }
                 "custom" -> RelayerEndpoint.custom(record.url)

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
@@ -49,8 +49,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.material3.CircularProgressIndicator
 import chat.onym.android.R
 import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerFetchStatus
 import chat.onym.android.chain.RelayerStrategy
 
 /**
@@ -136,25 +138,51 @@ fun RelayerSettingsScreen(
             }
 
             // ─── Add from Published List ─────────────────────────
+            // Gate on fetchStatus, not just `unconfiguredKnownList.isEmpty()`.
+            // PR #20 spun the spinner forever after a failed fetch
+            // because the only "empty" branch was the spinner. The
+            // four-way gate below surfaces the failure with a Try
+            // Again button (Failed), the genuinely-empty state with a
+            // dedicated string (Success + empty published list), and
+            // keeps the spinner only for the truly-fetching cold path.
+            // Mirrors `knownSectionContent` from onym-ios PR #23.
             item { SectionHeader(stringResource(R.string.relayer_section_add_known)) }
-            if (state.unconfiguredKnownList.isEmpty()) {
-                item {
-                    Text(
-                        stringResource(
-                            if (state.configuration.endpoints.isEmpty()) R.string.relayer_known_fetching
-                            else R.string.relayer_known_all_added
-                        ),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
-                    )
+            when (val status = state.fetchStatus) {
+                RelayerFetchStatus.Idle, RelayerFetchStatus.Fetching -> {
+                    if (state.knownList.isEmpty()) {
+                        item { FetchingSpinnerWithLabel() }
+                    } else {
+                        knownAddItems(state.unconfiguredKnownList) { viewModel.addKnown(it) }
+                    }
                 }
-            } else {
-                items(state.unconfiguredKnownList, key = { "known:${it.url}" }) { endpoint ->
-                    KnownRelayerAddRow(
-                        endpoint = endpoint,
-                        onClick = { viewModel.addKnown(endpoint) },
-                    )
+                RelayerFetchStatus.Success -> {
+                    when {
+                        state.knownList.isEmpty() -> item {
+                            Text(
+                                stringResource(R.string.relayer_fetch_no_published_yet),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
+                            )
+                        }
+                        state.unconfiguredKnownList.isEmpty() -> item {
+                            Text(
+                                stringResource(R.string.relayer_known_all_added),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp),
+                            )
+                        }
+                        else -> knownAddItems(state.unconfiguredKnownList) { viewModel.addKnown(it) }
+                    }
+                }
+                is RelayerFetchStatus.Failed -> {
+                    item {
+                        FetchFailedRow(
+                            message = status.message,
+                            onRetry = viewModel::tappedRetryFetch,
+                        )
+                    }
                 }
             }
 
@@ -170,6 +198,74 @@ fun RelayerSettingsScreen(
             }
             item { Footer(stringResource(R.string.relayer_custom_footer)) }
         }
+    }
+}
+
+/** Spinner + label, used while the boot fetch is in flight. */
+@Composable
+private fun FetchingSpinnerWithLabel() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.testTag("relayer.add.known.fetching"),
+            strokeWidth = 2.dp,
+        )
+        Text(
+            stringResource(R.string.relayer_known_fetching),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** Failure copy + Try Again button. The retry intent re-fires
+ *  `RelayerRepository.refresh()`, which republishes a fresh
+ *  Fetching → Success/Failed cycle. */
+@Composable
+private fun FetchFailedRow(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f))
+            .padding(16.dp)
+            .testTag("relayer.add.known.failed"),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        Button(
+            onClick = onRetry,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("relayer.add.known.retry"),
+            shape = RoundedCornerShape(10.dp),
+            contentPadding = PaddingValues(vertical = 12.dp),
+        ) {
+            Text(stringResource(R.string.relayer_fetch_retry), fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+/** LazyListScope helper — emits one [KnownRelayerAddRow] item per
+ *  endpoint with the standard test-tag key. Extracted so the
+ *  fetch-status `when` doesn't have three call sites for the same
+ *  block. */
+private fun androidx.compose.foundation.lazy.LazyListScope.knownAddItems(
+    endpoints: List<RelayerEndpoint>,
+    onClick: (RelayerEndpoint) -> Unit,
+) {
+    items(endpoints, key = { "known:${it.url}" }) { endpoint ->
+        KnownRelayerAddRow(endpoint = endpoint, onClick = { onClick(endpoint) })
     }
 }
 
@@ -299,7 +395,21 @@ private fun EndpointRow(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        NetworkBadge(network = endpoint.network)
+        NetworkBadges(networks = endpoint.networks)
+    }
+}
+
+/** One chip per network the endpoint serves. PR #23 changed
+ *  endpoints from singular `network: String` to plural
+ *  `networks: List<String>` because a single deployment can serve
+ *  testnet + public. Custom endpoints carry the [CUSTOM_NETWORK]
+ *  sentinel as their only network. */
+@Composable
+private fun NetworkBadges(networks: List<String>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (network in networks) {
+            NetworkBadge(network = network)
+        }
     }
 }
 
@@ -355,7 +465,7 @@ private fun KnownRelayerAddRow(endpoint: RelayerEndpoint, onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        NetworkBadge(network = endpoint.network)
+        NetworkBadges(networks = endpoint.networks)
     }
 }
 

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import chat.onym.android.chain.RelayerConfiguration
 import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerFetchStatus
 import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.chain.RelayerStrategy
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,11 +35,17 @@ class RelayerSettingsViewModel(
     /** Snapshot the screen renders. */
     data class State(
         val configuration: RelayerConfiguration,
-        /** Subset of `repository.snapshots.value.knownRelayers`
-         *  filtered to remove URLs already in [configuration]
-         *  endpoints — the "Add from Published List" section
-         *  shouldn't ghost an add as a no-op. */
+        /** Full published list as last seen on snapshot — exposed so
+         *  the screen can show counts / empty-state copy independently
+         *  of the unconfigured-subset gate. */
+        val knownList: List<RelayerEndpoint>,
+        /** Subset of [knownList] filtered to remove URLs already in
+         *  [configuration] endpoints — the "Add from Published List"
+         *  section shouldn't ghost an add as a no-op. */
         val unconfiguredKnownList: List<RelayerEndpoint>,
+        /** Drives the 4-way gate on the screen
+         *  (Idle / Fetching / Success / Failed). */
+        val fetchStatus: RelayerFetchStatus,
         val customDraft: String,
         val customDraftError: String?,
     )
@@ -46,7 +53,9 @@ class RelayerSettingsViewModel(
     private val _state = MutableStateFlow(
         State(
             configuration = RelayerConfiguration(),
+            knownList = emptyList(),
             unconfiguredKnownList = emptyList(),
+            fetchStatus = RelayerFetchStatus.Idle,
             customDraft = "",
             customDraftError = null,
         )
@@ -59,8 +68,10 @@ class RelayerSettingsViewModel(
                 val configuredUrls = snapshot.configuration.endpoints.map { it.url }.toSet()
                 _state.value = _state.value.copy(
                     configuration = snapshot.configuration,
+                    knownList = snapshot.knownRelayers,
                     unconfiguredKnownList = snapshot.knownRelayers
                         .filterNot { it.url in configuredUrls },
+                    fetchStatus = snapshot.fetchStatus,
                 )
             }
         }
@@ -106,6 +117,15 @@ class RelayerSettingsViewModel(
 
     fun setStrategy(strategy: RelayerStrategy) {
         viewModelScope.launch { repository.setStrategy(strategy) }
+    }
+
+    /** "Try Again" tap on the [RelayerFetchStatus.Failed] gate. The
+     *  repository republishes Fetching → Success/Failed, which the
+     *  screen reflects via the snapshot collector. We swallow the
+     *  rethrow here — the user-visible error already lives on the
+     *  next snapshot. */
+    fun tappedRetryFetch() {
+        viewModelScope.launch { runCatching { repository.refresh() } }
     }
 
     sealed class ValidationResult {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -94,6 +94,12 @@
     <string name="relayer_row_primary_label">Основной релеер</string>
     <string name="relayer_row_mark_primary">Сделать основным</string>
     <string name="relayer_row_delete">Удалить</string>
+    <!-- Fetch error / empty / retry copy (PR #23) -->
+    <string name="relayer_fetch_failed_status">Не удалось получить опубликованный список (код %1$d).</string>
+    <string name="relayer_fetch_failed_malformed">Опубликованный список в неожиданном формате.</string>
+    <string name="relayer_fetch_failed_offline">Не удалось получить опубликованный список.</string>
+    <string name="relayer_fetch_no_published_yet">Опубликованных релееров пока нет.</string>
+    <string name="relayer_fetch_retry">Повторить</string>
 
     <!-- ─── Settings → Anchors screen ────────────────────────────── -->
     <string name="anchors_title">Якоря</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,12 @@
     <string name="relayer_row_primary_label">Primary endpoint</string>
     <string name="relayer_row_mark_primary">Mark as primary</string>
     <string name="relayer_row_delete">Delete</string>
+    <!-- Fetch error / empty / retry copy (PR #23) -->
+    <string name="relayer_fetch_failed_status">Couldn\'t reach the published list (status %1$d).</string>
+    <string name="relayer_fetch_failed_malformed">Published list is in an unexpected format.</string>
+    <string name="relayer_fetch_failed_offline">Couldn\'t reach the published list.</string>
+    <string name="relayer_fetch_no_published_yet">No published relayers yet.</string>
+    <string name="relayer_fetch_retry">Try Again</string>
 
     <!-- ─── Settings → Anchors screen ────────────────────────────── -->
     <string name="anchors_title">Anchors</string>

--- a/app/src/test/kotlin/chat/onym/android/chain/KnownRelayersFetcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/KnownRelayersFetcherTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.IOException
 
 /**
  * Wire-format pin for the GitHub-Releases-backed fetcher. Uses a
@@ -31,12 +30,16 @@ class KnownRelayersFetcherTest {
 
     @Test
     fun fetch_happyPath_parsesTwoRelayerDocument() = runTest {
+        // PR #23 wire shape: `networks` is a plural list. The
+        // [RelayerEndpointSerializer] also accepts the legacy singular
+        // `network` field — pinned separately in
+        // `RelayerEndpointSchemaTest`.
         val json = """
             {
               "version": 1,
               "relayers": [
-                { "name": "Onym Official Testnet", "url": "https://relayer-testnet.onym.chat", "network": "testnet" },
-                { "name": "Onym Official Mainnet", "url": "https://relayer.onym.chat",         "network": "public"  }
+                { "name": "Onym Official Testnet", "url": "https://relayer-testnet.onym.chat", "networks": ["testnet"] },
+                { "name": "Onym Official Mainnet", "url": "https://relayer.onym.chat",         "networks": ["public"]  }
               ]
             }
         """.trimIndent()
@@ -45,8 +48,8 @@ class KnownRelayersFetcherTest {
 
         val list = fetcher.fetch()
         assertEquals(2, list.size)
-        assertEquals(RelayerEndpoint("Onym Official Testnet", "https://relayer-testnet.onym.chat", "testnet"), list[0])
-        assertEquals(RelayerEndpoint("Onym Official Mainnet", "https://relayer.onym.chat", "public"), list[1])
+        assertEquals(RelayerEndpoint("Onym Official Testnet", "https://relayer-testnet.onym.chat", listOf("testnet")), list[0])
+        assertEquals(RelayerEndpoint("Onym Official Mainnet", "https://relayer.onym.chat", listOf("public")), list[1])
     }
 
     @Test
@@ -60,52 +63,55 @@ class KnownRelayersFetcherTest {
     }
 
     @Test
-    fun fetch_404_throwsIOException() = runTest {
+    fun fetch_404_throwsBadStatus() = runTest {
+        // PR #23 raises typed errors (`RelayersFetchError.BadStatus`)
+        // so the repository can map each kind to its own localised
+        // user-facing message.
         val client = FakeOkHttpClient.build { req ->
             FakeOkHttpClient.status(req, 404, "Not Found")
         }
         val fetcher = GitHubReleasesKnownRelayersFetcher(client)
 
-        val thrown = assertThrows(IOException::class.java) {
+        val thrown = assertThrows(RelayersFetchError.BadStatus::class.java) {
             kotlinx.coroutines.runBlocking { fetcher.fetch() }
         }
-        assertTrue("error message should reference 404", thrown.message?.contains("404") == true)
+        assertEquals(404, thrown.code)
     }
 
     @Test
-    fun fetch_500_throwsIOException() = runTest {
+    fun fetch_500_throwsBadStatus() = runTest {
         val client = FakeOkHttpClient.build { req ->
             FakeOkHttpClient.status(req, 500, "Internal Server Error")
         }
         val fetcher = GitHubReleasesKnownRelayersFetcher(client)
 
-        val thrown = assertThrows(IOException::class.java) {
+        val thrown = assertThrows(RelayersFetchError.BadStatus::class.java) {
             kotlinx.coroutines.runBlocking { fetcher.fetch() }
         }
-        assertTrue(thrown.message?.contains("500") == true)
+        assertEquals(500, thrown.code)
     }
 
     @Test
-    fun fetch_malformedJson_throwsIOException() = runTest {
+    fun fetch_malformedJson_throwsMalformedDocument() = runTest {
         val client = FakeOkHttpClient.build { req ->
             FakeOkHttpClient.ok(req, "not really json {{{")
         }
         val fetcher = GitHubReleasesKnownRelayersFetcher(client)
 
-        assertThrows(IOException::class.java) {
+        assertThrows(RelayersFetchError.MalformedDocument::class.java) {
             kotlinx.coroutines.runBlocking { fetcher.fetch() }
         }
         Unit
     }
 
     @Test
-    fun fetch_missingRelayersField_throwsIOException() = runTest {
+    fun fetch_missingRelayersField_throwsMalformedDocument() = runTest {
         val client = FakeOkHttpClient.build { req ->
             FakeOkHttpClient.ok(req, """{ "version": 1 }""")
         }
         val fetcher = GitHubReleasesKnownRelayersFetcher(client)
 
-        assertThrows(IOException::class.java) {
+        assertThrows(RelayersFetchError.MalformedDocument::class.java) {
             kotlinx.coroutines.runBlocking { fetcher.fetch() }
         }
         Unit

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerConfigurationTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerConfigurationTest.kt
@@ -20,9 +20,9 @@ import kotlin.random.Random
  */
 class RelayerConfigurationTest {
 
-    private val a = RelayerEndpoint("A", "https://a.example", "testnet")
-    private val b = RelayerEndpoint("B", "https://b.example", "testnet")
-    private val c = RelayerEndpoint("C", "https://c.example", "public")
+    private val a = RelayerEndpoint("A", "https://a.example", listOf("testnet"))
+    private val b = RelayerEndpoint("B", "https://b.example", listOf("testnet"))
+    private val c = RelayerEndpoint("C", "https://c.example", listOf("public"))
 
     // ─── Empty list ───────────────────────────────────────────────
 
@@ -150,7 +150,7 @@ class RelayerConfigurationTest {
     @Test
     fun custom_factory_setsNetworkAndDerivesNameFromHost() {
         val ep = RelayerEndpoint.custom("https://relayer.example.com:9443/path")
-        assertEquals("custom", ep.network)
+        assertEquals(listOf("custom"), ep.networks)
         assertEquals("relayer.example.com", ep.name)
         assertEquals("https://relayer.example.com:9443/path", ep.url)
     }

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerEndpointSchemaTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerEndpointSchemaTest.kt
@@ -1,0 +1,142 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wire-format pin for [RelayerEndpoint]'s custom serializer. The
+ * serializer is the bridge between three on-disk shapes:
+ *
+ *  1. **New plural** — `"networks": ["testnet", "public"]`. The
+ *     current published `relayers.json` and every save going forward.
+ *  2. **Legacy singular** — `"network": "testnet"`. PR #20 / PR #22
+ *     saves on disk; one-time migration via this decoder.
+ *  3. **Mixed** — defensive: if both fields are present, the plural
+ *     wins (the future shape).
+ *
+ * Encode side: always writes the new plural shape; the legacy field
+ * is never serialized. Pinned here so a future "tidy the surrogate"
+ * refactor doesn't silently re-emit the singular field.
+ *
+ * Mirrors `RelayerEndpointSchemaTests` from onym-ios PR #23.
+ */
+class RelayerEndpointSchemaTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun decode_pluralWireShape_yieldsNetworksList() {
+        val raw = """
+            { "name": "Onym Mainnet",
+              "url": "https://relayer.onym.chat",
+              "networks": ["testnet", "public"] }
+        """.trimIndent()
+        val ep = json.decodeFromString(RelayerEndpoint.serializer(), raw)
+        assertEquals(listOf("testnet", "public"), ep.networks)
+        assertEquals("Onym Mainnet", ep.name)
+        assertEquals("https://relayer.onym.chat", ep.url)
+    }
+
+    @Test
+    fun decode_legacySingularNetwork_promotesToOneElementList() {
+        // PR #20 saved configurations look like this on disk —
+        // backward-compat is load-bearing for the silent install
+        // upgrade path.
+        val raw = """
+            { "name": "Onym Testnet",
+              "url": "https://relayer-testnet.onym.chat",
+              "network": "testnet" }
+        """.trimIndent()
+        val ep = json.decodeFromString(RelayerEndpoint.serializer(), raw)
+        assertEquals(listOf("testnet"), ep.networks)
+    }
+
+    @Test
+    fun decode_bothFieldsPresent_pluralWins() {
+        // Defensive: if a future asset publishes both shapes during a
+        // transition, the plural is the canonical answer.
+        val raw = """
+            { "name": "Onym",
+              "url": "https://relayer.example",
+              "networks": ["testnet"],
+              "network": "public" }
+        """.trimIndent()
+        val ep = json.decodeFromString(RelayerEndpoint.serializer(), raw)
+        assertEquals(listOf("testnet"), ep.networks)
+    }
+
+    @Test
+    fun decode_neitherFieldPresent_yieldsEmptyList() {
+        // A published-but-unspecified endpoint — would render with no
+        // network badges. Keep decode lenient so a single bad row
+        // doesn't fail the whole document.
+        val raw = """
+            { "name": "Onym",
+              "url": "https://relayer.example" }
+        """.trimIndent()
+        val ep = json.decodeFromString(RelayerEndpoint.serializer(), raw)
+        assertTrue(ep.networks.isEmpty())
+    }
+
+    @Test
+    fun encode_alwaysEmitsPlural_neverSingular() {
+        // Encoder pin: never write the legacy `network` field. A
+        // future refactor that "tidies up" the surrogate must keep
+        // this property — emitting the singular field would round-
+        // trip back to a one-element list, silently losing data when
+        // the source had multiple networks.
+        val ep = RelayerEndpoint(
+            name = "Onym",
+            url = "https://relayer.example",
+            networks = listOf("testnet", "public"),
+        )
+        val encoded = json.encodeToString(RelayerEndpoint.serializer(), ep)
+        assertTrue(
+            "encoded output must contain `networks` array, was: $encoded",
+            encoded.contains("\"networks\":[\"testnet\",\"public\"]"),
+        )
+        assertFalse(
+            "encoded output must not contain legacy `network` field, was: $encoded",
+            encoded.contains("\"network\":"),
+        )
+    }
+
+    @Test
+    fun roundTrip_preservesNetworksList() {
+        val original = RelayerEndpoint(
+            name = "Onym",
+            url = "https://relayer.example",
+            networks = listOf("testnet", "public", "futurenet"),
+        )
+        val encoded = json.encodeToString(RelayerEndpoint.serializer(), original)
+        val decoded = json.decodeFromString(RelayerEndpoint.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun decode_publishedRelayersJsonShape_matchesProductionWire() {
+        // Snapshot of the live published `relayers.json` shape (as of
+        // PR #23). Pins us against the on-disk shape the
+        // `releases/latest/download/<asset>` redirect actually emits
+        // — the entire deployment hot-path. If this test goes red, a
+        // server-side schema change has shipped that we need to
+        // mirror in the decoder.
+        val live = """
+            {
+              "version": 1,
+              "relayers": [
+                { "name": "Onym Official",
+                  "url": "https://relayer.onym.chat",
+                  "networks": ["testnet", "public"] }
+              ]
+            }
+        """.trimIndent()
+        val doc = json.decodeFromString(KnownRelayersDocument.serializer(), live)
+        assertEquals(1, doc.version)
+        assertEquals(1, doc.relayers.size)
+        assertEquals(listOf("testnet", "public"), doc.relayers.single().networks)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerRepositoryTest.kt
@@ -17,8 +17,8 @@ import kotlin.random.Random
  */
 class RelayerRepositoryTest {
 
-    private val a = RelayerEndpoint("A", "https://a.example", "testnet")
-    private val b = RelayerEndpoint("B", "https://b.example", "testnet")
+    private val a = RelayerEndpoint("A", "https://a.example", listOf("testnet"))
+    private val b = RelayerEndpoint("B", "https://b.example", listOf("testnet"))
     private val custom = RelayerEndpoint.custom("https://localhost:8080")
 
     private fun makeRepo(
@@ -195,7 +195,7 @@ class RelayerRepositoryTest {
 
         // Re-add `a`'s URL with new metadata (e.g. user typed it as
         // custom first, then the published list landed).
-        val refreshedA = a.copy(name = "Onym A (refreshed)", network = "public")
+        val refreshedA = a.copy(name = "Onym A (refreshed)", networks = listOf("public"))
         repo.addEndpoint(refreshedA)
 
         val endpoints = repo.snapshots.value.configuration.endpoints
@@ -344,5 +344,89 @@ class RelayerRepositoryTest {
         repo.setStrategy(RelayerStrategy.PRIMARY)
         // No setPrimary call → primaryUrl is null → fall through to first.
         assertEquals(a.url, repo.selectUrl())
+    }
+
+    // ─── PR #23: fetchStatus snapshots ────────────────────────────
+
+    @Test
+    fun bootstrap_leavesFetchStatusIdle() = runTest {
+        val (repo, _) = makeRepo()
+        repo.bootstrap()
+        assertEquals(RelayerFetchStatus.Idle, repo.snapshots.value.fetchStatus)
+    }
+
+    @Test
+    fun start_publishesSuccess_onHappyPath() = runTest {
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a, b)))
+        val (repo, _) = makeRepo(fetcher = fetcher)
+        repo.bootstrap()
+
+        repo.start()
+
+        assertEquals(RelayerFetchStatus.Success, repo.snapshots.value.fetchStatus)
+    }
+
+    @Test
+    fun start_publishesFailed_andStillSwallowsThrow_onError() = runTest {
+        // Repository must wire the typed error into a localised
+        // message via `errorMessageResolver` AND continue to swallow
+        // the throw so app launch survives a network blip.
+        val fetcher = FakeKnownRelayersFetcher(
+            FakeKnownRelayersFetcher.Mode.Failing(RelayersFetchError.BadStatus(503))
+        )
+        val (repo, _) = makeRepo(
+            fetcher = fetcher,
+        ).let { (r, s) ->
+            // Recreate with a controlled resolver so the assertion isn't
+            // tied to the Throwable's default message.
+            RelayerRepository(s, fetcher, errorMessageResolver = { "RESOLVED: ${it::class.simpleName}" }) to s
+        }
+        repo.bootstrap()
+
+        repo.start()  // must not throw — `start` swallows after publishing Failed
+
+        val status = repo.snapshots.value.fetchStatus
+        assertTrue("status must be Failed, was $status", status is RelayerFetchStatus.Failed)
+        assertEquals("RESOLVED: BadStatus", (status as RelayerFetchStatus.Failed).message)
+    }
+
+    @Test
+    fun refresh_publishesFailed_andRethrows_onError() = runTest {
+        // User-initiated retry: the Failed snapshot must be visible
+        // to UI observers BEFORE the throw propagates.
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(
+            FakeKnownRelayersFetcher.Mode.Failing(RelayersFetchError.MalformedDocument(IOException("boom")))
+        )
+        val repo = RelayerRepository(
+            store, fetcher,
+            errorMessageResolver = { "RESOLVED: ${it::class.simpleName}" },
+        )
+        repo.bootstrap()
+
+        val thrown = runCatching { repo.refresh() }.exceptionOrNull()
+
+        assertTrue("refresh must rethrow", thrown is RelayersFetchError.MalformedDocument)
+        val status = repo.snapshots.value.fetchStatus
+        assertTrue(status is RelayerFetchStatus.Failed)
+        assertEquals("RESOLVED: MalformedDocument", (status as RelayerFetchStatus.Failed).message)
+    }
+
+    @Test
+    fun refresh_clearsStaleFailed_onSuccessfulRetry() = runTest {
+        // A retry that succeeds must flip the snapshot back to
+        // Success so the UI hides the error row.
+        val fetcher = FakeKnownRelayersFetcher(
+            FakeKnownRelayersFetcher.Mode.Failing(IOException("offline"))
+        )
+        val (repo, _) = makeRepo(fetcher = fetcher)
+        repo.bootstrap()
+        repo.start()
+        assertTrue(repo.snapshots.value.fetchStatus is RelayerFetchStatus.Failed)
+
+        fetcher.mode = FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a))
+        repo.refresh()
+
+        assertEquals(RelayerFetchStatus.Success, repo.snapshots.value.fetchStatus)
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/RelayerSelectionStoreTest.kt
@@ -37,7 +37,7 @@ class RelayerSelectionStoreTest {
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var store: DataStorePreferencesRelayerSelectionStore
 
-    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", "testnet")
+    private val testnet = RelayerEndpoint("Onym Testnet", "https://relayer-testnet.onym.chat", listOf("testnet"))
 
     @Before
     fun setUp() {
@@ -117,7 +117,7 @@ class RelayerSelectionStoreTest {
         val migrated = store.loadConfiguration()
         assertEquals(1, migrated.endpoints.size)
         val ep = migrated.endpoints.single()
-        assertEquals("custom", ep.network)
+        assertEquals(listOf("custom"), ep.networks)
         assertEquals("https://localhost:8080", ep.url)
         assertEquals("localhost", ep.name)
         assertEquals(ep.url, migrated.primaryUrl)

--- a/app/src/test/kotlin/chat/onym/android/settings/RelayerSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/settings/RelayerSettingsViewModelTest.kt
@@ -4,8 +4,10 @@ package chat.onym.android.settings
 
 import chat.onym.android.chain.RelayerConfiguration
 import chat.onym.android.chain.RelayerEndpoint
+import chat.onym.android.chain.RelayerFetchStatus
 import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.chain.RelayerStrategy
+import java.io.IOException
 import chat.onym.android.support.FakeKnownRelayersFetcher
 import chat.onym.android.support.InMemoryRelayerSelectionStore
 import kotlinx.coroutines.Dispatchers
@@ -31,8 +33,8 @@ import org.junit.Test
  */
 class RelayerSettingsViewModelTest {
 
-    private val a = RelayerEndpoint("A", "https://a.example", "testnet")
-    private val b = RelayerEndpoint("B", "https://b.example", "public")
+    private val a = RelayerEndpoint("A", "https://a.example", listOf("testnet"))
+    private val b = RelayerEndpoint("B", "https://b.example", listOf("public"))
 
     @Before fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
     @After  fun tearDown() { Dispatchers.resetMain() }
@@ -60,7 +62,7 @@ class RelayerSettingsViewModelTest {
 
         val endpoints = repo.snapshots.value.configuration.endpoints
         assertEquals(1, endpoints.size)
-        assertEquals("custom", endpoints.single().network)
+        assertEquals(listOf("custom"), endpoints.single().networks)
         assertEquals("https://localhost:9090", endpoints.single().url)  // trimmed
     }
 
@@ -123,6 +125,62 @@ class RelayerSettingsViewModelTest {
         vm.setStrategy(RelayerStrategy.RANDOM); yield()
 
         assertEquals(RelayerStrategy.RANDOM, repo.snapshots.value.configuration.strategy)
+    }
+
+    // ─── PR #23: tappedRetryFetch + fetchStatus plumbing ──────────
+
+    @Test
+    fun fetchStatus_isPlumbedFromRepositorySnapshot() = runTest {
+        // After bootstrap (no fetch yet) the snapshot is Idle —
+        // the VM should mirror it so the screen's `when` gate
+        // doesn't render the "Failed" or "Success" branches before
+        // the first fetch happens.
+        val (_, vm) = makeViewModel()
+        assertEquals(RelayerFetchStatus.Idle, vm.state.value.fetchStatus)
+    }
+
+    @Test
+    fun tappedRetryFetch_onFailure_publishesFailedStatusAndDoesNotPropagate() = runTest {
+        // The user taps "Try Again". The repository fetch fails;
+        // the VM must catch the throw (so the UI doesn't crash) and
+        // surface the failure via the snapshot.
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(
+            FakeKnownRelayersFetcher.Mode.Failing(IOException("offline"))
+        )
+        val repo = RelayerRepository(
+            store, fetcher,
+            errorMessageResolver = { "OFFLINE" },
+        )
+        repo.bootstrap()
+        val vm = RelayerSettingsViewModel(repo)
+        yield()
+
+        vm.tappedRetryFetch()
+        yield()
+
+        val status = vm.state.value.fetchStatus
+        assertTrue("status must be Failed, was $status", status is RelayerFetchStatus.Failed)
+        assertEquals("OFFLINE", (status as RelayerFetchStatus.Failed).message)
+    }
+
+    @Test
+    fun tappedRetryFetch_onSuccess_clearsFailedAndExposesKnownList() = runTest {
+        // After a successful retry, the VM must surface the new list
+        // (so the screen can render it via `state.knownList` /
+        // `state.unconfiguredKnownList`) and flip the gate to Success.
+        val store = InMemoryRelayerSelectionStore()
+        val fetcher = FakeKnownRelayersFetcher(FakeKnownRelayersFetcher.Mode.Succeeds(listOf(a, b)))
+        val repo = RelayerRepository(store, fetcher)
+        repo.bootstrap()
+        val vm = RelayerSettingsViewModel(repo)
+        yield()
+
+        vm.tappedRetryFetch()
+        yield()
+
+        assertEquals(RelayerFetchStatus.Success, vm.state.value.fetchStatus)
+        assertEquals(listOf(a, b), vm.state.value.knownList)
     }
 
     // ─── unconfiguredKnownList filtering ──────────────────────────


### PR DESCRIPTION
## Summary

Settings → Relayer "Fetching list…" spun forever on cold install because two bugs combined:

1. **Wire-format mismatch.** The published `relayers.json` uses `\"networks\": [\"testnet\", \"public\"]` (plural list) but the on-disk decoder expected `\"network\": \"testnet\"` (singular). kotlinx.serialization raised `MissingFieldException` on every fetch — not `IOException`, so the empty-body catch path didn't apply.
2. **Silent failure.** `RelayerRepository.start()` swallowed the throw entirely; the picker gated the spinner on `knownList.isEmpty`, true forever after a failed fetch. There was no surface for the failure.

This PR fixes both, and adds a Try Again surface.

### Changes

- **Schema** (`RelayerEndpoint.kt`): `network: String` → `networks: List<String>` with a custom `KSerializer` that decodes both the new plural shape AND the legacy singular shape (PR #20 / PR #22 saves on disk). Encoder always emits the plural; the legacy field is never written.
- **Status** (`RelayerEndpoint.kt`, `RelayerRepository.kt`): new sealed `RelayerFetchStatus` (Idle / Fetching / Success / Failed) on `RelayerState`; `refreshInternal` publishes Fetching → fetch → Success or Failed (then rethrows for `refresh`, swallows for `start`). The mutex is no longer held across the network call.
- **Errors** (`KnownRelayersFetcher.kt`, `RelayerErrorMessages.kt`): sealed `RelayersFetchError.{BadStatus, MalformedDocument}` raised by the GitHub-Releases fetcher; resource-backed `(Throwable) -> String` mapper injected through `OnymApplication` keeps the repository Context-free.
- **UI** (`RelayerSettingsScreen.kt`, `RelayerSettingsViewModel.kt`): 4-way `when (state.fetchStatus)` gate replaces the single empty-list branch — Fetching shows a spinner with label, Failed shows the localised message + a Try Again button (`tappedRetryFetch` intent), Success with empty list shows the new "no published yet" copy. `NetworkBadges` iterates `endpoint.networks` so multi-network endpoints render all tags.
- **Strings** (`values/strings.xml`, `values-ru/strings.xml`): 5 new keys (relayer_fetch_failed_status / _malformed / _offline, relayer_fetch_no_published_yet, relayer_fetch_retry).

### Tests

- New `RelayerEndpointSchemaTest` pins both wire shapes — plural decode, legacy singular promoted to one-element list, plural-wins-on-conflict, encoder never writes the legacy field, snapshot of the live published `relayers.json`.
- Extended `RelayerRepositoryTest` for the four fetch-status transitions: bootstrap leaves Idle; start happy-path → Success; start failure → Failed (still swallows); refresh failure → Failed AND rethrows; successful retry clears stale Failed.
- Extended `RelayerSettingsViewModelTest` for `tappedRetryFetch` — VM mirrors snapshot status, retry-on-failure publishes Failed without propagating, retry-on-success exposes `knownList`.
- Existing fixtures migrated to `listOf(\"testnet\")` etc.; legacy singular `\"network\"` strings retained where they pin migration / backward-compat decode paths.

Mirrors onymchat/onym-ios#23.

## Test plan

- [x] `:app:assembleDebug` (production compiles)
- [x] `:app:testDebugUnitTest --tests \"chat.onym.android.chain.*\" --tests \"chat.onym.android.settings.*\"` (all green)
- [x] `:app:compileDebugAndroidTestKotlin` (instrumented sources compile)
- [x] Live `curl https://github.com/onymchat/onym-relayer/releases/latest/download/relayers.json` matches the snapshot test fixture
- [ ] CI's full test sweep
- [ ] On-device smoke: cold install → open Settings → Relayer; published list appears within seconds, both badges show

🤖 Generated with [Claude Code](https://claude.com/claude-code)