### PR TITLE
chain: invitation envelope sealer + relayer HTTP client + group state types

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/GroupCommitmentBuilderFfiTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/GroupCommitmentBuilderFfiTest.kt
@@ -1,0 +1,66 @@
+package chat.onym.android.group
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.chain.SepTier
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * FFI-backed tests for [GroupCommitmentBuilder]. Lives in
+ * `androidTest/` because each method here calls into
+ * `chat.onym.sdk.Common`, which loads its native `.so` from the SDK
+ * AAR's `jni/<abi>/` — only available on the device runtime.
+ *
+ * The pure-Kotlin helpers (salt generation + derivation) are covered
+ * by the unit-test twin under `app/src/test/.../group/GroupCommitmentBuilderTest.kt`.
+ *
+ * Mirrors the FFI portion of `GroupCommitmentBuilderTests.swift` from
+ * onym-ios PR #24.
+ */
+@RunWith(AndroidJUnit4::class)
+class GroupCommitmentBuilderFfiTest {
+
+    @Test
+    fun computePublicKeyAndLeafHash_returnExpectedSizes() {
+        val secret = ByteArray(32) { 0x42 }
+        val pub = GroupCommitmentBuilder.computePublicKey(secret)
+        val leaf = GroupCommitmentBuilder.computeLeafHash(secret)
+        assertEquals("compressed BLS12-381 G1 is 48 bytes", 48, pub.size)
+        assertEquals("Poseidon Fr leaf is 32 bytes", 32, leaf.size)
+    }
+
+    @Test
+    fun computeMerkleRoot_isOrderInvariant() {
+        // Lex-sort behaviour: building the same roster in two orders
+        // must produce the same Poseidon root. Anchors the cross-
+        // platform sort contract — both peers MUST sort identically.
+        val a = memberFromSecret(ByteArray(32) { 0x10 })
+        val b = memberFromSecret(ByteArray(32) { 0x20 })
+        val c = memberFromSecret(ByteArray(32) { 0x30 })
+
+        val root1 = GroupCommitmentBuilder.computeMerkleRoot(listOf(a, b, c), SepTier.SMALL)
+        val root2 = GroupCommitmentBuilder.computeMerkleRoot(listOf(c, a, b), SepTier.SMALL)
+        assertArrayEquals(root1, root2)
+        assertEquals(32, root1.size)
+    }
+
+    @Test
+    fun computePoseidonCommitment_changesWithEpoch() {
+        val member = memberFromSecret(ByteArray(32) { 0x42 })
+        val root = GroupCommitmentBuilder.computeMerkleRoot(listOf(member), SepTier.SMALL)
+        val salt = ByteArray(32) { 0x77 }
+
+        val c0 = GroupCommitmentBuilder.computePoseidonCommitment(root, 0uL, salt)
+        val c1 = GroupCommitmentBuilder.computePoseidonCommitment(root, 1uL, salt)
+        assertEquals(32, c0.size)
+        assertFalse("epoch participates in the commitment", c0.contentEquals(c1))
+    }
+
+    private fun memberFromSecret(secret: ByteArray): GovernanceMember = GovernanceMember(
+        publicKeyCompressed = GroupCommitmentBuilder.computePublicKey(secret),
+        leafHash = GroupCommitmentBuilder.computeLeafHash(secret),
+    )
+}

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
@@ -1,0 +1,168 @@
+package chat.onym.android.identity
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.Security
+import java.util.UUID
+
+/**
+ * Sender side of the invitation envelope. Mirrors
+ * [IdentityRepositoryInvitationDecryptTest] but exercises the new
+ * [IdentityRepository.sealInvitation] method — sealed bytes round-trip
+ * through `decryptInvitation` on a *different* [IdentityRepository]
+ * (the recipient) and the M-5 ephemeral-pubkey signature must verify
+ * against the sender's identity key.
+ *
+ * Lives in `androidTest/` for the same reason as the decrypt twin —
+ * the underlying `IdentitySecretStore` needs the real Android
+ * Keystore + the OnymSDK `.so`.
+ *
+ * Mirrors `IdentityRepositorySealInvitationTests.swift` from
+ * onym-ios PR #24.
+ */
+@RunWith(AndroidJUnit4::class)
+class IdentityRepositorySealInvitationTest {
+
+    /** Cross-platform fixture mnemonics. Two distinct identities so
+     *  sender and recipient have different inbox + signing keys. */
+    private val senderMnemonic =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow"
+    private val recipientMnemonic =
+        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above"
+
+    private lateinit var ctx: Context
+    private lateinit var senderStore: IdentitySecretStore
+    private lateinit var recipientStore: IdentitySecretStore
+    private lateinit var sender: IdentityRepository
+    private lateinit var recipient: IdentityRepository
+
+    @Before
+    fun setUp() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.insertProviderAt(BouncyCastleProvider(), 2)
+        }
+        ctx = ApplicationProvider.getApplicationContext()
+        senderStore = IdentitySecretStore(
+            ctx,
+            prefsFileName = "chat.onym.android.identity.seal.sender.${UUID.randomUUID()}",
+        )
+        recipientStore = IdentitySecretStore(
+            ctx,
+            prefsFileName = "chat.onym.android.identity.seal.recipient.${UUID.randomUUID()}",
+        )
+        sender = IdentityRepository(senderStore)
+        recipient = IdentityRepository(recipientStore)
+        runBlocking {
+            sender.restore(senderMnemonic)
+            recipient.restore(recipientMnemonic)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        try { senderStore.wipe() } catch (_: Throwable) { /* best-effort */ }
+        try { recipientStore.wipe() } catch (_: Throwable) { /* best-effort */ }
+    }
+
+    // ─── happy paths ──────────────────────────────────────────────
+
+    @Test
+    fun seal_roundtripsThroughRecipientDecrypt() = runBlocking {
+        val recipientIdentity = recipient.snapshots.value!!
+        val plaintext = "hello, invitee".toByteArray()
+
+        val sealed = sender.sealInvitation(
+            payload = plaintext,
+            recipientInboxPublicKey = recipientIdentity.inboxPublicKey,
+        )
+        val decrypted = recipient.decryptInvitation(sealed)
+        assertArrayEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun seal_signatureVerifiesAgainstSenderIdentity() = runBlocking {
+        val recipientIdentity = recipient.snapshots.value!!
+        val senderIdentity = sender.snapshots.value!!
+
+        val sealed = sender.sealInvitation(
+            payload = "attested".toByteArray(),
+            recipientInboxPublicKey = recipientIdentity.inboxPublicKey,
+        )
+        val envelope = Json { ignoreUnknownKeys = true }
+            .decodeFromString(SealedEnvelope.serializer(), sealed.toString(Charsets.UTF_8))
+
+        val senderPub = envelope.senderEd25519PublicKey
+        assertNotNull("envelope must carry sender Ed25519 pubkey", senderPub)
+        assertArrayEquals(
+            senderIdentity.stellarPublicKey,
+            senderPub,
+        )
+        val ephPub = envelope.ephemeralPublicKey!!
+        val sig = envelope.ephemeralKeySignature!!
+        val verifier = Ed25519Signer().apply {
+            init(false, Ed25519PublicKeyParameters(senderPub!!, 0))
+        }
+        verifier.update(ephPub, 0, ephPub.size)
+        assertTrue("M-5 signature over ephemeral pubkey must verify", verifier.verifySignature(sig))
+    }
+
+    @Test
+    fun seal_freshEphemeralPerCall() = runBlocking {
+        val recipientIdentity = recipient.snapshots.value!!
+        val first = sender.sealInvitation("a".toByteArray(), recipientIdentity.inboxPublicKey)
+        val second = sender.sealInvitation("a".toByteArray(), recipientIdentity.inboxPublicKey)
+
+        val json = Json { ignoreUnknownKeys = true }
+        val firstEnv = json.decodeFromString(SealedEnvelope.serializer(), first.toString(Charsets.UTF_8))
+        val secondEnv = json.decodeFromString(SealedEnvelope.serializer(), second.toString(Charsets.UTF_8))
+        assertFalse(
+            "each seal must mint a fresh per-envelope X25519 keypair",
+            firstEnv.ephemeralPublicKey!!.contentEquals(secondEnv.ephemeralPublicKey!!),
+        )
+        assertFalse(
+            "different nonce → different ciphertext",
+            firstEnv.ciphertext.contentEquals(secondEnv.ciphertext),
+        )
+    }
+
+    // ─── error paths ──────────────────────────────────────────────
+
+    @Test
+    fun seal_rejectsInvalidRecipientPublicKey_wrongSize() = runBlocking {
+        val tooShort = ByteArray(16)  // X25519 expects 32B
+        assertThrows(InvitationSealError.InvalidRecipientPublicKey::class.java) {
+            runBlocking { sender.sealInvitation("x".toByteArray(), tooShort) }
+        }
+        Unit
+    }
+
+    @Test
+    fun seal_throwsIdentityNotLoaded_afterWipe() = runBlocking {
+        val recipientIdentity = recipient.snapshots.value!!
+        sender.wipe()
+
+        val thrown = assertThrows(InvitationSealError.IdentityNotLoaded::class.java) {
+            runBlocking {
+                sender.sealInvitation("x".toByteArray(), recipientIdentity.inboxPublicKey)
+            }
+        }
+        assertSame(InvitationSealError.IdentityNotLoaded, thrown)
+        Unit
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
@@ -1,0 +1,170 @@
+package chat.onym.android.chain
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.IOException
+
+/**
+ * Pins a `(contractId, transport)` pair and exposes the three
+ * contract entrypoints PR-A needs:
+ *
+ *  - `create_group_v2` — Anarchy / OneOnOne / Democracy / Tyranny
+ *    creation. Per-type Oligarchy creation lives outside PR-A scope.
+ *  - `update_commitment` — Tyranny member-add (used by PR-B+).
+ *  - `get_state` — post-create read-back used by the E2E test (PR-D).
+ *
+ * Stellar Soroban SDK is intentionally not pulled in: the relayer
+ * handles tx assembly + signing, this client just POSTs the function
+ * call in the [SepContractInvocation] envelope shape.
+ *
+ * Mirrors `SEPContractClient` from onym-ios PR #24.
+ *
+ * @param contractId Soroban contract ID the relayer will route the
+ *   call to. Comes from `ContractsRepository` selection.
+ * @param transport The HTTP-leg seam — production uses
+ *   [OkHttpSepContractTransport], tests substitute [FakeSepContractTransport]
+ *   (or build an [OkHttpClient] via `FakeOkHttpClient` and wrap).
+ */
+class SepContractClient(
+    val contractId: String,
+    private val transport: SepContractTransport,
+) {
+
+    suspend fun createGroupV2(request: SepCreateGroupV2Request): SepSubmissionResponse =
+        invoke(
+            function = "create_group_v2",
+            payload = request,
+            payloadSerializer = SepCreateGroupV2Request.serializer(),
+            responseSerializer = SepSubmissionResponse.serializer(),
+        )
+
+    suspend fun updateCommitment(request: SepUpdateCommitmentRequest): SepSubmissionResponse =
+        invoke(
+            function = "update_commitment",
+            payload = request,
+            payloadSerializer = SepUpdateCommitmentRequest.serializer(),
+            responseSerializer = SepSubmissionResponse.serializer(),
+        )
+
+    suspend fun getState(groupId: ByteArray): SepCommitmentEntry =
+        invoke(
+            function = "get_state",
+            payload = SepGetStateRequest(groupId = groupId),
+            payloadSerializer = SepGetStateRequest.serializer(),
+            responseSerializer = SepCommitmentEntry.serializer(),
+        )
+
+    private suspend fun <P, R> invoke(
+        function: String,
+        payload: P,
+        payloadSerializer: KSerializer<P>,
+        responseSerializer: KSerializer<R>,
+    ): R {
+        val invocation = SepContractInvocation(
+            contractId = contractId,
+            function = function,
+            payload = payload,
+        )
+        return transport.invoke(
+            invocation = invocation,
+            invocationSerializer = SepContractInvocation.serializer(payloadSerializer),
+            responseSerializer = responseSerializer,
+        )
+    }
+}
+
+/**
+ * Seam for the network leg. Tests inject [FakeSepContractTransport];
+ * production uses [OkHttpSepContractTransport] constructed from a
+ * [chat.onym.android.chain.RelayerEndpoint] resolved via
+ * `RelayerRepository.selectUrl`.
+ */
+interface SepContractTransport {
+    suspend fun <P, R> invoke(
+        invocation: SepContractInvocation<P>,
+        invocationSerializer: KSerializer<SepContractInvocation<P>>,
+        responseSerializer: KSerializer<R>,
+    ): R
+}
+
+/**
+ * OkHttp-backed transport. POSTs the JSON-encoded invocation envelope
+ * to [endpointUrl] and decodes the body on 2xx; throws
+ * [SepContractError.BadStatus] on non-2xx (after capturing the body —
+ * gotcha #3 in the brief: `Response.body!!.bytes()` is single-shot).
+ *
+ * @param httpClient Injected for tests; production passes the same
+ *   shared [OkHttpClient] as the rest of the app.
+ * @param endpointUrl The relayer's contract-call URL. Resolved per
+ *   request from `RelayerRepository.selectUrl()`.
+ */
+class OkHttpSepContractTransport(
+    private val httpClient: OkHttpClient,
+    private val endpointUrl: String,
+) : SepContractTransport {
+
+    override suspend fun <P, R> invoke(
+        invocation: SepContractInvocation<P>,
+        invocationSerializer: KSerializer<SepContractInvocation<P>>,
+        responseSerializer: KSerializer<R>,
+    ): R = withContext(Dispatchers.IO) {
+        val bodyJson = jsonFormat.encodeToString(invocationSerializer, invocation)
+        val request = Request.Builder()
+            .url(endpointUrl.toHttpUrl())
+            .header("Content-Type", "application/json")
+            .post(bodyJson.toRequestBody("application/json".toMediaType()))
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+            // Single-shot body read — capture the bytes before
+            // checking status so the error path can include the
+            // response body without a second `.bytes()` call.
+            val responseBytes = try {
+                response.body?.bytes() ?: ByteArray(0)
+            } catch (e: IOException) {
+                throw SepContractError.NotConnected(e)
+            }
+
+            if (!response.isSuccessful) {
+                val bodyStr = try {
+                    responseBytes.toString(Charsets.UTF_8)
+                } catch (_: Throwable) {
+                    "<non-UTF8 body, ${responseBytes.size} bytes>"
+                }
+                throw SepContractError.BadStatus(code = response.code, body = bodyStr)
+            }
+
+            try {
+                jsonFormat.decodeFromString(
+                    responseSerializer,
+                    responseBytes.toString(Charsets.UTF_8),
+                )
+            } catch (e: SerializationException) {
+                throw SepContractError.MalformedResponse(e)
+            } catch (e: IllegalArgumentException) {
+                // base64 decode failure inside per-field serializer
+                throw SepContractError.MalformedResponse(e)
+            }
+        }
+    }
+
+    companion object {
+        /** Permissive decode: relayer may add fields in a future
+         *  version, and unknown keys must not break the client. */
+        private val jsonFormat = Json {
+            ignoreUnknownKeys = true
+            // Forward-compat: encode with default values present so a
+            // future relayer that REQUIRES a field with our default
+            // doesn't break.
+            encodeDefaults = true
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractError.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractError.kt
@@ -1,0 +1,29 @@
+package chat.onym.android.chain
+
+import java.io.IOException
+
+/**
+ * Failure modes for [SepContractClient]. Sealed so `when`
+ * exhaustiveness checks downstream don't need an `else` branch.
+ *
+ * Mirrors `SEPError` from onym-ios PR #24, plus a [NotConnected]
+ * variant that the iOS twin folds into URLSession's own
+ * `URLError.notConnectedToInternet`. We surface it explicitly so the
+ * UI can render a distinct "offline" message vs. "server returned
+ * 5xx".
+ */
+sealed class SepContractError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    /** Server returned a non-2xx response. [body] is the captured
+     *  response body (already decoded as UTF-8 if possible). */
+    class BadStatus(val code: Int, val body: String) :
+        SepContractError("contract call returned HTTP $code: $body")
+
+    /** Response body didn't match the expected schema. */
+    class MalformedResponse(cause: Throwable) :
+        SepContractError("response body didn't match the expected schema", cause)
+
+    /** Network-layer failure (DNS, TLS, connect, mid-flight read). */
+    class NotConnected(cause: IOException) :
+        SepContractError("network error: ${cause.message}", cause)
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
@@ -1,0 +1,292 @@
+package chat.onym.android.chain
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Wire-format pin for the relayer JSON payloads. **Field names are
+ * load-bearing** — they must match `SEPContractTypes.swift` from
+ * onym-ios PR #24 byte-for-byte (snake_case via [SerialName]).
+ *
+ * `ByteArray` fields are encoded as base64 strings via
+ * [Base64ByteArraySerializer] (matches Foundation's default
+ * `Data` Codable shape on iOS).
+ *
+ * UInt32 / UInt64 are serialised as JSON numbers via the experimental
+ * unsigned support — kotlinx.serialization 1.6+ writes them as
+ * positive integers, matching iOS Codable's UInt32 / UInt64 emission.
+ *
+ * Mirrors `SEPContractTypes.swift` from onym-ios PR #24.
+ */
+
+// ─── enums ────────────────────────────────────────────────────────
+
+/**
+ * Mirrors `SEPGroupType` from swift-mls plus the post-v0.0.3
+ * [TYRANNY] case (group_type=4). Persisted as the `group_type` u32 in
+ * the contract's `CommitmentEntryV2`.
+ */
+@Serializable(with = SepGroupTypeSerializer::class)
+enum class SepGroupType(val rawValue: UInt) {
+    ANARCHY(0u),
+    ONE_ON_ONE(1u),
+    DEMOCRACY(2u),
+    OLIGARCHY(3u),
+    TYRANNY(4u),
+    ;
+
+    companion object {
+        fun fromRaw(raw: UInt): SepGroupType =
+            entries.firstOrNull { it.rawValue == raw }
+                ?: throw IllegalArgumentException("unknown SepGroupType raw=$raw")
+    }
+}
+
+internal object SepGroupTypeSerializer : KSerializer<SepGroupType> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("SepGroupType", PrimitiveKind.INT)
+
+    override fun serialize(encoder: Encoder, value: SepGroupType) {
+        encoder.encodeInt(value.rawValue.toInt())
+    }
+
+    override fun deserialize(decoder: Decoder): SepGroupType =
+        SepGroupType.fromRaw(decoder.decodeInt().toUInt())
+}
+
+/**
+ * Tier sizing for the Merkle tree. Values pinned to match the VK
+ * ceremonies. iOS uses Int rawValue but exposes derived
+ * `maxMembers` / `depth`; we mirror.
+ */
+enum class SepTier(val rawValue: Int, val maxMembers: Int, val depth: Int) {
+    SMALL(0, 32, 5),
+    MEDIUM(1, 256, 8),
+    LARGE(2, 2048, 11),
+}
+
+// ─── public-input bundles ─────────────────────────────────────────
+
+/** Public-input bundle for the create circuit: commitment + epoch. */
+@Serializable
+data class SepPublicInputs(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    val epoch: ULong,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepPublicInputs) return false
+        return commitment.contentEquals(other.commitment) && epoch == other.epoch
+    }
+
+    override fun hashCode(): Int =
+        31 * commitment.contentHashCode() + epoch.hashCode()
+}
+
+/**
+ * Public-input bundle for the update circuit (sep-mls #59 fix). The
+ * contract rederives `c_new` from the proof itself, so the relayer no
+ * longer trusts a client-supplied "new commitment".
+ */
+@Serializable
+data class SepUpdatePublicInputs(
+    @SerialName("c_old")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val cOld: ByteArray,
+    @SerialName("epoch_old")
+    val epochOld: ULong,
+    @SerialName("c_new")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val cNew: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepUpdatePublicInputs) return false
+        return cOld.contentEquals(other.cOld) &&
+            epochOld == other.epochOld &&
+            cNew.contentEquals(other.cNew)
+    }
+
+    override fun hashCode(): Int {
+        var h = cOld.contentHashCode()
+        h = 31 * h + epochOld.hashCode()
+        h = 31 * h + cNew.contentHashCode()
+        return h
+    }
+}
+
+// ─── request payloads ─────────────────────────────────────────────
+
+/**
+ * Payload for `create_group_v2`. Used by Anarchy, OneOnOne, Democracy,
+ * AND Tyranny. Oligarchy uses its own dedicated request shape because
+ * it seeds an extra admin root (out of scope for PR-A).
+ */
+@Serializable
+data class SepCreateGroupV2Request(
+    val caller: String,
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    val tier: UInt,
+    @SerialName("group_type")
+    val groupType: SepGroupType,
+    @SerialName("member_count")
+    val memberCount: UInt,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val proof: ByteArray,
+    @SerialName("public_inputs")
+    val publicInputs: SepPublicInputs,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepCreateGroupV2Request) return false
+        return caller == other.caller &&
+            groupId.contentEquals(other.groupId) &&
+            commitment.contentEquals(other.commitment) &&
+            tier == other.tier &&
+            groupType == other.groupType &&
+            memberCount == other.memberCount &&
+            proof.contentEquals(other.proof) &&
+            publicInputs == other.publicInputs
+    }
+
+    override fun hashCode(): Int {
+        var h = caller.hashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + commitment.contentHashCode()
+        h = 31 * h + tier.hashCode()
+        h = 31 * h + groupType.hashCode()
+        h = 31 * h + memberCount.hashCode()
+        h = 31 * h + proof.contentHashCode()
+        h = 31 * h + publicInputs.hashCode()
+        return h
+    }
+}
+
+/** Payload for `update_commitment` (member-add / member-remove). */
+@Serializable
+data class SepUpdateCommitmentRequest(
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val proof: ByteArray,
+    @SerialName("public_inputs")
+    val publicInputs: SepUpdatePublicInputs,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepUpdateCommitmentRequest) return false
+        return groupId.contentEquals(other.groupId) &&
+            proof.contentEquals(other.proof) &&
+            publicInputs == other.publicInputs
+    }
+
+    override fun hashCode(): Int {
+        var h = groupId.contentHashCode()
+        h = 31 * h + proof.contentHashCode()
+        h = 31 * h + publicInputs.hashCode()
+        return h
+    }
+}
+
+/** Payload for `get_state` / `get_state_v2` / `get_admin_root`. */
+@Serializable
+data class SepGetStateRequest(
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepGetStateRequest) return false
+        return groupId.contentEquals(other.groupId)
+    }
+
+    override fun hashCode(): Int = groupId.contentHashCode()
+}
+
+// ─── response payloads ────────────────────────────────────────────
+
+/**
+ * On-chain state returned by `get_state`. V1 entries (no group_type
+ * metadata).
+ */
+@Serializable
+data class SepCommitmentEntry(
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    val epoch: ULong,
+    val timestamp: ULong,
+    val tier: UInt,
+    val active: Boolean,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SepCommitmentEntry) return false
+        return commitment.contentEquals(other.commitment) &&
+            epoch == other.epoch &&
+            timestamp == other.timestamp &&
+            tier == other.tier &&
+            active == other.active
+    }
+
+    override fun hashCode(): Int {
+        var h = commitment.contentHashCode()
+        h = 31 * h + epoch.hashCode()
+        h = 31 * h + timestamp.hashCode()
+        h = 31 * h + tier.hashCode()
+        h = 31 * h + active.hashCode()
+        return h
+    }
+}
+
+/**
+ * Relayer's response to a contract-invocation POST. `accepted`
+ * reflects the contract's verification result; [transactionHash] is
+ * set when a Soroban tx was actually submitted.
+ *
+ * **Note:** iOS `SEPSubmissionResponse` doesn't override CodingKeys,
+ * so [transactionHash] is encoded as the verbatim camelCase field
+ * (NOT snake_case `transaction_hash`). We mirror that exactly.
+ */
+@Serializable
+data class SepSubmissionResponse(
+    val accepted: Boolean,
+    val transactionHash: String? = null,
+    val message: String? = null,
+)
+
+// ─── invocation envelope ──────────────────────────────────────────
+
+/**
+ * Generic envelope wrapping a contract-function invocation. Mirrors
+ * `swift-mls`'s `SEPContractInvocation` so the relayer wire format
+ * stays in sync — the relayer reads `contract_id`, `function`, and
+ * `payload` out of the JSON top-level.
+ *
+ * Stellar Soroban SDK is intentionally not pulled in: relayers handle
+ * tx assembly + signing, this client just posts the function call.
+ *
+ * Generic over the payload type so each call site keeps its compile-
+ * time payload shape; serialised through
+ * [SepContractClient.invokeRaw].
+ */
+@Serializable
+data class SepContractInvocation<P>(
+    @SerialName("contract_id")
+    val contractId: String,
+    val function: String,
+    val payload: P,
+)

