### PR TITLE
fix: bootstrap identity on launch + bundle relayer Bearer auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,18 @@ name: Release
 #   ANDROID_KEYSTORE_PASSWORD  — keystore password
 #   ANDROID_KEY_ALIAS          — alias inside the keystore
 #   ANDROID_KEY_PASSWORD       — password for that alias
+#   RELAYER_AUTH_TOKEN         — Bearer token the relayer's
+#                                 `validate_auth` requires on every
+#                                 contract-call POST. Inlined into
+#                                 `BuildConfig.RELAYER_AUTH_TOKEN` at
+#                                 assembleRelease and consumed at
+#                                 runtime by `BearerAuthInterceptor`.
+#                                 Without this secret, release builds
+#                                 still compile but every relayer call
+#                                 401s with "missing bearer" (the
+#                                 interceptor skips the header on a
+#                                 blank token rather than sending
+#                                 `Bearer ""`).
 
 on:
   workflow_dispatch:
@@ -210,6 +222,15 @@ jobs:
         # Produces app/build/outputs/apk/release/app-release-unsigned.apk
         # (no signingConfig is declared on the release buildType, so
         # AGP emits an unsigned APK rather than failing the build).
+        #
+        # RELAYER_AUTH_TOKEN is consumed by `relayerAuthToken()` in
+        # `app/build.gradle.kts` and inlined into BuildConfig at
+        # compile time; runtime `BearerAuthInterceptor` reads it from
+        # `BuildConfig.RELAYER_AUTH_TOKEN`. Required new repo secret
+        # — without it, release builds compile and ship but every
+        # relayer call 401s with "missing bearer".
+        env:
+          RELAYER_AUTH_TOKEN: ${{ secrets.RELAYER_AUTH_TOKEN }}
         run: ./gradlew :app:assembleRelease --no-daemon
 
       - name: Locate + rename APK

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -28,6 +30,19 @@ android {
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
         }
