### PR TITLE
fix(manifest): declare android.permission.INTERNET so the relayer fetch can leave the device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
+    <!--
+        Required by `GitHubReleasesKnownRelayersFetcher` (pulls
+        `relayers.json` from the latest release of `onymchat/onym-relayer`)
+        and by `GitHubReleasesContractsManifestFetcher` (same pattern for
+        the contracts manifest). Without it, OkHttp throws SecurityException
+        on every call and the relayer picker shows "could not reach
+        published list" forever — this was the visible symptom on cold
+        install before this fix.
+    -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".OnymApplication"
         android:label="@string/app_name"


### PR DESCRIPTION
## Summary

PR #22 (relayer fetch-status gating) shipped without anyone noticing that `AndroidManifest.xml` was missing `<uses-permission android:name=\"android.permission.INTERNET\" />`. The new gate correctly surfaces the failure as \"could not reach published list\", but the underlying call never leaves the device — OkHttp throws `SecurityException`, the `RelayerErrorMessages` resolver falls through to the offline branch, and the user sees the offline copy regardless of whether they're actually online.

iOS has no analogous declaration (network access is the default-allowed posture); on Android it's a hard requirement. The same permission also unblocks `GitHubReleasesContractsManifestFetcher`, which has the same shape and the same dependency.

## Test plan

- [x] `:app:assembleDebug` (manifest merger picks the new permission up)
- [ ] On-device smoke: cold install → Settings → Relayer; published list lands within seconds, no \"could not reach published list\" copy
- [ ] CI's full sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)