### PR TITLE
group: Tyranny proof generator + group repository (PR-B of Create Group)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/chain/GroupProofGeneratorFfiTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/chain/GroupProofGeneratorFfiTest.kt
@@ -1,0 +1,81 @@
+package chat.onym.android.chain
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.group.GovernanceMember
+import chat.onym.sdk.Common
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Real proof generation against the OnymSDK Tyranny circuit. Tier
+ * is `SMALL` (depth 5) — fastest to prove (~3.5s on a Pixel 6) but
+ * still goes through the full circuit so the byte-size assertions
+ * here would catch any drift in `Tyranny.CreateProof.publicInputs`
+ * layout.
+ *
+ * Lives in `androidTest/` because the JNI .so for `chat.onym.sdk.*`
+ * is only loaded by the on-device runtime; the unit-test runner
+ * doesn't see it.
+ *
+ * Mirrors `test_proveCreate_tyranny_returnsParsedProofAndCommitment`
+ * from onym-ios PR #25.
+ */
+@RunWith(AndroidJUnit4::class)
+class GroupProofGeneratorFfiTest {
+
+    @Test
+    fun proveCreate_tyranny_returnsParsedProofAndCommitment() = runBlocking {
+        // Three distinct member secrets (1, 2, 3 as 32-byte BE Frs).
+        val secrets = (1uL..3uL).map(::frFromU64)
+        val members = secrets.map { sk ->
+            GovernanceMember(
+                publicKeyCompressed = Common.publicKey(sk),
+                leafHash = Common.leafHash(sk),
+            )
+        }
+        val sorted = members.sortedWith { a, b -> compareLex(a.publicKeyCompressed, b.publicKeyCompressed) }
+        val adminSecret = secrets[0]
+        val adminLeaf = Common.leafHash(adminSecret)
+        val adminIndex = sorted.indexOfFirst { it.leafHash.contentEquals(adminLeaf) }
+
+        val input = GroupProofCreateInput(
+            groupType = SepGroupType.TYRANNY,
+            tier = SepTier.SMALL,
+            members = sorted,
+            adminBlsSecretKey = adminSecret,
+            adminIndex = adminIndex,
+            groupId = frFromU64(0x7777uL),
+            salt = ByteArray(32) { 0xEE.toByte() },
+        )
+
+        val result = OnymGroupProofGenerator().proveCreate(input)
+        assertEquals(
+            "Common.parsePlonkProof trims the 1601-byte raw output to 1568 bytes",
+            1568,
+            result.proof.size,
+        )
+        assertEquals(32, result.publicInputs.commitment.size)
+        assertEquals("create-group is always epoch 0", 0uL, result.publicInputs.epoch)
+    }
+
+    /** 32-byte big-endian encoding of a small u64 — copied from the
+     *  iOS test helpers (can't import OnymSDK test fixtures here). */
+    private fun frFromU64(value: ULong): ByteArray {
+        val out = ByteArray(32)
+        for (i in 0 until 8) {
+            out[31 - i] = ((value shr (i * 8)) and 0xFFuL).toByte()
+        }
+        return out
+    }
+
+    private fun compareLex(a: ByteArray, b: ByteArray): Int {
+        val len = minOf(a.size, b.size)
+        for (i in 0 until len) {
+            val cmp = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+            if (cmp != 0) return cmp
+        }
+        return a.size - b.size
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
@@ -1,0 +1,181 @@
+package chat.onym.android.chain
+
+import chat.onym.android.group.GovernanceMember
+import chat.onym.sdk.Common
+import chat.onym.sdk.Tyranny
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Output of [GroupProofGenerator.proveCreate]. The relayer / contract
+ * expect:
+ *
+ *  - [proof] — 1568 bytes, the [Common.parsePlonkProof]-trimmed form
+ *    of the raw 1601-byte SDK output (strips four `len()` u64 prefixes
+ *    + the trailing `plookup_proof: None` byte). The unparsed shape
+ *    is rejected on-chain.
+ *  - [publicInputs] — the `(commitment, epoch)` pair the
+ *    [SepCreateGroupV2Request] carries. For create the SDK's per-type
+ *    PI bundle (`commitment(32) || Fr(0)(32) || admin_pubkey_commitment(32) || group_id_fr(32)`)
+ *    is sliced to its first 32 bytes for the commitment; epoch is
+ *    always 0 for create.
+ *
+ * Mirrors `GroupCreateProof` from onym-ios PR #25.
+ */
+data class GroupCreateProof(
+    val proof: ByteArray,
+    val publicInputs: SepPublicInputs,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GroupCreateProof) return false
+        return proof.contentEquals(other.proof) && publicInputs == other.publicInputs
+    }
+
+    override fun hashCode(): Int =
+        31 * proof.contentHashCode() + publicInputs.hashCode()
+}
+
+/**
+ * Inputs for a create-group proof. The caller (PR-C interactor) is
+ * responsible for:
+ *
+ *  - lex-sorting [members] by [GovernanceMember.publicKeyCompressed]
+ *    BEFORE computing [adminIndex] (the SDK reuses the same sort to
+ *    validate `memberLeafHashes[adminIndex] == leafHash(adminBlsSecretKey)`),
+ *  - generating a fresh 32-byte [salt] via
+ *    `chat.onym.android.group.GroupCommitmentBuilder.generateSalt`,
+ *  - choosing the [tier] based on the expected member count.
+ *
+ * Mirrors `GroupProofCreateInput` from onym-ios PR #25.
+ */
+data class GroupProofCreateInput(
+    val groupType: SepGroupType,
+    val tier: SepTier,
+    /** Lex-sorted by `publicKeyCompressed`. The packed `leafHash`es
+     *  land in the prover in this order. */
+    val members: List<GovernanceMember>,
+    /** 32 bytes BE — the sender's own BLS Fr scalar. */
+    val adminBlsSecretKey: ByteArray,
+    /** Position of the admin in [members] (after the lex sort). */
+    val adminIndex: Int,
+    /** 32-byte raw group ID — used directly as the `group_id_fr`
+     *  per-group binding scalar in the Tyranny circuit. */
+    val groupId: ByteArray,
+    /** 32 bytes; LE-mod-r in-circuit. */
+    val salt: ByteArray,
+)
+
+/**
+ * Failure modes for [GroupProofGenerator.proveCreate]. Sealed so
+ * `when` exhaustiveness checks downstream don't need an `else`
+ * branch.
+ *
+ * Mirrors `GroupProofGeneratorError` from onym-ios PR #25.
+ */
+sealed class GroupProofGeneratorError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    /** Caller asked for a governance type other than [SepGroupType.TYRANNY].
+     *  PR-B ships Tyranny only — UI surfaces this as a clear "TBD". */
+    class NotYetSupported(val type: SepGroupType) :
+        GroupProofGeneratorError("group type not yet supported: $type")
+
+    /** [GroupProofCreateInput.adminIndex] was negative or `>= members.size`.
+     *  Short-circuits before the JNI call so the SDK doesn't have to
+     *  panic on the same condition. */
+    class AdminIndexOutOfRange(val index: Int, val count: Int) :
+        GroupProofGeneratorError("admin index $index out of range (members.size=$count)")
+
+    /** Anything thrown out of the OnymSDK FFI — circuit-internal panic,
+     *  malformed leaf hash, etc. Wraps the message but not the cause
+     *  type because the SDK's exception hierarchy isn't part of our
+     *  stable surface. */
+    class SdkFailure(message: String) :
+        GroupProofGeneratorError("OnymSDK proveCreate failed: $message")
+}
+
+/**
+ * Chain seam for proof generation. Switches on
+ * [GroupProofCreateInput.groupType] so PR-C's `CreateGroupInteractor`
+ * doesn't need to import OnymSDK directly. Only [SepGroupType.TYRANNY]
+ * is wired in this slice — the other governance types throw
+ * [GroupProofGeneratorError.NotYetSupported].
+ *
+ * Mirrors `GroupProofGenerator` from onym-ios PR #25.
+ */
+interface GroupProofGenerator {
+    /**
+     * Generate a create-group PLONK proof + the on-wire commitment.
+     *
+     * **Runs on [Dispatchers.Default]** — the call is CPU-bound
+     * (~3.5s on a Pixel 6 at depth 5) and would block any other
+     * dispatcher's worker thread for the duration. Callers that want
+     * to overlap with I/O should not switch dispatchers themselves.
+     */
+    suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof
+}
+
+/**
+ * Production [GroupProofGenerator] backed by `chat.onym.sdk.Tyranny`.
+ *
+ * Mirrors `OnymGroupProofGenerator` from onym-ios PR #25.
+ */
+class OnymGroupProofGenerator : GroupProofGenerator {
+
+    override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof =
+        when (input.groupType) {
+            SepGroupType.TYRANNY -> proveTyrannyCreate(input)
+            SepGroupType.ANARCHY,
+            SepGroupType.ONE_ON_ONE,
+            SepGroupType.DEMOCRACY,
+            SepGroupType.OLIGARCHY,
+                -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
+        }
+
+    private suspend fun proveTyrannyCreate(input: GroupProofCreateInput): GroupCreateProof {
+        if (input.adminIndex < 0 || input.adminIndex >= input.members.size) {
+            throw GroupProofGeneratorError.AdminIndexOutOfRange(
+                index = input.adminIndex,
+                count = input.members.size,
+            )
+        }
+        val packedLeaves = ByteArray(input.members.size * 32)
+        for ((i, member) in input.members.withIndex()) {
+            require(member.leafHash.size == 32) {
+                "leafHash for member $i has unexpected size ${member.leafHash.size}, expected 32"
+            }
+            System.arraycopy(member.leafHash, 0, packedLeaves, i * 32, 32)
+        }
+
+        // CPU-bound — keep it off Dispatchers.IO (which is for blocking
+        // I/O) and off Dispatchers.Main. ~3.5s at depth 5 on a Pixel 6.
+        return withContext(Dispatchers.Default) {
+            val raw = try {
+                Tyranny.proveCreate(
+                    /* depth = */ input.tier.depth,
+                    /* memberLeafHashes = */ packedLeaves,
+                    /* adminSecretKey = */ input.adminBlsSecretKey,
+                    /* adminIndex = */ input.adminIndex,
+                    /* groupIdFr = */ input.groupId,
+                    /* salt = */ input.salt,
+                )
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            val parsed = try {
+                Common.parsePlonkProof(raw.proof)
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            // PI bundle layout (Tyranny.CreateProof):
+            //   commitment(32) || Fr(0)(32) || admin_pubkey_commitment(32) || group_id_fr(32)
+            // Only the first 32 bytes (commitment) cross the wire; the
+            // contract rederives the latter three from the proof itself.
+            val commitment = raw.publicInputs.copyOfRange(0, 32)
+            GroupCreateProof(
+                proof = parsed,
+                publicInputs = SepPublicInputs(commitment = commitment, epoch = 0uL),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/GroupDao.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupDao.kt
@@ -1,0 +1,63 @@
+package chat.onym.android.group
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+
+/**
+ * Room DAO over [PersistedGroup]. The five verbs the repository
+ * needs (list, select-by-id, insert, update, mark-published, delete);
+ * nothing else.
+ *
+ * Suspend functions throughout — Room dispatches them on its
+ * single-threaded query executor by default, which is fine for our
+ * volume (a group is created at user-action speed).
+ *
+ * Mirrors the SwiftData fetch / save calls in `SwiftDataGroupStore`
+ * from onym-ios PR #25 — the SwiftData side does the same
+ * fetch-then-update pattern in `insertOrUpdate`, just inline.
+ */
+@Dao
+interface GroupDao {
+
+    @Query("SELECT * FROM groups ORDER BY createdAt DESC")
+    suspend fun list(): List<PersistedGroup>
+
+    @Query("SELECT * FROM groups WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): PersistedGroup?
+
+    /**
+     * Pure insert. Use [findById] first to decide between insert
+     * and [update] so [RoomGroupStore.insertOrUpdate] can return
+     * `true` on insert / `false` on update. Throws on PK conflict
+     * (the store's caller has already gone through [findById] and
+     * routed accordingly).
+     */
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(record: PersistedGroup)
+
+    @Update
+    suspend fun update(record: PersistedGroup)
+
+    /**
+     * Flip [PersistedGroup.isPublishedOnChain] to true and replace
+     * the [PersistedGroup.encryptedCommitment]. Caller passes a
+     * non-null encrypted blob OR omits the column update entirely
+     * via [markPublishedFlagOnly].
+     */
+    @Query("UPDATE groups SET isPublishedOnChain = 1, encryptedCommitment = :encryptedCommitment WHERE id = :id")
+    suspend fun markPublishedWithCommitment(id: String, encryptedCommitment: ByteArray): Int
+
+    /**
+     * Flip [PersistedGroup.isPublishedOnChain] to true without
+     * touching the commitment column — used when the post-anchor
+     * flow doesn't have a fresh commitment to write.
+     */
+    @Query("UPDATE groups SET isPublishedOnChain = 1 WHERE id = :id")
+    suspend fun markPublishedFlagOnly(id: String): Int
+
+    @Query("DELETE FROM groups WHERE id = :id")
+    suspend fun delete(id: String): Int
+}

--- a/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
@@ -1,0 +1,29 @@
+package chat.onym.android.group
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * Room database housing [PersistedGroup].
+ *
+ * Sibling to `chat.onym.android.persistence.InvitationDatabase` —
+ * each persistence domain (invitations, groups, messages later) gets
+ * its own `@Database` so migrations stay scoped per-domain and the
+ * version number doesn't accumulate the `version = 17` rebase pain
+ * the stellar-mls reference impl suffers from.
+ *
+ * Mirrors the SwiftData `ModelContainer([PersistedGroup.self])` that
+ * `SwiftDataGroupStore` constructs in onym-ios PR #25.
+ */
+@Database(
+    entities = [PersistedGroup::class],
+    version = 1,
+    // Schema export is for cross-version diffing during migration
+    // authoring; nothing to diff at v1 and KSP warns loudly about
+    // the missing `room.schemaLocation` directory otherwise. Flip
+    // to true and add the apt arg when version 2 lands.
+    exportSchema = false,
+)
+abstract class GroupDatabase : RoomDatabase() {
+    abstract fun groupDao(): GroupDao
+}

--- a/app/src/main/kotlin/chat/onym/android/group/GroupRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupRepository.kt
@@ -1,0 +1,85 @@
+package chat.onym.android.group
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns the in-memory view of the user's chat groups plus the
+ * corresponding writes to the persistence seam. Touch-surface
+ * compliance:
+ *
+ *  - Holds **only** a [GroupStore] reference. No transport, no
+ *    OnymSDK, no Compose, no `Context`.
+ *  - Exposes a [StateFlow] for observation; [insert] / [markPublished]
+ *    / [delete] / [reload] are the suspend mutators.
+ *  - Mutations serialise through a [Mutex]; reads are lock-free
+ *    off the [StateFlow].
+ *
+ * iOS uses `actor + AsyncStream` for the same role; Android stays
+ * with [StateFlow] because Compose subscribes via
+ * `collectAsStateWithLifecycle()` with no per-view boilerplate (same
+ * argument as `IncomingInvitationsRepository` from PR #16).
+ *
+ * **Replay-on-subscribe** is intentional — every new collector
+ * receives the current value immediately. Don't swap [StateFlow]
+ * for [kotlinx.coroutines.flow.MutableSharedFlow]; PR-C's screen
+ * relies on the replay so it can render an immediate snapshot
+ * without a `LaunchedEffect { reload() }` dance.
+ *
+ * Mirrors `GroupRepository.swift` from onym-ios PR #25.
+ */
+class GroupRepository(
+    private val store: GroupStore,
+) {
+    private val mutex = Mutex()
+    private val _snapshots = MutableStateFlow<List<ChatGroup>>(emptyList())
+
+    /** Hot stream of the user's groups, sorted by [ChatGroup.createdAtMillis]
+     *  desc. Empty until [reload] (or any mutator) runs. */
+    val snapshots: StateFlow<List<ChatGroup>> = _snapshots.asStateFlow()
+
+    /**
+     * Hydrate from disk. Idempotent — safe to call from any
+     * `onCreate` / `LaunchedEffect`. Repeated calls reload but don't
+     * error.
+     */
+    suspend fun reload() = mutex.withLock { refreshLocked() }
+
+    /**
+     * Idempotent on [ChatGroup.id] (delegates to
+     * [GroupStore.insertOrUpdate]). Any subsequent insert with the
+     * same id overwrites the row in place — the chain-anchor flow
+     * uses this to flip [ChatGroup.isPublishedOnChain] and bump the
+     * commitment.
+     *
+     * @return `true` on insert, `false` on update.
+     */
+    suspend fun insert(group: ChatGroup): Boolean = mutex.withLock {
+        val inserted = store.insertOrUpdate(group)
+        refreshLocked()
+        inserted
+    }
+
+    /**
+     * Mark a group as anchored on chain. The commitment, when
+     * supplied, replaces whatever was held in memory (the relayer's
+     * `get_state` is the source of truth post-anchor); a `null`
+     * commitment leaves the existing column untouched.
+     */
+    suspend fun markPublished(id: String, commitment: ByteArray?) = mutex.withLock {
+        store.markPublished(id, commitment)
+        refreshLocked()
+    }
+
+    suspend fun delete(id: String) = mutex.withLock {
+        store.delete(id)
+        refreshLocked()
+    }
+
+    private suspend fun refreshLocked() {
+        _snapshots.value = store.list()
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/GroupStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupStore.kt
@@ -1,0 +1,44 @@
+package chat.onym.android.group
+
+/**
+ * Persistence seam for chat groups. Async surface mirrors
+ * [chat.onym.android.persistence.InvitationStore] (PR #16) so a
+ * concrete impl can serialise writes on its own dispatcher without
+ * forcing callers onto a specific dispatcher.
+ *
+ * [ChatGroup] is the domain shape; the store is responsible for
+ * AES-GCM-wrapping the sensitive columns at the boundary.
+ *
+ * Mirrors `GroupStore` from onym-ios PR #25.
+ */
+interface GroupStore {
+
+    /** All persisted groups, sorted by [ChatGroup.createdAtMillis] desc. */
+    suspend fun list(): List<ChatGroup>
+
+    /**
+     * Idempotent on [ChatGroup.id]: if the row exists, sensitive +
+     * mutable fields are overwritten in place (so a chain-anchor
+     * retry can flip [ChatGroup.isPublishedOnChain] and bump the
+     * commitment without losing the original [ChatGroup.createdAtMillis]).
+     *
+     * @return `true` on insert, `false` on update.
+     */
+    suspend fun insertOrUpdate(group: ChatGroup): Boolean
+
+    /**
+     * Convenience for the post-anchor flow: flip
+     * [ChatGroup.isPublishedOnChain] to `true` and update the
+     * commitment to whatever the relayer's `get_state` returned.
+     * No-op if [id] is missing.
+     *
+     * If [commitment] is `null`, only the flag is updated — the
+     * existing commitment column is preserved (the relayer's
+     * `get_state` is the source of truth post-anchor; if we don't
+     * have a fresh value, we don't blow away whatever's there).
+     */
+    suspend fun markPublished(id: String, commitment: ByteArray?)
+
+    /** No-op if [id] is absent. */
+    suspend fun delete(id: String)
+}

--- a/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
@@ -1,0 +1,87 @@
+package chat.onym.android.group
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Room row shape for one chat group on disk. Splits the schema into
+ * plain (queryable, non-identifying) and AES-GCM-encrypted (sensitive)
+ * columns — same pattern as `PersistedInvitation` (PR #16).
+ *
+ * Plain columns:
+ *  - [id] — 64-char hex of the 32-byte group ID. Already public on
+ *    chain (the contract stores it as the entry key), so encrypting
+ *    locally would buy nothing while breaking dedup lookups.
+ *  - [createdAt] — wall-clock ms since the Unix epoch. Stored
+ *    primitive INTEGER so the DAO can `ORDER BY createdAt DESC`
+ *    without a converter.
+ *  - [epoch], [tierRaw], [groupTypeRaw], [isPublishedOnChain] — small
+ *    enums / counts; not user-identifying.
+ *
+ * Encrypted columns (`StorageEncryption.encrypt`):
+ *  - [encryptedName] — user-supplied; can leak intent.
+ *  - [encryptedGroupSecret] — drives all message-key derivation.
+ *  - [encryptedMembersJson] — the lex-sorted roster (BLS pubkeys +
+ *    leaf hashes) encoded as JSON before encryption.
+ *  - [encryptedSalt], [encryptedCommitment], [encryptedAdminPubkeyHex].
+ *
+ * Decryption boundary lives in [RoomGroupStore], not here —
+ * [PersistedGroup] is intentionally dumb storage so Room never has
+ * to reason about `chat.onym.android.persistence.StorageEncryption`.
+ *
+ * `epoch` is stored as `Long` (not `ULong`) because Room can't
+ * persist unsigned types directly — the domain layer also keeps it
+ * as `Long` to match (the relayer JSON serializer is what cares
+ * about unsigned semantics, and that's covered elsewhere).
+ *
+ * Mirrors `PersistedGroup.swift` from onym-ios PR #25.
+ */
+@Entity(tableName = "groups")
+data class PersistedGroup(
+    @PrimaryKey val id: String,
+    val createdAt: Long,
+    val epoch: Long,
+    val tierRaw: Int,
+    val groupTypeRaw: Int,
+    val isPublishedOnChain: Boolean,
+
+    val encryptedName: ByteArray,
+    val encryptedGroupSecret: ByteArray,
+    val encryptedMembersJson: ByteArray,
+    val encryptedSalt: ByteArray,
+    val encryptedCommitment: ByteArray? = null,
+    val encryptedAdminPubkeyHex: ByteArray? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PersistedGroup) return false
+        return id == other.id &&
+            createdAt == other.createdAt &&
+            epoch == other.epoch &&
+            tierRaw == other.tierRaw &&
+            groupTypeRaw == other.groupTypeRaw &&
+            isPublishedOnChain == other.isPublishedOnChain &&
+            encryptedName.contentEquals(other.encryptedName) &&
+            encryptedGroupSecret.contentEquals(other.encryptedGroupSecret) &&
+            encryptedMembersJson.contentEquals(other.encryptedMembersJson) &&
+            encryptedSalt.contentEquals(other.encryptedSalt) &&
+            (encryptedCommitment?.contentEquals(other.encryptedCommitment) ?: (other.encryptedCommitment == null)) &&
+            (encryptedAdminPubkeyHex?.contentEquals(other.encryptedAdminPubkeyHex) ?: (other.encryptedAdminPubkeyHex == null))
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + createdAt.hashCode()
+        h = 31 * h + epoch.hashCode()
+        h = 31 * h + tierRaw
+        h = 31 * h + groupTypeRaw
+        h = 31 * h + isPublishedOnChain.hashCode()
+        h = 31 * h + encryptedName.contentHashCode()
+        h = 31 * h + encryptedGroupSecret.contentHashCode()
+        h = 31 * h + encryptedMembersJson.contentHashCode()
+        h = 31 * h + encryptedSalt.contentHashCode()
+        h = 31 * h + (encryptedCommitment?.contentHashCode() ?: 0)
+        h = 31 * h + (encryptedAdminPubkeyHex?.contentHashCode() ?: 0)
+        return h
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
@@ -1,0 +1,147 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.persistence.StorageEncryption
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * [GroupStore] backed by Room + [StorageEncryption]. Wraps the
+ * sensitive columns with AES-GCM on the way in, unwraps on the way
+ * out — the encryption is invisible to callers.
+ *
+ * IO happens on [ioDispatcher]; default is [Dispatchers.IO]. Tests
+ * pass `UnconfinedTestDispatcher` (or rely on
+ * `Room.allowMainThreadQueries()`).
+ *
+ * Mirrors `SwiftDataGroupStore` from onym-ios PR #25.
+ */
+class RoomGroupStore(
+    private val dao: GroupDao,
+    private val encryption: StorageEncryption,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : GroupStore {
+
+    override suspend fun list(): List<ChatGroup> = withContext(ioDispatcher) {
+        dao.list().mapNotNull(::decode)
+    }
+
+    override suspend fun insertOrUpdate(group: ChatGroup): Boolean = withContext(ioDispatcher) {
+        val encoded = encode(group)
+        // Pre-check via findById so we can honour the
+        // "true on insert, false on update" contract precisely;
+        // OnConflictStrategy.REPLACE alone would lose the original
+        // row's createdAt on update conflicts.
+        val existing = dao.findById(group.id)
+        if (existing == null) {
+            dao.insert(encoded)
+            true
+        } else {
+            // Preserve the original createdAt on update — only the
+            // mutable columns (epoch, commitment, isPublished, name,
+            // members, etc.) get refreshed. Mirrors the iOS twin's
+            // explicit field-by-field assignment in `insertOrUpdate`.
+            dao.update(encoded.copy(createdAt = existing.createdAt))
+            false
+        }
+    }
+
+    override suspend fun markPublished(id: String, commitment: ByteArray?) {
+        withContext(ioDispatcher) {
+            if (commitment != null) {
+                dao.markPublishedWithCommitment(id, encryption.encrypt(commitment))
+            } else {
+                dao.markPublishedFlagOnly(id)
+            }
+        }
+    }
+
+    override suspend fun delete(id: String) {
+        withContext(ioDispatcher) { dao.delete(id) }
+    }
+
+    // ─── encode / decode boundary ──────────────────────────────────
+
+    private fun encode(group: ChatGroup): PersistedGroup {
+        val membersJson = jsonFormat.encodeToString(membersSerializer, group.members)
+        return PersistedGroup(
+            id = group.id,
+            createdAt = group.createdAtMillis,
+            // ULong → Long via bit pattern preserves all 64 bits;
+            // domain layer does the inverse via toULong() when reading.
+            epoch = group.epoch.toLong(),
+            tierRaw = group.tier.rawValue,
+            groupTypeRaw = group.groupType.rawValue.toInt(),
+            isPublishedOnChain = group.isPublishedOnChain,
+            encryptedName = encryption.encrypt(group.name),
+            encryptedGroupSecret = encryption.encrypt(group.groupSecret),
+            encryptedMembersJson = encryption.encrypt(membersJson.toByteArray(Charsets.UTF_8)),
+            encryptedSalt = encryption.encrypt(group.salt),
+            encryptedCommitment = group.commitment?.let(encryption::encrypt),
+            encryptedAdminPubkeyHex = group.adminPubkeyHex?.let(encryption::encrypt),
+        )
+    }
+
+    /** Tolerant decode: a row whose encrypted columns fail to
+     *  decrypt or whose enum rawValues don't resolve is skipped
+     *  rather than crashing the whole list read. Mirrors the
+     *  `guard let … else { return nil }` ladder in iOS's `decode`. */
+    private fun decode(row: PersistedGroup): ChatGroup? {
+        val name = tryDecryptString(row.encryptedName) ?: return null
+        val groupSecret = tryDecrypt(row.encryptedGroupSecret) ?: return null
+        val membersJsonBytes = tryDecrypt(row.encryptedMembersJson) ?: return null
+        val members = try {
+            jsonFormat.decodeFromString(
+                membersSerializer,
+                membersJsonBytes.toString(Charsets.UTF_8),
+            )
+        } catch (_: SerializationException) {
+            return null
+        }
+        val salt = tryDecrypt(row.encryptedSalt) ?: return null
+        val tier = SepTier.entries.firstOrNull { it.rawValue == row.tierRaw } ?: return null
+        val groupType = try {
+            SepGroupType.fromRaw(row.groupTypeRaw.toUInt())
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+        val commitment = row.encryptedCommitment?.let { tryDecrypt(it) }
+        val adminPubkeyHex = row.encryptedAdminPubkeyHex?.let { tryDecryptString(it) }
+
+        return ChatGroup(
+            id = row.id,
+            name = name,
+            groupSecret = groupSecret,
+            createdAtMillis = row.createdAt,
+            members = members,
+            // Long → ULong via bit pattern recovers the original
+            // 64-bit value. Serializer on SepPublicInputs uses ULong
+            // when this round-trips back to JSON.
+            epoch = row.epoch.toULong(),
+            salt = salt,
+            commitment = commitment,
+            tier = tier,
+            groupType = groupType,
+            adminPubkeyHex = adminPubkeyHex,
+            isPublishedOnChain = row.isPublishedOnChain,
+        )
+    }
+
+    private fun tryDecrypt(bytes: ByteArray): ByteArray? = try {
+        encryption.decrypt(bytes)
+    } catch (_: Throwable) { null }
+
+    private fun tryDecryptString(bytes: ByteArray): String? = try {
+        encryption.decryptString(bytes)
+    } catch (_: Throwable) { null }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+        private val membersSerializer = ListSerializer(GovernanceMember.serializer())
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
@@ -1,0 +1,95 @@
+package chat.onym.android.chain
+
+import chat.onym.android.group.GovernanceMember
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Pure-Kotlin tests for [OnymGroupProofGenerator] — only the
+ * short-circuit branches that don't hit `chat.onym.sdk.Tyranny.proveCreate`.
+ * The real proof-generation case (`proveCreate_tyranny_returnsParsedProofAndCommitment`)
+ * needs the JNI .so loaded and lives in
+ * `app/src/androidTest/.../GroupProofGeneratorFfiTest.kt`.
+ *
+ * Mirrors the synchronous error-path assertions from
+ * `GroupProofGeneratorTests.swift` in onym-ios PR #25.
+ */
+class GroupProofGeneratorTest {
+
+    @Test
+    fun proveCreate_anarchy_throwsNotYetSupported() = runTest {
+        val input = stubInput(SepGroupType.ANARCHY)
+        val thrown = assertThrows(GroupProofGeneratorError.NotYetSupported::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        assertEquals(SepGroupType.ANARCHY, thrown.type)
+    }
+
+    @Test
+    fun proveCreate_oneOnOne_throwsNotYetSupported() = runTest {
+        val input = stubInput(SepGroupType.ONE_ON_ONE)
+        val thrown = assertThrows(GroupProofGeneratorError.NotYetSupported::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        assertEquals(SepGroupType.ONE_ON_ONE, thrown.type)
+    }
+
+    @Test
+    fun proveCreate_adminIndexOutOfRange_shortCircuitsBeforeJni() = runTest {
+        // Single-member roster + adminIndex=5 — must throw before any
+        // FFI call (the SDK isn't loaded in unit tests).
+        val input = GroupProofCreateInput(
+            groupType = SepGroupType.TYRANNY,
+            tier = SepTier.SMALL,
+            members = listOf(
+                GovernanceMember(
+                    publicKeyCompressed = ByteArray(48) { 0xAA.toByte() },
+                    leafHash = ByteArray(32) { 0xBB.toByte() },
+                ),
+            ),
+            adminBlsSecretKey = ByteArray(32) { 0x01 },
+            adminIndex = 5,
+            groupId = ByteArray(32),
+            salt = ByteArray(32),
+        )
+        val thrown = assertThrows(GroupProofGeneratorError.AdminIndexOutOfRange::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        assertEquals(5, thrown.index)
+        assertEquals(1, thrown.count)
+    }
+
+    @Test
+    fun proveCreate_negativeAdminIndex_shortCircuitsBeforeJni() = runTest {
+        val input = GroupProofCreateInput(
+            groupType = SepGroupType.TYRANNY,
+            tier = SepTier.SMALL,
+            members = listOf(
+                GovernanceMember(
+                    publicKeyCompressed = ByteArray(48),
+                    leafHash = ByteArray(32),
+                ),
+            ),
+            adminBlsSecretKey = ByteArray(32),
+            adminIndex = -1,
+            groupId = ByteArray(32),
+            salt = ByteArray(32),
+        )
+        val thrown = assertThrows(GroupProofGeneratorError.AdminIndexOutOfRange::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        assertEquals(-1, thrown.index)
+    }
+
+    private fun stubInput(groupType: SepGroupType) = GroupProofCreateInput(
+        groupType = groupType,
+        tier = SepTier.SMALL,
+        members = emptyList(),
+        adminBlsSecretKey = ByteArray(32) { 0x01 },
+        adminIndex = 0,
+        groupId = ByteArray(32),
+        salt = ByteArray(32),
+    )
+}

--- a/app/src/test/kotlin/chat/onym/android/group/GroupRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/GroupRepositoryTest.kt
@@ -1,0 +1,147 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reactive-surface tests for [GroupRepository]. Backed by an
+ * in-memory [GroupStore] fake (defined at the bottom of this file)
+ * so the Room layer doesn't pull in `Robolectric` /
+ * `StorageEncryption` here — those are
+ * [RoomGroupStoreTest]'s responsibility.
+ *
+ * Mirrors `GroupRepositoryTests.swift` from onym-ios PR #25.
+ */
+class GroupRepositoryTest {
+
+    @Test
+    fun snapshots_replaysCurrentOnSubscribe() = runTest {
+        val store = InMemoryGroupStore()
+        val group = makeGroup(id = "aa".repeat(32), name = "Family")
+        store.preload(listOf(group))
+        val repo = GroupRepository(store)
+        repo.reload()
+
+        // StateFlow.first() reads the current value — this is the
+        // replay-on-subscribe property the screen relies on for an
+        // immediate render.
+        val snapshot = repo.snapshots.first()
+        assertEquals(1, snapshot.size)
+        assertEquals(group.id, snapshot.first().id)
+    }
+
+    @Test
+    fun insert_broadcastsNewSnapshot() = runTest {
+        val store = InMemoryGroupStore()
+        val repo = GroupRepository(store)
+
+        val group = makeGroup(id = "bb".repeat(32), name = "Friends")
+        val inserted = repo.insert(group)
+        assertTrue("first insert returns true", inserted)
+
+        val snapshot = repo.snapshots.value
+        assertEquals(1, snapshot.size)
+        assertEquals("Friends", snapshot.first().name)
+    }
+
+    @Test
+    fun insert_secondCallUpdatesAndReturnsFalse() = runTest {
+        val store = InMemoryGroupStore()
+        val repo = GroupRepository(store)
+
+        val group = makeGroup(id = "bc".repeat(32), name = "Friends")
+        repo.insert(group)
+        val secondInserted = repo.insert(group.copy(name = "Friends (renamed)"))
+
+        assertFalse("second insert with same id is an update", secondInserted)
+        assertEquals("Friends (renamed)", repo.snapshots.value.single().name)
+    }
+
+    @Test
+    fun markPublished_broadcastsUpdatedSnapshot() = runTest {
+        val store = InMemoryGroupStore()
+        val group = makeGroup(id = "cc".repeat(32), name = "G")
+        store.preload(listOf(group))
+        val repo = GroupRepository(store)
+        repo.reload()
+
+        val onchainCommitment = ByteArray(32) { 0x42 }
+        repo.markPublished(group.id, onchainCommitment)
+
+        val snapshot = repo.snapshots.value.single()
+        assertTrue(snapshot.isPublishedOnChain)
+        assertArrayEquals(onchainCommitment, snapshot.commitment)
+    }
+
+    @Test
+    fun delete_emptiesSnapshot() = runTest {
+        val store = InMemoryGroupStore()
+        val group = makeGroup(id = "dd".repeat(32), name = "G")
+        store.preload(listOf(group))
+        val repo = GroupRepository(store)
+        repo.reload()
+
+        repo.delete(group.id)
+        assertTrue(repo.snapshots.value.isEmpty())
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeGroup(id: String, name: String) = ChatGroup(
+        id = id,
+        name = name,
+        groupSecret = ByteArray(32) { 0x33 },
+        createdAtMillis = 1_700_000_000_000L,
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32) { 0x44 },
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = null,
+        isPublishedOnChain = false,
+    )
+}
+
+/**
+ * In-memory [GroupStore] fake. Lives next to the test that uses it
+ * because PR-B has only one consumer; promote to a `support/`
+ * package when PR-C's interactor tests grow a second one. Mirrors
+ * the same private-fake placement in
+ * `GroupRepositoryTests.swift` (onym-ios PR #25).
+ */
+private class InMemoryGroupStore : GroupStore {
+    private val rows = LinkedHashMap<String, ChatGroup>()
+
+    fun preload(groups: List<ChatGroup>) {
+        for (g in groups) rows[g.id] = g
+    }
+
+    override suspend fun list(): List<ChatGroup> =
+        rows.values.sortedByDescending { it.createdAtMillis }
+
+    override suspend fun insertOrUpdate(group: ChatGroup): Boolean {
+        val isNew = !rows.containsKey(group.id)
+        rows[group.id] = group
+        return isNew
+    }
+
+    override suspend fun markPublished(id: String, commitment: ByteArray?) {
+        val existing = rows[id] ?: return
+        rows[id] = existing.copy(
+            isPublishedOnChain = true,
+            commitment = commitment ?: existing.commitment,
+        )
+    }
+
+    override suspend fun delete(id: String) {
+        rows.remove(id)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/RoomGroupStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/RoomGroupStoreTest.kt
@@ -1,0 +1,242 @@
+package chat.onym.android.group
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.persistence.StorageEncryption
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.security.SecureRandom
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Round-trip tests for [RoomGroupStore]. Uses
+ * `Room.inMemoryDatabaseBuilder` so the on-disk store isn't touched.
+ * Encrypted columns go through a real [StorageEncryption] backed by
+ * a fresh AES key per test (no Robolectric Keystore dance).
+ *
+ * Mirrors `SwiftDataGroupStoreTests.swift` from onym-ios PR #25.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class RoomGroupStoreTest {
+
+    private lateinit var db: GroupDatabase
+    private lateinit var store: RoomGroupStore
+    private lateinit var encryption: StorageEncryption
+
+    @Before
+    fun setUp() {
+        val ctx: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(ctx, GroupDatabase::class.java)
+            .allowMainThreadQueries()  // tests run sync; no UI thread to protect
+            .build()
+        encryption = StorageEncryption(
+            SecretKeySpec(ByteArray(32).also { SecureRandom().nextBytes(it) }, "AES")
+        )
+        store = RoomGroupStore(db.groupDao(), encryption)
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    // ─── round-trip ───────────────────────────────────────────────
+
+    @Test
+    fun insertOrUpdate_thenList_roundtripsAllFields() = runTest {
+        val group = makeGroup(
+            id = "aa".repeat(32),
+            name = "Family",
+            adminPubkeyHex = "ee".repeat(48),
+        )
+        assertTrue("first insertOrUpdate must report insert", store.insertOrUpdate(group))
+
+        val listed = store.list()
+        assertEquals(1, listed.size)
+        val first = listed[0]
+        assertEquals(group.id, first.id)
+        assertEquals("Family", first.name)
+        assertArrayEquals(group.groupSecret, first.groupSecret)
+        assertArrayEquals(group.salt, first.salt)
+        assertArrayEquals(group.commitment, first.commitment)
+        assertEquals(SepTier.SMALL, first.tier)
+        assertEquals(SepGroupType.TYRANNY, first.groupType)
+        assertEquals("ee".repeat(48), first.adminPubkeyHex)
+        assertEquals(group.epoch, first.epoch)
+        assertFalse(first.isPublishedOnChain)
+        assertEquals(group.members.size, first.members.size)
+        assertArrayEquals(
+            group.members.first().publicKeyCompressed,
+            first.members.first().publicKeyCompressed,
+        )
+    }
+
+    // ─── encryption-at-rest ───────────────────────────────────────
+
+    @Test
+    fun encryptedColumns_doNotContainPlaintext() = runTest {
+        val plaintextName = "Family".toByteArray(Charsets.UTF_8)
+        val plaintextSecret = ByteArray(32) { 0x33 }
+        val group = makeGroup(id = "ab".repeat(32), name = "Family")
+        store.insertOrUpdate(group)
+
+        val raw = db.groupDao().findById(group.id)!!
+        assertNotEquals(
+            "encryptedName must not contain the plaintext name",
+            plaintextName.toList(),
+            raw.encryptedName.toList(),
+        )
+        assertNotEquals(
+            "encryptedGroupSecret must not contain the plaintext secret",
+            plaintextSecret.toList(),
+            raw.encryptedGroupSecret.toList(),
+        )
+        // …but the seam decrypts it back to the plaintext.
+        assertEquals("Family", store.list().single().name)
+        // Layout sanity: nonce(12) + ciphertext("Family", 6 bytes) + tag(16) = 34B.
+        assertEquals(
+            StorageEncryption.NONCE_SIZE + plaintextName.size + StorageEncryption.TAG_SIZE,
+            raw.encryptedName.size,
+        )
+    }
+
+    // ─── idempotence ──────────────────────────────────────────────
+
+    @Test
+    fun insertOrUpdate_secondCallUpdatesInPlace() = runTest {
+        val original = makeGroup(id = "bb".repeat(32), name = "Old name")
+        assertTrue(store.insertOrUpdate(original))
+
+        val updated = original.copy(
+            epoch = 7uL,
+            commitment = ByteArray(32) { 0x99.toByte() },
+        )
+        assertFalse(
+            "second insertOrUpdate on same id is an update",
+            store.insertOrUpdate(updated),
+        )
+
+        val listed = store.list()
+        assertEquals(1, listed.size)
+        assertEquals(7uL, listed[0].epoch)
+        assertArrayEquals(ByteArray(32) { 0x99.toByte() }, listed[0].commitment)
+        // createdAt preserved across update — the post-anchor flow
+        // mustn't reset the user-visible "this group was created at"
+        // timestamp.
+        assertEquals(original.createdAtMillis, listed[0].createdAtMillis)
+    }
+
+    // ─── markPublished ────────────────────────────────────────────
+
+    @Test
+    fun markPublished_flipsFlagAndStoresCommitment() = runTest {
+        val group = makeGroup(id = "cc".repeat(32), name = "G")
+        store.insertOrUpdate(group)
+
+        val onchainCommitment = ByteArray(32) { 0x42 }
+        store.markPublished(group.id, onchainCommitment)
+
+        val listed = store.list()
+        assertTrue(listed[0].isPublishedOnChain)
+        assertArrayEquals(onchainCommitment, listed[0].commitment)
+    }
+
+    @Test
+    fun markPublished_unknownIdIsNoOp() = runTest {
+        store.markPublished("ff".repeat(32), null)
+        assertTrue("no group existed; list must stay empty", store.list().isEmpty())
+    }
+
+    @Test
+    fun markPublished_nullCommitment_preservesExistingCommitment() = runTest {
+        val group = makeGroup(id = "ed".repeat(32), name = "G")
+        store.insertOrUpdate(group)
+        val originalCommitment = group.commitment
+
+        store.markPublished(group.id, null)
+
+        val listed = store.list().single()
+        assertTrue(listed.isPublishedOnChain)
+        assertArrayEquals(
+            "null commitment update must preserve the existing column",
+            originalCommitment,
+            listed.commitment,
+        )
+    }
+
+    // ─── delete ───────────────────────────────────────────────────
+
+    @Test
+    fun delete_removesRow() = runTest {
+        val group = makeGroup(id = "dd".repeat(32), name = "G")
+        store.insertOrUpdate(group)
+        assertEquals(1, store.list().size)
+
+        store.delete(group.id)
+        assertTrue(store.list().isEmpty())
+    }
+
+    // ─── ordering ─────────────────────────────────────────────────
+
+    @Test
+    fun list_sortsByCreatedAtDescending() = runTest {
+        val older = makeGroup(
+            id = "01".repeat(32),
+            name = "older",
+            createdAtMillis = 1_700_000_000_000L,
+        )
+        val newer = makeGroup(
+            id = "02".repeat(32),
+            name = "newer",
+            createdAtMillis = 1_700_000_500_000L,
+        )
+        store.insertOrUpdate(older)
+        store.insertOrUpdate(newer)
+
+        assertEquals(listOf(newer.id, older.id), store.list().map { it.id })
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeGroup(
+        id: String,
+        name: String,
+        adminPubkeyHex: String? = null,
+        createdAtMillis: Long = 1_700_000_000_000L,
+    ): ChatGroup {
+        val member = GovernanceMember(
+            publicKeyCompressed = ByteArray(48) { 0x11 },
+            leafHash = ByteArray(32) { 0x22 },
+        )
+        return ChatGroup(
+            id = id,
+            name = name,
+            groupSecret = ByteArray(32) { 0x33 },
+            createdAtMillis = createdAtMillis,
+            members = listOf(member),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x44 },
+            commitment = ByteArray(32) { 0x55 },
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = adminPubkeyHex,
+            isPublishedOnChain = false,
+        )
+    }
+
+    @Suppress("unused")
+    private fun assertNullOk(value: Any?) { assertNull(value) }
+}


### PR DESCRIPTION
## Summary

PR-B of the 4-PR Create Group slice. Wires Tyranny proof generation through `chat.onym.sdk.Tyranny` and adds the Room-backed `GroupRepository`. No UI in this PR — PR-C is the orchestration + Compose layer.

Mirrors onymchat/onym-ios#25.

## What lands

| Layer | File | What it does |
|---|---|---|
| Chain | `GroupProofGenerator.kt` | Interface + `OnymGroupProofGenerator` impl. Tyranny only; other governance types throw `NotYetSupported`. Bounds-checks `adminIndex` before the FFI; runs the prove on `Dispatchers.Default`; trims the 1601-byte raw output to 1568 bytes via `Common.parsePlonkProof`; slices the first 32 bytes of the SDK's PI bundle as the on-wire commitment. |
| Group | `PersistedGroup.kt` | Room `@Entity`. Plain columns (`id` PK / `createdAt` / `epoch` / `tierRaw` / `groupTypeRaw` / `isPublishedOnChain`) vs encrypted (`name` / `groupSecret` / `membersJson` / `salt` / `commitment?` / `adminPubkeyHex?`). |
| Group | `GroupDao.kt` | `list` (ORDER BY createdAt DESC), `findById`, `insert`, `update`, `markPublishedWithCommitment` / `markPublishedFlagOnly`, `delete`. |
| Group | `GroupDatabase.kt` | `@Database(version=1)`. Sibling to `InvitationDatabase`. |
| Group | `GroupStore.kt` | Persistence seam. `insertOrUpdate(group): Boolean` returns true on insert / false on update; `markPublished(id, commitment?)` no-ops on missing id. |
| Group | `RoomGroupStore.kt` | Room + `StorageEncryption` boundary. Field-level AES-GCM on encrypted columns; tolerant decode (a corrupt row is skipped, not a crash). Preserves original `createdAt` on update. |
| Group | `GroupRepository.kt` | `Mutex` + `MutableStateFlow<List<ChatGroup>>`. Mirrors `IncomingInvitationsRepository`. Replay-on-subscribe semantics — don't swap for `MutableSharedFlow`. |

## Tyranny only — by design

Per `project_create_group_plan` memory: PR-B ships Tyranny proving only. `OnymGroupProofGenerator.proveCreate` switches on `SepGroupType` and throws `NotYetSupported` for Anarchy / OneOnOne / Democracy / Oligarchy. PR-C's UI surfaces this as a clear "TBD" rather than a silent fallback. Wiring the other types here without a UI to drive them just accumulates dead code.

## Three Android-specific gotchas (from the brief)

1. **Tier→depth.** `SepTier.depth` is already exposed on the enum (small=5, medium=8, large=11) from PR-A, so the proof generator passes `input.tier.depth` straight through.
2. **Room can't store `ULong`.** `PersistedGroup.epoch` is `Long`; `RoomGroupStore` round-trips via `toLong()` / `toULong()`. The relayer JSON layer is what cares about unsigned semantics, and that's already covered in `SepContractTypes` from PR-A.
3. **`StorageEncryption.encrypt` may throw.** The encode path propagates (any throw bubbles out of `insertOrUpdate`); no plaintext-fallback. Decode is tolerant — a bad row is skipped, not a crash, mirroring the iOS `guard let … else { return nil }` ladder.

## Architecture compliance

- `GroupProofGenerator` imports `chat.onym.sdk.*` only — no Room, no OkHttp.
- `RoomGroupStore` imports `androidx.room.*` + `StorageEncryption` only.
- `GroupRepository` holds `GroupStore` only — no SDK, no OkHttp, no Room.
- All three live in their respective packages (`chain/`, `group/`); no cross-package leakage.

## Test plan

- [x] `:app:assembleDebug` — production compiles
- [x] `:app:testDebugUnitTest --tests 'chat.onym.android.chain.GroupProofGeneratorTest' --tests 'chat.onym.android.group.*Test'` — 4 + 5 + 8 unit tests pass (PR-B's contributions plus PR-A's `ChatGroupTest` + `GroupCommitmentBuilderTest` re-run as a sanity check)
- [x] `:app:compileDebugAndroidTestKotlin` — instrumented sources compile (1 `GroupProofGeneratorFfiTest` for the real ~3.5s Tyranny prove)
- [ ] CI's full sweep
- [ ] `:app:connectedDebugAndroidTest --tests 'chat.onym.android.chain.GroupProofGeneratorFfiTest'` — needs an emulator; covers the real prove + parse + commitment slice

## Out of scope (PR-B)

- Wiring into `OnymApplication` / `AppDependencies` — lands in PR-C.
- The `CreateGroupInteractor` orchestration (proveCreate → relayer POST → `repository.insert` → `markPublished` → invitation send) — PR-C.
- All Compose UI — PR-C.
- Anarchy / OneOnOne / Democracy / Oligarchy proof methods — stubbed with `NotYetSupported`; ship in their own slice.
- `update_commitment` proof generation — comes with the chat-screen slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)