+
+        // Bearer token the relayer's `validate_auth` requires on every
+        // POST. Sourced from (in order):
+        //   1. ENV `RELAYER_AUTH_TOKEN` — release CI passes the GitHub
+        //      Actions secret here.
+        //   2. `local.properties` `relayer.authToken=…` — local dev
+        //      (gitignored).
+        //   3. Empty string — build still succeeds; the relayer 401s
+        //      every call with a clear message, surfacing the missing
+        //      config to the dev rather than failing silently.
+        // See `OnymApplication.buildDependencies` for the OkHttp
+        // interceptor that consumes this.
+        buildConfigField("String", "RELAYER_AUTH_TOKEN", "\"${relayerAuthToken()}\"")
     }
 
     buildTypes {
@@ -50,6 +65,9 @@ android {
 
     buildFeatures {
         compose = true
+        // AGP 8 disabled BuildConfig generation by default — we
+        // re-enable it to surface RELAYER_AUTH_TOKEN to runtime.
+        buildConfig = true
     }
 
     // Lint hard-gates the build on missing localizations: every string
@@ -181,4 +199,32 @@ dependencies {
     // without a real Activity from main code. Required by Compose UI
     // tests that don't use `createAndroidComposeRule<MyActivity>`.
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+/**
+ * Resolves the relayer Bearer token at configuration time.
+ *
+ * Resolution order:
+ *  1. Environment variable `RELAYER_AUTH_TOKEN` (release CI passes
+ *     `${{ secrets.RELAYER_AUTH_TOKEN }}` through this).
+ *  2. `local.properties` `relayer.authToken=…` (local dev — the file
+ *     is gitignored so the token never gets committed).
+ *  3. Empty string — the build still succeeds, but every relayer
+ *     call 401s with a clear message. The
+ *     `BearerAuthInterceptor.takeIf { it.isNotBlank() }` guard skips
+ *     the `Authorization` header entirely on empty so the failure is
+ *     "no header" (relayer's `validate_auth` says so) rather than
+ *     `Bearer ""` (more confusing).
+ *
+ * Mirrors the iOS `RelayerSecrets` resolution flow from PR #28 —
+ * different storage primitives (UserDefaults / Info.plist over there;
+ * `BuildConfig` here) but same precedence + fallback story.
+ */
+fun relayerAuthToken(): String {
+    System.getenv("RELAYER_AUTH_TOKEN")?.takeIf { it.isNotBlank() }?.let { return it }
+    val props = Properties().apply {
+        val f = rootProject.file("local.properties")
+        if (f.exists()) f.inputStream().use { load(it) }
+    }
+    return props.getProperty("relayer.authToken").orEmpty()
 }

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -9,8 +9,10 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.fragment.app.FragmentActivity
 import androidx.room.Room
+import chat.onym.android.chain.BearerAuthInterceptor
 import chat.onym.android.chain.ContractsRepository
 import chat.onym.android.chain.DataStoreNetworkPreferenceProvider
+import chat.onym.android.chain.OkHttpSepContractTransport
 import chat.onym.android.chain.DataStorePreferencesAnchorSelectionStore
 import chat.onym.android.chain.DataStorePreferencesRelayerSelectionStore
 import chat.onym.android.chain.GitHubReleasesContractsManifestFetcher
@@ -157,11 +159,37 @@ class OnymApplication : Application() {
         val identityRepository = IdentityRepository(
             store = IdentitySecretStore(applicationContext),
         )
+        // Eager bootstrap (PR-28 follow-up). Without this, the first
+        // Create Group attempt on a fresh install fails with
+        // `MissingIdentity` because the identity is loaded lazily by
+        // whichever flow asks for it first — typically the Backup
+        // screen, but the user can hit Create Group before opening
+        // Backup. Idempotent: a second `bootstrap()` is a no-op.
+        // Failure is silent — the next operation that needs identity
+        // surfaces a clean error (`IdentityNotLoaded`).
+        applicationScope.launch {
+            runCatching { identityRepository.bootstrap() }
+        }
         val nostrSignerProvider = OnymNostrSignerProvider()
         val clipboard = AndroidClipboardWriter(applicationContext)
         val strings = AndroidStringProvider(applicationContext)
 
-        val httpClient = OkHttpClient()
+        // Single OkHttpClient with the relayer Bearer auth
+        // interceptor installed once. The relayer's `validate_auth`
+        // requires the header on every contract-call POST; the
+        // interceptor adds it transparently so callers (relayer
+        // fetcher, contracts manifest fetcher, SEP contract client)
+        // don't have to know about the token.
+        //
+        // `takeIf { isNotBlank() }` keeps the dev experience honest:
+        // if `local.properties` is missing the token, no header is
+        // added (relayer 401s with a clear message) instead of
+        // `Authorization: Bearer ""` (also 401, but more confusing).
+        val httpClient = OkHttpClient.Builder()
+            .addInterceptor(BearerAuthInterceptor(
+                token = BuildConfig.RELAYER_AUTH_TOKEN.takeIf { it.isNotBlank() },
+            ))
+            .build()
 
         // Relayer wiring (PR #17). Bootstrap loads cached + selection
         // from disk; start() fires the network fetch. Both run on the
@@ -286,6 +314,18 @@ class OnymApplication : Application() {
                     contracts = contractsRepository,
                     groups = groupRepository,
                     networkPreference = networkPreference,
+                    // Use the shared httpClient (with the
+                    // BearerAuthInterceptor installed) so the
+                    // create-group call carries the token. Without
+                    // this override the interactor's default builds a
+                    // fresh OkHttpClient() per call with no auth
+                    // wired in — relayer 401s every request.
+                    makeContractTransport = { url ->
+                        OkHttpSepContractTransport(
+                            httpClient = httpClient,
+                            endpointUrl = url,
+                        )
+                    },
                     inboxTransport = inboxTransport,
                 )
                 CreateGroupViewModel(

--- a/app/src/main/kotlin/chat/onym/android/chain/BearerAuthInterceptor.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/BearerAuthInterceptor.kt
@@ -1,0 +1,37 @@
+package chat.onym.android.chain
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Adds `Authorization: Bearer <token>` to every outbound request
+ * when [token] is non-null and non-blank. The relayer's
+ * `validate_auth` (`onym-relayer/src/validation.rs`) requires this
+ * header on every contract-call POST; without it, every request 401s.
+ *
+ * The "skip when blank" guard is deliberate — if a dev clones the
+ * repo without pasting `relayer.authToken=…` into `local.properties`,
+ * the empty `BuildConfig.RELAYER_AUTH_TOKEN` would otherwise produce
+ * `Authorization: Bearer ` on the wire. The relayer rejects both, but
+ * "no Authorization header" is a clearer failure signal than `Bearer ""`.
+ *
+ * Idempotent: requests that already carry an `Authorization` header
+ * (e.g. some future auth flow we haven't designed yet) are passed
+ * through untouched.
+ *
+ * Mirrors `BearerAuthInterceptor` from onym-ios PR #28.
+ */
+class BearerAuthInterceptor(private val token: String?) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val withAuth = if (!token.isNullOrBlank() && request.header("Authorization") == null) {
+            request.newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else {
+            request
+        }
+        return chain.proceed(withAuth)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
@@ -250,6 +250,80 @@ class SepContractClientTest {
         assertNotNull(obj["payload"])
     }
 
+    // ─── BearerAuthInterceptor wiring (PR-28 follow-up) ────────────
+
+    @Test
+    fun bearerAuth_addsAuthorizationHeader_whenTokenSet() = runTest {
+        var capturedAuthHeader: String? = null
+        val httpClient = okhttp3.OkHttpClient.Builder()
+            .addInterceptor(BearerAuthInterceptor(token = "deadbeefcafef00d"))
+            .addInterceptor { chain ->
+                capturedAuthHeader = chain.request().header("Authorization")
+                FakeOkHttpClient.ok(chain.request(), """{"accepted":true}""")
+            }
+            .build()
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.TYRANNY,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        client.createGroupTyranny(stubPayload())
+
+        assertEquals("Bearer deadbeefcafef00d", capturedAuthHeader)
+    }
+
+    @Test
+    fun bearerAuth_omitsAuthorizationHeader_whenTokenNullOrBlank() = runTest {
+        var capturedAuthHeader: String? = "<unset-sentinel>"
+        val httpClient = okhttp3.OkHttpClient.Builder()
+            .addInterceptor(BearerAuthInterceptor(token = null))
+            .addInterceptor { chain ->
+                capturedAuthHeader = chain.request().header("Authorization")
+                FakeOkHttpClient.ok(chain.request(), """{"accepted":true}""")
+            }
+            .build()
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.TYRANNY,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        client.createGroupTyranny(stubPayload())
+
+        // No Authorization header — relayer 401s with a clear "missing
+        // bearer" message rather than `Bearer ""` (also 401, more
+        // confusing).
+        org.junit.Assert.assertNull(capturedAuthHeader)
+    }
+
+    @Test
+    fun bearerAuth_omitsAuthorizationHeader_whenTokenIsBlank() = runTest {
+        var capturedAuthHeader: String? = "<unset-sentinel>"
+        val httpClient = okhttp3.OkHttpClient.Builder()
+            .addInterceptor(BearerAuthInterceptor(token = "   "))
+            .addInterceptor { chain ->
+                capturedAuthHeader = chain.request().header("Authorization")
+                FakeOkHttpClient.ok(chain.request(), """{"accepted":true}""")
+            }
+            .build()
+        val transport = OkHttpSepContractTransport(httpClient, "https://r.example/c")
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.TYRANNY,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        client.createGroupTyranny(stubPayload())
+
+        org.junit.Assert.assertNull(capturedAuthHeader)
+    }
+
     // ─── error sentinel sanity ─────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Two fixes uncovered when actually trying the Create Group flow on a fresh install. Mirrors onymchat/onym-ios#28.

## TL;DR

| # | Fix | Surface |
|---|---|---|
| 1 | **Eager identity bootstrap** | `OnymApplication.buildDependencies` calls `IdentityRepository.bootstrap()` so flows that need identity don't fail with `IdentityNotLoaded` on first launch |
| 2 | **Relayer Bearer auth** | OkHttp `BearerAuthInterceptor` adds `Authorization: Bearer <token>` from `BuildConfig.RELAYER_AUTH_TOKEN`; sourced from gitignored `local.properties` for dev + GitHub Actions secret for release |

## 1. Eager identity bootstrap

Previously the identity was loaded lazily by whichever flow asked for it first — typically the Backup screen, but the user can hit Create Group before opening Backup. The interactor would then fail with `CreateGroupError.MissingIdentity`.

`OnymApplication.buildDependencies` now does `applicationScope.launch { runCatching { identityRepository.bootstrap() } }` right after constructing the repository. Idempotent (a second call after success is a no-op); failure is silent (the next operation that needs identity surfaces a clean `IdentityNotLoaded`).

## 2. Relayer Bearer auth

The relayer's `validate_auth` (`onym-relayer/src/validation.rs`) requires `Authorization: Bearer <token>` on every contract-call POST. PR-C through PR-C-followup shipped without it, so every Create Group attempt 401s.

**Build-time wiring** — `app/build.gradle.kts` adds `buildConfigField(\"String\", \"RELAYER_AUTH_TOKEN\", ...)` + enables `buildFeatures { buildConfig = true }`. The `relayerAuthToken()` helper resolves the token from (in order):

1. ENV `RELAYER_AUTH_TOKEN` — release CI passes the GitHub Actions secret here.
2. `local.properties` `relayer.authToken=…` — local dev (file is gitignored at `.gitignore` line 13).
3. Empty string — build still succeeds; the relayer 401s every call with a clear message rather than failing silently.

**Runtime wiring** — new `chain/BearerAuthInterceptor.kt` adds the header transparently. The `takeIf { it.isNotBlank() }` guard skips the header entirely on a blank token (clean \"missing bearer\" 401 instead of `Bearer \"\"` which is also 401 but more confusing).

`OnymApplication`'s shared `OkHttpClient` (used by the relayer fetcher + contracts manifest fetcher) gets the interceptor in its builder. The create-group path's `makeContractTransport` factory is overridden in the same place to reuse the shared client — without this override the interactor's default builds a fresh `OkHttpClient()` per call with no auth wired in.

## Tests

3 new cases in `SepContractClientTest`:

- `bearerAuth_addsAuthorizationHeader_whenTokenSet` — `Bearer <token>` on the captured request.
- `bearerAuth_omitsAuthorizationHeader_whenTokenNullOrBlank` — no header sent on null token.
- `bearerAuth_omitsAuthorizationHeader_whenTokenIsBlank` — same for whitespace-only token (the `local.properties` typo case).

No new test for the identity bootstrap — it's a one-liner exercised by every UI test launching the app.

## Required action before merging

**Add `RELAYER_AUTH_TOKEN` to GitHub Actions repo secrets.** Without it:
- Local dev builds work fine if the dev pasted the token into `local.properties`.
- Release builds compile + ship, but the bundled token is empty → relayer 401s every call → Create Group surfaces a clean error.

## Test plan

- [x] `:app:assembleDebug` — production compiles + `BuildConfig.RELAYER_AUTH_TOKEN` lands in the generated source
- [x] `:app:testDebugUnitTest --tests 'chat.onym.android.chain.*'` — 3 new + existing client tests all green
- [x] `:app:compileDebugAndroidTestKotlin` — instrumented sources still compile
- [x] `python3 scripts/lint-secrets.py` — clean
- [x] Confirmed `local.properties` is gitignored + token is NOT in the staged diff
- [ ] CI's full sweep
- [ ] On-device smoke: cold install → Create Group → relayer accepts (no 401)

## Out of scope

- Token rotation / per-environment tokens. Relayer accepts a set of valid tokens; we ship one. Extend `BuildConfig` to a map if/when we need that.
- Encrypting the token at rest in the APK. Low-value secret (relayer rate-limits + IP-throttles regardless); standard `BuildConfig` string inline at compile time is fine for this threat model — same as iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)