--- a/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
@@ -1,0 +1,136 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * In-memory snapshot of a chat group as the Android app understands
+ * it. PR-A holds this purely as a value type — `GroupRepository` and
+ * the Room `@Entity` land in PR-B.
+ *
+ * Trimmed compared to `stellar-mls/clients/android` group entities:
+ * the chat-message / avatar / push fields are out of scope until the
+ * chat screen ships. [groupSecret] stays in the type because it's
+ * seeded into the invitation envelope at create time and the receiver
+ * needs it to derive message keys later.
+ *
+ * Mirrors `ChatGroup.swift` from onym-ios PR #24.
+ */
+@Serializable
+data class ChatGroup(
+    /** Hex-encoded 32-byte group ID. */
+    val id: String,
+    val name: String,
+    /**
+     * 32-byte shared secret. Used for `topicTag` derivation and
+     * message-key HKDF (both still TBD on Android, but the value
+     * MUST be sealed into the invitation now so receivers can rebuild
+     * the same key).
+     */
+    @SerialName("group_secret")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupSecret: ByteArray,
+    /** Unix epoch milliseconds (matches what `System.currentTimeMillis()`
+     *  emits — one less unit conversion at persistence boundaries). */
+    @SerialName("created_at")
+    val createdAtMillis: Long,
+
+    val members: List<GovernanceMember>,
+    val epoch: ULong,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val salt: ByteArray,
+    /**
+     * Latest verified Poseidon commitment. `null` until the first
+     * `recomputeCommitment` call (or until on-chain state is read
+     * back).
+     */
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray? = null,
+    val tier: SepTier,
+    @SerialName("group_type")
+    val groupType: SepGroupType,
+    /**
+     * Hex (lowercase, 96 chars) BLS pubkey of the single Tyranny
+     * admin. `null` for [SepGroupType.ANARCHY] / [SepGroupType.ONE_ON_ONE]
+     * (no privileged member).
+     */
+    @SerialName("admin_pubkey_hex")
+    val adminPubkeyHex: String? = null,
+    /**
+     * Flips to `true` once the relayer's `create_group_v2` returns
+     * `accepted = true`. Persisted-but-not-anchored groups can be
+     * retried.
+     */
+    @SerialName("is_published_on_chain")
+    val isPublishedOnChain: Boolean = false,
+) {
+    /** Group ID as the raw 32-byte payload, parsed back from [id].
+     *  Used directly when building chain payloads + invitations. */
+    val groupIdBytes: ByteArray
+        get() = bytesFromHex(id)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ChatGroup) return false
+        return id == other.id &&
+            name == other.name &&
+            groupSecret.contentEquals(other.groupSecret) &&
+            createdAtMillis == other.createdAtMillis &&
+            members == other.members &&
+            epoch == other.epoch &&
+            salt.contentEquals(other.salt) &&
+            (commitment?.contentEquals(other.commitment) ?: (other.commitment == null)) &&
+            tier == other.tier &&
+            groupType == other.groupType &&
+            adminPubkeyHex == other.adminPubkeyHex &&
+            isPublishedOnChain == other.isPublishedOnChain
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + name.hashCode()
+        h = 31 * h + groupSecret.contentHashCode()
+        h = 31 * h + createdAtMillis.hashCode()
+        h = 31 * h + members.hashCode()
+        h = 31 * h + epoch.hashCode()
+        h = 31 * h + salt.contentHashCode()
+        h = 31 * h + (commitment?.contentHashCode() ?: 0)
+        h = 31 * h + tier.hashCode()
+        h = 31 * h + groupType.hashCode()
+        h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
+        h = 31 * h + isPublishedOnChain.hashCode()
+        return h
+    }
+
+    companion object {
+        /** Lenient hex → bytes. Lowercases the input first so
+         *  callers don't have to. Skips trailing odd nibbles
+         *  silently — the constructor accepts only well-formed hex
+         *  IDs in practice; this lenience exists to mirror iOS's
+         *  `bytes(fromHex:)` parser. */
+        fun bytesFromHex(hex: String): ByteArray {
+            val lower = hex.lowercase()
+            val out = ByteArray(lower.length / 2)
+            for (i in out.indices) {
+                val high = Character.digit(lower[i * 2], 16)
+                val low = Character.digit(lower[i * 2 + 1], 16)
+                if (high == -1 || low == -1) continue
+                out[i] = ((high shl 4) or low).toByte()
+            }
+            return out
+        }
+    }
+}
+
+/** Stub for the chain-anchor binding metadata that PR-B will
+ *  populate (txHash / ledger / network). Held here so [ChatGroup]
+ *  has a slot to embed it once PR-B lands; PR-A leaves it `null`. */
+@Serializable
+data class AnchorBinding(
+    @SerialName("transaction_hash")
+    val transactionHash: String,
+    val network: String,
+)

--- a/app/src/main/kotlin/chat/onym/android/group/GovernanceMember.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GovernanceMember.kt
@@ -1,0 +1,42 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * One member-leaf entry in a group's roster. The two byte arrays are
+ * derived from the same 32-byte BLS Fr secret:
+ *
+ *  - [publicKeyCompressed] — 48 bytes, arkworks-compressed G1Affine
+ *    (`[sk] · G`). Used for Merkle-tree leaf ordering (lex sort) and
+ *    as the stable on-the-wire identifier of a member across epochs.
+ *  - [leafHash] — 32 bytes, `Poseidon(sk_fr)`. The actual scalar that
+ *    lands in the Poseidon Merkle tree the contract verifies against.
+ *
+ * Both fields encode as base64 strings (matches the iOS Codable
+ * shape; cross-platform invitation payloads round-trip without
+ * platform-specific shims).
+ *
+ * Mirrors `GovernanceMember.swift` from onym-ios PR #24 and
+ * `SEPGroupMemberLeaf` in `swift-mls`.
+ */
+@Serializable
+data class GovernanceMember(
+    @SerialName("public_key_compressed")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val publicKeyCompressed: ByteArray,
+    @SerialName("leaf_hash")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val leafHash: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GovernanceMember) return false
+        return publicKeyCompressed.contentEquals(other.publicKeyCompressed) &&
+            leafHash.contentEquals(other.leafHash)
+    }
+
+    override fun hashCode(): Int =
+        31 * publicKeyCompressed.contentHashCode() + leafHash.contentHashCode()
+}

--- a/app/src/main/kotlin/chat/onym/android/group/GroupCommitmentBuilder.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupCommitmentBuilder.kt
@@ -1,0 +1,89 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepTier
+import chat.onym.sdk.Common
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * Thin wrapper around [chat.onym.sdk.Common] that speaks
+ * [GovernanceMember] rather than raw byte buffers. Mirrors
+ * `SEPCommitmentBuilder` in `swift-mls` (and
+ * `GroupCommitmentBuilder.swift` from onym-ios PR #24) so
+ * cross-platform behaviour (and test vectors) stays aligned.
+ *
+ * All FFI calls are synchronous — the heavy work is hashing, not
+ * proving, so they're fine on the calling thread.
+ */
+object GroupCommitmentBuilder {
+
+    /**
+     * Fresh 32-byte salt for a brand-new group. The circuit
+     * interprets the bytes little-endian-mod-r in-circuit.
+     */
+    fun generateSalt(): ByteArray =
+        ByteArray(32).also { SecureRandom().nextBytes(it) }
+
+    /**
+     * Deterministic salt rotation for member-add events.
+     * `SHA256(previousSalt || memberKey)` — both sides of a
+     * member-join derive the same salt and therefore the same
+     * epoch's encryption key, so observers don't fork.
+     */
+    fun deriveSalt(previousSalt: ByteArray, memberKey: ByteArray): ByteArray {
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(previousSalt)
+        md.update(memberKey)
+        return md.digest()
+    }
+
+    /** 32-byte Poseidon leaf hash for a single member's BLS Fr secret. */
+    fun computeLeafHash(secretKey: ByteArray): ByteArray =
+        Common.leafHash(secretKey)
+
+    /** 48-byte arkworks-compressed G1 BLS public key for a 32-byte
+     *  secret. Used to compute the stable [GovernanceMember.publicKeyCompressed]. */
+    fun computePublicKey(secretKey: ByteArray): ByteArray =
+        Common.publicKey(secretKey)
+
+    /**
+     * Sort [members] lex by [GovernanceMember.publicKeyCompressed],
+     * pack the [GovernanceMember.leafHash] bytes, and ask OnymSDK for
+     * the Poseidon Merkle root at the supplied [tier]'s depth.
+     *
+     * The lex sort matches SEP-XXXX §2.1 — both peers MUST sort
+     * identically before computing roots, otherwise commitments
+     * diverge.
+     */
+    fun computeMerkleRoot(members: List<GovernanceMember>, tier: SepTier): ByteArray {
+        val sorted = members.sortedWith { a, b -> compareLex(a.publicKeyCompressed, b.publicKeyCompressed) }
+        val packed = ByteArray(sorted.size * 32)
+        for ((i, member) in sorted.withIndex()) {
+            require(member.leafHash.size == 32) {
+                "leafHash for member $i has unexpected size ${member.leafHash.size}, expected 32"
+            }
+            System.arraycopy(member.leafHash, 0, packed, i * 32, 32)
+        }
+        return Common.merkleRoot(packed, tier.depth)
+    }
+
+    /**
+     * `Poseidon(Poseidon(root, Fr(epoch)), salt_fr)`. The plonk-era
+     * commitment shape used by every sep-* contract.
+     */
+    fun computePoseidonCommitment(
+        poseidonRoot: ByteArray,
+        epoch: ULong,
+        salt: ByteArray,
+    ): ByteArray = Common.poseidonCommitment(poseidonRoot, epoch.toLong(), salt)
+
+    /** Lex byte comparison, returning negative / zero / positive. */
+    private fun compareLex(a: ByteArray, b: ByteArray): Int {
+        val len = minOf(a.size, b.size)
+        for (i in 0 until len) {
+            val cmp = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+            if (cmp != 0) return cmp
+        }
+        return a.size - b.size
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -19,6 +19,7 @@ import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
 import org.bouncycastle.crypto.params.X25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
 import java.security.MessageDigest
+import java.security.SecureRandom
 import javax.crypto.AEADBadTagException
 import javax.crypto.Cipher
 import javax.crypto.IllegalBlockSizeException
@@ -61,7 +62,7 @@ import javax.crypto.spec.SecretKeySpec
 class IdentityRepository(
     private val store: IdentitySecretStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : InvitationEnvelopeDecrypter {
+) : InvitationEnvelopeDecrypter, InvitationEnvelopeSealer {
     private val mutex = Mutex()
     private val _snapshots = MutableStateFlow<Identity?>(null)
 
@@ -220,6 +221,117 @@ class IdentityRepository(
         }
     }
 
+    // ─── InvitationEnvelopeSealer ───────────────────────────────────
+
+    /**
+     * Sender-side mirror of [decryptInvitation]. Generates a fresh
+     * per-envelope X25519 keypair, derives the AES-GCM key from the
+     * ECDH shared secret with [recipientInboxPublicKey], encrypts the
+     * payload, signs the ephemeral pubkey with this device's Ed25519
+     * identity key (M-5), and returns the JSON-serialised
+     * [SealedEnvelope]. Secret material never escapes this method —
+     * only the resulting bytes do.
+     *
+     * The Ed25519 signing key is recomputed from the persisted nostr
+     * secret on every call and never assigned to a stored property,
+     * matching [decryptInvitation]'s posture for the recipient X25519
+     * private key.
+     *
+     * Mirrors `IdentityRepository.sealInvitation` from onym-ios PR #24.
+     */
+    override suspend fun sealInvitation(
+        payload: ByteArray,
+        recipientInboxPublicKey: ByteArray,
+    ): ByteArray = withContext(ioDispatcher) {
+        if (recipientInboxPublicKey.size != 32) {
+            throw InvitationSealError.InvalidRecipientPublicKey(
+                "expected 32 bytes, got ${recipientInboxPublicKey.size}"
+            )
+        }
+        val recipientPub = try {
+            X25519PublicKeyParameters(recipientInboxPublicKey, 0)
+        } catch (e: IllegalArgumentException) {
+            throw InvitationSealError.InvalidRecipientPublicKey(e.message ?: "parse failed")
+        }
+        val snapshot = store.load() ?: throw InvitationSealError.IdentityNotLoaded
+        sealInvitationLocked(snapshot, payload, recipientPub)
+    }
+
+    private fun sealInvitationLocked(
+        snapshot: StoredSnapshot,
+        payload: ByteArray,
+        recipientPub: X25519PublicKeyParameters,
+    ): ByteArray {
+        // Fresh per-envelope X25519 keypair. SecureRandom seed is the
+        // OS RNG; bouncycastle generates a clamped private scalar
+        // internally.
+        val ephemeralPrivate = X25519PrivateKeyParameters(SecureRandom())
+        val ephemeralPub = ephemeralPrivate.generatePublicKey().encoded
+
+        // ECDH against the recipient's X25519 inbox pubkey.
+        val agreement = X25519Agreement().apply { init(ephemeralPrivate) }
+        val sharedSecret = ByteArray(agreement.agreementSize)
+        agreement.calculateAgreement(recipientPub, sharedSecret, 0)
+
+        // HKDF salt + info MUST match decryptInvitation exactly —
+        // interop with iOS senders/receivers + stellar-mls senders
+        // rides on these constants.
+        val aesKey = Bip39.hkdfSha256(
+            ikm = sharedSecret,
+            salt = "sep-invitation-v1".toByteArray(Charsets.UTF_8),
+            info = "aes-256-gcm".toByteArray(Charsets.UTF_8),
+            length = 32,
+        )
+
+        // Random 12-byte AES-GCM nonce. Each call mints a fresh one;
+        // a duplicate would break GCM security against the same key.
+        val nonce = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val (ciphertext, authTag) = try {
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+                init(Cipher.ENCRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, nonce))
+            }
+            val combined = cipher.doFinal(payload)
+            // GCM emits ciphertext || tag as one buffer; split for the
+            // wire shape, which keeps them in separate base64 fields.
+            val tagLen = 16
+            combined.copyOfRange(0, combined.size - tagLen) to
+                combined.copyOfRange(combined.size - tagLen, combined.size)
+        } catch (e: Exception) {
+            throw InvitationSealError.EncryptionFailed(e)
+        }
+
+        // M-5: sign the ephemeral pubkey with the sender's long-term
+        // Ed25519 identity key. Recipient verifies in
+        // decryptInvitation against `senderEd25519PublicKey`.
+        val signingKey = stellarSigningPrivateKey(snapshot.nostrSecretKey)
+        val senderPubkey = signingKey.generatePublicKey().encoded
+        val ephSignature = try {
+            Ed25519Signer().apply {
+                init(true, signingKey)
+                update(ephemeralPub, 0, ephemeralPub.size)
+            }.generateSignature()
+        } catch (e: Exception) {
+            throw InvitationSealError.SigningFailed(e)
+        }
+
+        val envelope = SealedEnvelope(
+            version = 1,
+            scheme = "x25519-aes-256-gcm-v1",
+            ephemeralPublicKey = ephemeralPub,
+            ephemeralKeySignature = ephSignature,
+            senderEd25519PublicKey = senderPubkey,
+            nonce = nonce,
+            ciphertext = ciphertext,
+            authenticationTag = authTag,
+        )
+        return try {
+            envelopeJsonFormat.encodeToString(SealedEnvelope.serializer(), envelope)
+                .toByteArray(Charsets.UTF_8)
+        } catch (e: SerializationException) {
+            throw InvitationSealError.EncodingFailed(e)
+        }
+    }
+
     // ─── Private ─────────────────────────────────────────────────────
 
     private fun generateNewLocked(): Identity {
@@ -291,15 +403,25 @@ class IdentityRepository(
          * preserve for cross-platform interop. Do not change without
          * coordinating with iOS + stellar-mls.
          */
-        internal fun stellarPublicKey(nostrSecret: ByteArray): ByteArray {
+        internal fun stellarPublicKey(nostrSecret: ByteArray): ByteArray =
+            stellarSigningPrivateKey(nostrSecret).generatePublicKey().encoded
+
+        /**
+         * Sibling of [stellarPublicKey] that returns the Ed25519
+         * *private* key. Used by [sealInvitation] for the M-5
+         * attestation signature on per-envelope ephemeral pubkeys.
+         * Internal because it returns secret material; production
+         * callers MUST discard the returned object after a single use,
+         * never assign to a stored property.
+         */
+        internal fun stellarSigningPrivateKey(nostrSecret: ByteArray): Ed25519PrivateKeyParameters {
             val seed = Bip39.hkdfSha256(
                 ikm = nostrSecret,
                 salt = "chat.onym.ios".toByteArray(Charsets.UTF_8),
                 info = "stellar-ed25519-v1".toByteArray(Charsets.UTF_8),
                 length = 32,
             )
-            val sk = Ed25519PrivateKeyParameters(seed, 0)
-            return sk.generatePublicKey().encoded
+            return Ed25519PrivateKeyParameters(seed, 0)
         }
 
         /**

--- a/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeSealer.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeSealer.kt
@@ -1,0 +1,62 @@
+package chat.onym.android.identity
+
+/**
+ * Sender-side mirror of [InvitationEnvelopeDecrypter]. The chain
+ * interactor that creates a group depends on this seam to wrap each
+ * invitee's bootstrap payload in an X25519+AES-GCM-sealed envelope —
+ * without ever holding the device's long-term identity keys directly.
+ *
+ * Only the producer of this interface (i.e. [IdentityRepository])
+ * holds the Ed25519 signing key used to attest the per-envelope
+ * ephemeral X25519 pubkey (M-5). The interactor only sees the
+ * resulting bytes ready to drop on `InboxTransport.send(...)`.
+ *
+ * Mirrors `InvitationEnvelopeSealing.swift` from onym-ios PR #24.
+ */
+interface InvitationEnvelopeSealer {
+    /**
+     * Seal [payload] for a single recipient. Generates a fresh
+     * per-envelope X25519 keypair, derives the AES-GCM key via
+     * HKDF-SHA256 over the ECDH shared secret with
+     * [recipientInboxPublicKey] (32-byte raw X25519 pubkey), encrypts
+     * the payload with a random 12-byte nonce, signs the ephemeral
+     * pubkey with the sender's Ed25519 identity key (M-5), and
+     * returns the JSON-encoded [SealedEnvelope] bytes.
+     *
+     * Throws [InvitationSealError]; never raw `javax.crypto` /
+     * `kotlinx.serialization` exceptions, so callers can classify
+     * with a `when (e: InvitationSealError)`.
+     */
+    suspend fun sealInvitation(payload: ByteArray, recipientInboxPublicKey: ByteArray): ByteArray
+}
+
+/**
+ * Failure modes for [InvitationEnvelopeSealer.sealInvitation].
+ * Sealed so `when` exhaustiveness checks downstream don't need an
+ * `else` branch.
+ */
+sealed class InvitationSealError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    /** [IdentityRepository.bootstrap] hasn't been called or [wipe]
+     *  was called — there's no sender secret to derive the M-5
+     *  signing key from. */
+    object IdentityNotLoaded : InvitationSealError("identity not loaded; call bootstrap() first") {
+        private fun readResolve(): Any = IdentityNotLoaded
+    }
+
+    /** Recipient's public key wasn't a 32-byte X25519 raw pubkey. */
+    class InvalidRecipientPublicKey(reason: String) :
+        InvitationSealError("invalid recipient X25519 public key: $reason")
+
+    /** Ed25519 sign over the ephemeral pubkey failed. */
+    class SigningFailed(cause: Throwable) :
+        InvitationSealError("ephemeral key signing failed", cause)
+
+    /** AES-GCM seal failed (key derivation or cipher init). */
+    class EncryptionFailed(cause: Throwable) :
+        InvitationSealError("AES-GCM seal failed", cause)
+
+    /** Encoding the resulting [SealedEnvelope] to JSON failed. */
+    class EncodingFailed(cause: Throwable) :
+        InvitationSealError("envelope JSON encode failed", cause)
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeSepContractTransport.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeSepContractTransport.kt
@@ -1,0 +1,50 @@
+package chat.onym.android.support
+
+import chat.onym.android.chain.SepContractInvocation
+import chat.onym.android.chain.SepContractTransport
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Reusable test fake for [SepContractTransport]. Mirrors the
+ * `RecordingTransport` private fixture at the bottom of
+ * `SEPContractClientTests.swift` (onym-ios PR #24), promoted to a
+ * package-public fake here so PR-C's `CreateGroupInteractor` tests
+ * can reuse it without duplicating the encode/decode dance.
+ *
+ * Records the last invocation as a [JsonObject] so wire-shape
+ * assertions (snake_case key checks, base64 payload presence) read
+ * naturally.
+ */
+class FakeSepContractTransport(
+    private val cannedResponseJson: String,
+) : SepContractTransport {
+
+    private val jsonFormat = Json { encodeDefaults = true }
+
+    /** Last invocation's top-level JSON (`contract_id`, `function`,
+     *  `payload`). `null` if `invoke` was never called. */
+    @Volatile
+    var lastInvocationJson: JsonObject? = null
+        private set
+
+    /** Last invocation's `function` value. */
+    val lastFunction: String?
+        get() = (lastInvocationJson?.get("function") as? kotlinx.serialization.json.JsonPrimitive)?.content
+
+    /** Last invocation's `payload` field as a JsonObject (most
+     *  payloads are objects; pin tests grab keys off this). */
+    val lastPayloadJson: JsonObject?
+        get() = lastInvocationJson?.get("payload") as? JsonObject
+
+    override suspend fun <P, R> invoke(
+        invocation: SepContractInvocation<P>,
+        invocationSerializer: KSerializer<SepContractInvocation<P>>,
+        responseSerializer: KSerializer<R>,
+    ): R {
+        val encoded = jsonFormat.encodeToString(invocationSerializer, invocation)
+        lastInvocationJson = jsonFormat.parseToJsonElement(encoded) as JsonObject
+        return jsonFormat.decodeFromString(responseSerializer, cannedResponseJson)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
@@ -1,0 +1,297 @@
+package chat.onym.android.chain
+
+import chat.onym.android.support.FakeOkHttpClient
+import chat.onym.android.support.FakeSepContractTransport
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-Kotlin unit tests for [SepContractClient]. Two layers:
+ *
+ *  1. **Wire-shape pins** via [FakeSepContractTransport] — the fake
+ *     captures the encoded invocation JSON so we can assert the
+ *     snake_case top-level keys (`contract_id`, `function`, `payload`)
+ *     and per-function payload contents.
+ *  2. **OkHttp transport behaviour** via [FakeOkHttpClient] — actual
+ *     [OkHttpSepContractTransport] driven against a canned interceptor
+ *     response, so we cover happy 2xx, 4xx with body, 5xx, and
+ *     malformed body. No `MockWebServer`.
+ *
+ * Mirrors `SEPContractClientTests.swift` from onym-ios PR #24.
+ */
+class SepContractClientTest {
+
+    private val testContractId = "C00000000000000000000000000000000000000000000000000000"
+
+    // ─── wire-shape pins (fake transport) ──────────────────────────
+
+    @Test
+    fun createGroupV2_sendsSnakeCasePayload_andCorrectFunction() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """{"accepted":true,"transactionHash":"abc123"}""",
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        val request = SepCreateGroupV2Request(
+            caller = "GBABCDEF",
+            groupId = ByteArray(32) { 0xAB.toByte() },
+            commitment = ByteArray(32) { 0xCD.toByte() },
+            tier = SepTier.SMALL.rawValue.toUInt(),
+            groupType = SepGroupType.TYRANNY,
+            memberCount = 1u,
+            proof = ByteArray(64) { 0xEE.toByte() },
+            publicInputs = SepPublicInputs(
+                commitment = ByteArray(32) { 0xCD.toByte() },
+                epoch = 0uL,
+            ),
+        )
+        val response = client.createGroupV2(request)
+        assertTrue(response.accepted)
+        assertEquals("abc123", response.transactionHash)
+
+        val invocation = transport.lastInvocationJson
+        assertNotNull(invocation)
+        assertEquals(testContractId, invocation!!["contract_id"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("create_group_v2", transport.lastFunction)
+
+        val payload = transport.lastPayloadJson
+        assertNotNull(payload)
+        assertEquals("GBABCDEF", payload!!["caller"]!!.jsonPrimitive.contentOrNull)
+        assertEquals(SepGroupType.TYRANNY.rawValue.toInt(), payload["group_type"]!!.jsonPrimitive.int)
+        assertEquals(1, payload["member_count"]!!.jsonPrimitive.int)
+        assertNotNull("group_id required", payload["group_id"])
+        assertNotNull("public_inputs required", payload["public_inputs"])
+    }
+
+    @Test
+    fun updateCommitment_routesToUpdateFunction_withSnakeCasePublicInputs() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """{"accepted":true}""",
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        val request = SepUpdateCommitmentRequest(
+            groupId = ByteArray(32) { 0x01 },
+            proof = ByteArray(32) { 0x02 },
+            publicInputs = SepUpdatePublicInputs(
+                cOld = ByteArray(32) { 0x03 },
+                epochOld = 1uL,
+                cNew = ByteArray(32) { 0x04 },
+            ),
+        )
+        client.updateCommitment(request)
+
+        assertEquals("update_commitment", transport.lastFunction)
+        val payload = transport.lastPayloadJson!!
+        val publicInputs = payload["public_inputs"] as kotlinx.serialization.json.JsonObject
+        assertNotNull(publicInputs["c_old"])
+        assertNotNull(publicInputs["c_new"])
+        assertEquals(1L, publicInputs["epoch_old"]!!.jsonPrimitive.long)
+    }
+
+    @Test
+    fun getState_sendsGroupIdInGetStateEnvelope() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """
+                {"commitment":"CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk=",
+                 "epoch":7,"timestamp":1700000000,"tier":0,"active":true}
+            """.trimIndent(),
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        val result = client.getState(groupId = ByteArray(32) { 0x55 })
+        assertEquals(7uL, result.epoch)
+        assertEquals(1_700_000_000uL, result.timestamp)
+        assertEquals(0u, result.tier)
+        assertTrue(result.active)
+        assertArrayEquals(ByteArray(32) { 0x09 }, result.commitment)
+
+        assertEquals("get_state", transport.lastFunction)
+        assertNotNull(transport.lastPayloadJson!!["group_id"])
+    }
+
+    // ─── OkHttp transport behaviour ────────────────────────────────
+
+    @Test
+    fun okHttpTransport_returnsDecodedResponseOn2xx() = runTest {
+        val canned = """{"accepted":true,"transactionHash":"deadbeef","message":"ok"}"""
+        val httpClient = FakeOkHttpClient.build { req ->
+            assertEquals("POST", req.method)
+            // OkHttp may append `; charset=utf-8`; just check the prefix.
+            assertTrue(req.body?.contentType().toString().startsWith("application/json"))
+            FakeOkHttpClient.ok(req, canned)
+        }
+        val transport = OkHttpSepContractTransport(
+            httpClient = httpClient,
+            endpointUrl = "https://relayer.example/contract",
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        val response = client.createGroupV2(
+            SepCreateGroupV2Request(
+                caller = "GBABCDEF",
+                groupId = ByteArray(32),
+                commitment = ByteArray(32),
+                tier = 0u,
+                groupType = SepGroupType.TYRANNY,
+                memberCount = 1u,
+                proof = ByteArray(0),
+                publicInputs = SepPublicInputs(commitment = ByteArray(32), epoch = 0uL),
+            )
+        )
+        assertEquals("deadbeef", response.transactionHash)
+        assertEquals("ok", response.message)
+        assertTrue(response.accepted)
+    }
+
+    @Test
+    fun okHttpTransport_throwsBadStatus_andCapturesBody() = runTest {
+        val httpClient = FakeOkHttpClient.build { req ->
+            Response.Builder()
+                .request(req)
+                .protocol(Protocol.HTTP_1_1)
+                .code(500)
+                .message("Internal Server Error")
+                .body("boom".toResponseBody("text/plain".toMediaType()))
+                .build()
+        }
+        val transport = OkHttpSepContractTransport(
+            httpClient = httpClient,
+            endpointUrl = "https://relayer.example/contract",
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        val thrown = assertThrows(SepContractError.BadStatus::class.java) {
+            kotlinx.coroutines.runBlocking {
+                client.getState(ByteArray(32))
+            }
+        }
+        assertEquals(500, thrown.code)
+        // Body is captured BEFORE the status check so the error path
+        // can include it (gotcha #3 in the brief — `bytes()` is single-shot).
+        assertEquals("boom", thrown.body)
+    }
+
+    @Test
+    fun okHttpTransport_throwsBadStatusOn4xx() = runTest {
+        val httpClient = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.status(req, 422, "Unprocessable Entity")
+        }
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(testContractId, transport)
+
+        val thrown = assertThrows(SepContractError.BadStatus::class.java) {
+            kotlinx.coroutines.runBlocking { client.getState(ByteArray(32)) }
+        }
+        assertEquals(422, thrown.code)
+    }
+
+    @Test
+    fun okHttpTransport_throwsMalformedResponse_onJunkBody() = runTest {
+        val httpClient = FakeOkHttpClient.build { req ->
+            FakeOkHttpClient.ok(req, "not really json {{{")
+        }
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(testContractId, transport)
+
+        assertThrows(SepContractError.MalformedResponse::class.java) {
+            kotlinx.coroutines.runBlocking {
+                client.createGroupV2(
+                    SepCreateGroupV2Request(
+                        caller = "G",
+                        groupId = ByteArray(32),
+                        commitment = ByteArray(32),
+                        tier = 0u,
+                        groupType = SepGroupType.TYRANNY,
+                        memberCount = 0u,
+                        proof = ByteArray(0),
+                        publicInputs = SepPublicInputs(ByteArray(32), 0uL),
+                    )
+                )
+            }
+        }
+        Unit
+    }
+
+    @Test
+    fun okHttpTransport_targetsConfiguredEndpointUrl() = runTest {
+        var capturedUrl: String? = null
+        val httpClient = FakeOkHttpClient.build { req ->
+            capturedUrl = req.url.toString()
+            FakeOkHttpClient.ok(req, """{"accepted":true}""")
+        }
+        val transport = OkHttpSepContractTransport(
+            httpClient = httpClient,
+            endpointUrl = "https://example.invalid/some/path",
+        )
+        val client = SepContractClient(testContractId, transport)
+
+        client.updateCommitment(
+            SepUpdateCommitmentRequest(
+                groupId = ByteArray(32),
+                proof = ByteArray(32),
+                publicInputs = SepUpdatePublicInputs(ByteArray(32), 0uL, ByteArray(32)),
+            )
+        )
+        assertEquals("https://example.invalid/some/path", capturedUrl)
+    }
+
+    @Test
+    fun okHttpTransport_postsBodyAsContractInvocationEnvelope() = runTest {
+        var capturedBodyJson: String? = null
+        val httpClient = FakeOkHttpClient.build { req ->
+            capturedBodyJson = req.body!!.let { body ->
+                val buffer = okio.Buffer()
+                body.writeTo(buffer)
+                buffer.readUtf8()
+            }
+            FakeOkHttpClient.ok(req, """{"accepted":true}""")
+        }
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(testContractId, transport)
+
+        // Use updateCommitment so the canned `{"accepted":true}`
+        // decodes as the expected SepSubmissionResponse — getState
+        // would expect a SepCommitmentEntry shape we don't care about
+        // for this body-shape pin.
+        client.updateCommitment(
+            SepUpdateCommitmentRequest(
+                groupId = ByteArray(32) { 0x55 },
+                proof = ByteArray(8),
+                publicInputs = SepUpdatePublicInputs(ByteArray(32), 0uL, ByteArray(32)),
+            )
+        )
+
+        val obj = Json.parseToJsonElement(capturedBodyJson!!) as kotlinx.serialization.json.JsonObject
+        assertEquals(testContractId, obj["contract_id"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("update_commitment", obj["function"]!!.jsonPrimitive.contentOrNull)
+        assertNotNull(obj["payload"])
+    }
+
+    // ─── error sentinel sanity ─────────────────────────────────────
+
+    @Test
+    fun badStatus_messageContainsCodeAndBody() {
+        val err = SepContractError.BadStatus(503, "service unavailable")
+        assertTrue(err.message!!.contains("503"))
+        assertTrue(err.message!!.contains("service unavailable"))
+        // Identity check — sealed hierarchy is the public surface.
+        assertSame(err, err)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
@@ -1,0 +1,237 @@
+package chat.onym.android.chain
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Wire-format pin for the chain JSON payloads. Each request/response
+ * struct round-trips losslessly AND emits the snake_case keys the
+ * iOS twin (`SEPContractTypes.swift`) writes — both are load-bearing
+ * for cross-platform interop with the relayer.
+ *
+ * Mirrors the Codable round-trip + JSON-shape assertions inlined
+ * across `SEPContractClientTests.swift` from onym-ios PR #24.
+ */
+class SepContractTypesTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    // ─── enum ─────────────────────────────────────────────────────
+
+    @Test
+    fun sepGroupType_serializesAsRawUInt32() {
+        val tyrannyJson = json.encodeToString(SepGroupType.serializer(), SepGroupType.TYRANNY)
+        assertEquals("4", tyrannyJson)
+        val anarchyJson = json.encodeToString(SepGroupType.serializer(), SepGroupType.ANARCHY)
+        assertEquals("0", anarchyJson)
+    }
+
+    @Test
+    fun sepGroupType_decodesFromRawInt() {
+        assertEquals(SepGroupType.TYRANNY, json.decodeFromString(SepGroupType.serializer(), "4"))
+        assertEquals(SepGroupType.OLIGARCHY, json.decodeFromString(SepGroupType.serializer(), "3"))
+    }
+
+    // ─── public-input bundles ─────────────────────────────────────
+
+    @Test
+    fun sepPublicInputs_roundtripPreservesFields() {
+        val original = SepPublicInputs(
+            commitment = ByteArray(32) { 0xAB.toByte() },
+            epoch = 7uL,
+        )
+        val encoded = json.encodeToString(SepPublicInputs.serializer(), original)
+        val decoded = json.decodeFromString(SepPublicInputs.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun sepUpdatePublicInputs_emitsSnakeCaseKeys() {
+        val payload = SepUpdatePublicInputs(
+            cOld = ByteArray(32) { 0x01 },
+            epochOld = 1uL,
+            cNew = ByteArray(32) { 0x02 },
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(SepUpdatePublicInputs.serializer(), payload)
+        ).jsonObject
+        assertNotNull("c_old key required", obj["c_old"])
+        assertNotNull("c_new key required", obj["c_new"])
+        assertEquals(1L, obj["epoch_old"]!!.jsonPrimitive.long)
+        assertNull("plain `cOld` must NOT appear", obj["cOld"])
+        assertNull("plain `cNew` must NOT appear", obj["cNew"])
+    }
+
+    // ─── create_group_v2 payload ──────────────────────────────────
+
+    @Test
+    fun createGroupV2Request_roundtripPreservesAllFields() {
+        val original = SepCreateGroupV2Request(
+            caller = "GBABCDEF",
+            groupId = ByteArray(32) { 0xAB.toByte() },
+            commitment = ByteArray(32) { 0xCD.toByte() },
+            tier = 0u,
+            groupType = SepGroupType.TYRANNY,
+            memberCount = 1u,
+            proof = ByteArray(64) { 0xEE.toByte() },
+            publicInputs = SepPublicInputs(
+                commitment = ByteArray(32) { 0xCD.toByte() },
+                epoch = 0uL,
+            ),
+        )
+        val encoded = json.encodeToString(SepCreateGroupV2Request.serializer(), original)
+        val decoded = json.decodeFromString(SepCreateGroupV2Request.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun createGroupV2Request_emitsSnakeCaseKeys() {
+        val request = SepCreateGroupV2Request(
+            caller = "GBABCDEF",
+            groupId = ByteArray(32) { 0xAB.toByte() },
+            commitment = ByteArray(32) { 0xCD.toByte() },
+            tier = 0u,
+            groupType = SepGroupType.TYRANNY,
+            memberCount = 3u,
+            proof = ByteArray(8) { 0xEE.toByte() },
+            publicInputs = SepPublicInputs(
+                commitment = ByteArray(32) { 0xCD.toByte() },
+                epoch = 0uL,
+            ),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(SepCreateGroupV2Request.serializer(), request)
+        ).jsonObject
+
+        // Snake-case key checks — iOS emits these via explicit
+        // CodingKeys. Drift here breaks the relayer.
+        assertNotNull("group_id required", obj["group_id"])
+        assertEquals(0, obj["tier"]!!.jsonPrimitive.int)
+        assertEquals(4, obj["group_type"]!!.jsonPrimitive.int)
+        assertEquals(3, obj["member_count"]!!.jsonPrimitive.int)
+        assertNotNull("public_inputs required", obj["public_inputs"])
+        assertNull("plain `groupId` must NOT appear", obj["groupId"])
+        assertNull("plain `groupType` must NOT appear", obj["groupType"])
+        assertNull("plain `memberCount` must NOT appear", obj["memberCount"])
+
+        // ByteArray fields encode as base64 strings — pin one to lock
+        // the wire shape against accidental "JSON int array" drift.
+        val groupIdEncoded = obj["group_id"]!!.jsonPrimitive.contentOrNull
+        assertNotNull(groupIdEncoded)
+        assertTrue(
+            "group_id must round-trip as base64 of the original bytes",
+            Base64.getDecoder().decode(groupIdEncoded!!).contentEquals(request.groupId),
+        )
+    }
+
+    // ─── update_commitment payload ────────────────────────────────
+
+    @Test
+    fun updateCommitmentRequest_roundtripPreservesAllFields() {
+        val original = SepUpdateCommitmentRequest(
+            groupId = ByteArray(32) { 0x01 },
+            proof = ByteArray(32) { 0x02 },
+            publicInputs = SepUpdatePublicInputs(
+                cOld = ByteArray(32) { 0x03 },
+                epochOld = 1uL,
+                cNew = ByteArray(32) { 0x04 },
+            ),
+        )
+        val encoded = json.encodeToString(SepUpdateCommitmentRequest.serializer(), original)
+        val decoded = json.decodeFromString(SepUpdateCommitmentRequest.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    // ─── get_state ────────────────────────────────────────────────
+
+    @Test
+    fun getStateRequest_emitsGroupIdSnakeCase() {
+        val obj = json.parseToJsonElement(
+            json.encodeToString(
+                SepGetStateRequest.serializer(),
+                SepGetStateRequest(groupId = ByteArray(32) { 0x55 }),
+            )
+        ).jsonObject
+        assertNotNull("group_id required", obj["group_id"])
+        assertNull(obj["groupId"])
+    }
+
+    @Test
+    fun commitmentEntry_roundtripPreservesAllFields() {
+        val original = SepCommitmentEntry(
+            commitment = ByteArray(32) { 0x09 },
+            epoch = 7uL,
+            timestamp = 1_700_000_000uL,
+            tier = 0u,
+            active = true,
+        )
+        val encoded = json.encodeToString(SepCommitmentEntry.serializer(), original)
+        val decoded = json.decodeFromString(SepCommitmentEntry.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    // ─── submission response ──────────────────────────────────────
+
+    @Test
+    fun submissionResponse_keepsCamelCaseTransactionHashKey() {
+        // **Load-bearing quirk**: iOS doesn't override the CodingKey
+        // for `transactionHash`, so the JSON key stays camelCase
+        // (NOT `transaction_hash`). Pin the Android side to the same
+        // shape — relayer parsing depends on it.
+        val payload = SepSubmissionResponse(
+            accepted = true,
+            transactionHash = "abc123",
+            message = "ok",
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(SepSubmissionResponse.serializer(), payload)
+        ).jsonObject
+        assertEquals("abc123", obj["transactionHash"]!!.jsonPrimitive.contentOrNull)
+        assertNull("snake-case `transaction_hash` must NOT appear", obj["transaction_hash"])
+    }
+
+    @Test
+    fun submissionResponse_decodesNullableFields() {
+        val raw = """{"accepted":true}"""
+        val decoded = json.decodeFromString(SepSubmissionResponse.serializer(), raw)
+        assertTrue(decoded.accepted)
+        assertNull(decoded.transactionHash)
+        assertNull(decoded.message)
+    }
+
+    // ─── invocation envelope ──────────────────────────────────────
+
+    @Test
+    fun invocationEnvelope_topLevelKeysAreContractIdFunctionPayload() {
+        val invocation = SepContractInvocation(
+            contractId = "C12345",
+            function = "create_group_v2",
+            payload = JsonPrimitive("payload-stub"),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(SepContractInvocation.serializer(JsonPrimitive.serializer()), invocation)
+        ).jsonObject
+        assertEquals("C12345", obj["contract_id"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("create_group_v2", obj["function"]!!.jsonPrimitive.contentOrNull)
+        assertNotNull(obj["payload"])
+        assertNull("plain `contractId` must NOT appear", obj["contractId"])
+    }
+
+    // ─── helper assertion ────────────────────────────────────────
+
+    @Suppress("unused")
+    private fun JsonObject.boolField(key: String): Boolean = this[key]!!.jsonPrimitive.boolean
+}

--- a/app/src/test/kotlin/chat/onym/android/group/ChatGroupTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ChatGroupTest.kt
@@ -1,0 +1,112 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-Kotlin tests for the [ChatGroup] value type — no SDK FFI, no
+ * Room. Mirrors `ChatGroupTests.swift` from onym-ios PR #24 plus a
+ * Codable round-trip pin (the iOS twin doesn't bother because Swift's
+ * derived Codable is well-trodden; on Android the explicit
+ * `Base64ByteArraySerializer` annotations are easy to break, so we
+ * pin them).
+ */
+class ChatGroupTest {
+
+    private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+    @Test
+    fun groupIdBytes_roundtripsThroughLowercaseHex() {
+        val raw = ByteArray(32) { 0xAB.toByte() }
+        val hex = raw.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        val group = makeGroup(id = hex)
+        assertArrayEquals(raw, group.groupIdBytes)
+        assertEquals(32, group.groupIdBytes.size)
+    }
+
+    @Test
+    fun groupIdBytes_handlesShortHex() {
+        val group = makeGroup(id = "abcd")
+        assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xCD.toByte()), group.groupIdBytes)
+    }
+
+    @Test
+    fun groupIdBytes_isLowercaseInsensitive() {
+        val group = makeGroup(id = "AbCd")
+        assertArrayEquals(byteArrayOf(0xAB.toByte(), 0xCD.toByte()), group.groupIdBytes)
+    }
+
+    @Test
+    fun roundtrip_preservesAllFields() {
+        val original = ChatGroup(
+            id = "ab".repeat(32),
+            name = "test",
+            groupSecret = ByteArray(32) { 0x11 },
+            createdAtMillis = 1_700_000_000_000L,
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x22 },
+            commitment = ByteArray(32) { 0x33 },
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = "cd".repeat(48),
+            isPublishedOnChain = true,
+        )
+        val encoded = json.encodeToString(ChatGroup.serializer(), original)
+        val decoded = json.decodeFromString(ChatGroup.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun roundtrip_nullableCommitmentDecodes() {
+        val cold = ChatGroup(
+            id = "00".repeat(32),
+            name = "cold",
+            groupSecret = ByteArray(32),
+            createdAtMillis = 0L,
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = null,
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.ANARCHY,
+            adminPubkeyHex = null,
+            isPublishedOnChain = false,
+        )
+        val encoded = json.encodeToString(ChatGroup.serializer(), cold)
+        val decoded = json.decodeFromString(ChatGroup.serializer(), encoded)
+        assertNull(decoded.commitment)
+        assertNull(decoded.adminPubkeyHex)
+        assertEquals(cold, decoded)
+    }
+
+    @Test
+    fun anchorBinding_codableRoundtrips() {
+        val original = AnchorBinding(transactionHash = "deadbeef", network = "testnet")
+        val encoded = json.encodeToString(AnchorBinding.serializer(), original)
+        val decoded = json.decodeFromString(AnchorBinding.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertNotNull(encoded)
+    }
+
+    private fun makeGroup(id: String): ChatGroup = ChatGroup(
+        id = id,
+        name = "test",
+        groupSecret = ByteArray(32),
+        createdAtMillis = 0L,
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32),
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = null,
+        isPublishedOnChain = false,
+    )
+}

--- a/app/src/test/kotlin/chat/onym/android/group/GroupCommitmentBuilderTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/GroupCommitmentBuilderTest.kt
@@ -1,0 +1,59 @@
+package chat.onym.android.group
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.security.MessageDigest
+
+/**
+ * Pure-Kotlin tests for [GroupCommitmentBuilder]. Only the helpers
+ * that don't hit the OnymSDK FFI (`generateSalt`, `deriveSalt`) live
+ * here — the FFI-backed `computeLeafHash` / `computePublicKey` /
+ * `computeMerkleRoot` / `computePoseidonCommitment` need the JNI .so
+ * to be loaded, which only the `androidTest` source-set provides.
+ * Their coverage lives in `app/src/androidTest/.../group/GroupCommitmentBuilderFfiTest.kt`.
+ *
+ * Mirrors the `generateSalt` + `deriveSalt` portion of
+ * `GroupCommitmentBuilderTests.swift` from onym-ios PR #24.
+ */
+class GroupCommitmentBuilderTest {
+
+    @Test
+    fun generateSalt_returns32RandomBytes() {
+        val a = GroupCommitmentBuilder.generateSalt()
+        val b = GroupCommitmentBuilder.generateSalt()
+        assertEquals(32, a.size)
+        assertEquals(32, b.size)
+        assertFalse(
+            "two consecutive calls must produce different salts",
+            a.contentEquals(b),
+        )
+    }
+
+    @Test
+    fun deriveSalt_isDeterministic_andMatchesSha256() {
+        val prev = ByteArray(32) { 0xAA.toByte() }
+        val memberKey = ByteArray(48) { 0xBB.toByte() }
+
+        val first = GroupCommitmentBuilder.deriveSalt(prev, memberKey)
+        val second = GroupCommitmentBuilder.deriveSalt(prev, memberKey)
+        assertArrayEquals("deterministic for the same inputs", first, second)
+
+        val md = MessageDigest.getInstance("SHA-256")
+        md.update(prev)
+        md.update(memberKey)
+        assertArrayEquals(md.digest(), first)
+    }
+
+    @Test
+    fun deriveSalt_differentMemberKeysDiverge() {
+        val prev = ByteArray(32) { 0xAA.toByte() }
+        val m1 = ByteArray(48) { 0x01 }
+        val m2 = ByteArray(48) { 0x02 }
+        assertFalse(
+            GroupCommitmentBuilder.deriveSalt(prev, m1)
+                .contentEquals(GroupCommitmentBuilder.deriveSalt(prev, m2))
+        )
+    }
+}


### PR DESCRIPTION
## Summary

PR-A of the 4-PR Create Group slice. Pure foundation port — no UI wires these in yet. Mirrors onymchat/onym-ios#24 byte-for-byte on the wire format and method surface.

The 4 PRs (matches iOS):
- **PR-A (this one)**: foundation port — sealer interface, contract client, ChatGroup/GovernanceMember/GroupCommitmentBuilder.
- PR-B: Tyranny proof generator (`Tyranny.proveCreate`) + group repository (Room + StorageEncryption).
- PR-C: Create Group UI + invitation send (paste-only invitee picker).
- PR-D: real-testnet E2E test gated on `ONYM_INTEGRATION=1`.

## What lands

| Layer | File | What it does |
|---|---|---|
| Identity | `InvitationEnvelopeSealer.kt` | Sender-side mirror of `InvitationEnvelopeDecrypter`. |
| Identity | `IdentityRepository.kt` | `+sealInvitation`: fresh per-envelope X25519, AES-GCM-256 seal, M-5 Ed25519 attestation. Secrets stay inside the repository class — only the resulting bytes leave. |
| Chain | `SepContractTypes.kt` | `@Serializable` payloads with snake_case `@SerialName` keys (`group_id`, `group_type`, `member_count`, `public_inputs`, `c_old`, `c_new`, `epoch_old`). `SepGroupType` UInt32 enum with `TYRANNY = 4`. `Base64ByteArraySerializer` reused from PR #17 for cross-platform `Data` interop. |
| Chain | `SepContractClient.kt` | OkHttp port of swift-mls's `SEPContractClient`. `SepContractTransport` seam for tests. |
| Chain | `SepContractError.kt` | Sealed class: BadStatus(code, body) / MalformedResponse / NotConnected. |
| Group | `ChatGroup.kt`, `GovernanceMember.kt` | Trimmed value types — no chat / avatar / push fields yet. |
| Group | `GroupCommitmentBuilder.kt` | OnymSDK.Common wrapper — Poseidon leaf hash + lex-sorted merkle root + 2-level commitment. |

## Architecture compliance

- `SepContractClient` imports OkHttp + kotlinx.serialization only.
- `GroupCommitmentBuilder` imports `chat.onym.sdk.Common` only.
- `IdentityRepository.sealInvitation` is the **only** producer of `InvitationEnvelopeSealer`; downstream interactors (PR-C+) hold the interface, never the repository.
- No imports of `androidx.compose.*`, `okhttp3.*`, or `chat.onym.sdk.*` from anything outside `chain/`, `group/`, or `identity/`.

## Three Android-specific gotchas (from the brief)

1. **`ByteArray` JSON shape**. Each `ByteArray` field uses `@Serializable(with = Base64ByteArraySerializer::class)` so the wire shape is base64 strings, matching iOS's `Data` Codable default. Pinned in `SepContractTypesTest`.
2. **OkHttp single-shot body**. `OkHttpSepContractTransport` reads `response.body!!.bytes()` ONCE before checking `isSuccessful` so the BadStatus error path can include the captured body without a second `.bytes()` call. Pinned in `okHttpTransport_throwsBadStatus_andCapturesBody`.
3. **Camel-case `transactionHash` quirk**. iOS doesn't override the CodingKey for `transactionHash` on `SEPSubmissionResponse`, so the JSON key stays camelCase (NOT snake_case `transaction_hash`). Mirrored exactly + pinned in `submissionResponse_keepsCamelCaseTransactionHashKey`.

## Test plan

- [x] `:app:assembleDebug` — production compiles
- [x] `:app:testDebugUnitTest --tests 'chat.onym.android.chain.*' --tests 'chat.onym.android.group.*'` — chain + group unit tests pass
- [x] `:app:compileDebugAndroidTestKotlin` — instrumented sources compile (5 sealer tests + 3 FFI commitment tests gated on the JNI .so)
- [ ] CI's full sweep
- [ ] PR-D's real-testnet E2E once PR-B and PR-C land

## Out of scope (PR-A)

- `CreateGroupInteractor` and any UI — those land in PR-C.
- `update_commitment` flow (member-add) — Tyranny supports it; the create-only MVP doesn't need it. Comes in the chat-screen slice.
- Anarchy + OneOnOne proof generation — stubbed in PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)