### PR TITLE
ux: scrollable + selectable error banner on Creating screen

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -32,6 +34,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -643,12 +646,33 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                     modifier = Modifier.padding(14.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Text(
-                        text = state.error?.message ?: "Couldn't create the group",
-                        color = OnymTokens.Red,
-                        style = TextStyle(fontSize = 13.sp),
-                        textAlign = TextAlign.Center,
-                    )
+                    // Soroban diagnostic chains can be 500+ chars
+                    // (proof-verify failures spell out the contract
+                    // IDs + error codes + bytes payloads); cap the
+                    // banner height so the Cancel/Try again row stays
+                    // visible. Monospaced + left-aligned for hex
+                    // readability; SelectionContainer lets the user
+                    // long-press to copy into a bug report.
+                    // Mirrors onym-ios PR #29.
+                    SelectionContainer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 200.dp)
+                            .verticalScroll(rememberScrollState()),
+                    ) {
+                        Text(
+                            text = state.error?.message ?: "Couldn't create the group",
+                            color = OnymTokens.Red,
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                fontFamily = FontFamily.Monospace,
+                            ),
+                            textAlign = TextAlign.Start,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                        )
+                    }
                     Spacer(Modifier.height(12.dp))
                     Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                         // Cancel — closes the whole flow. Mirrors the


### PR DESCRIPTION
## Summary

Soroban diagnostic chains can be 500+ chars (proof-verify failures spell out the contract IDs + error codes + bytes payloads). The center-aligned single `Text` was eating the whole bottom of the screen and pushing the Cancel/Try-again row below the fold.

Three small tweaks:

- Wrap the error `Text` in a `verticalScroll` capped at **200dp**.
- Switch to **monospaced + left-aligned** for hex/diagnostic readability.
- Wrap in `SelectionContainer` so the user can long-press to copy the message into a bug report (Compose equivalent of iOS's `.textSelection(.enabled)`).

Mirrors onymchat/onym-ios#29.

## Before / after

Before: the diagnostic text wrapped center-aligned and grew downward off-screen, pushing the Cancel/Try-again buttons below the fold.

After: the diagnostic stays inside a 200dp scrollable region; the action buttons remain visible right under it; long-press selects the text for copy.

## Test plan

- [x] `:app:assembleDebug` — builds clean
- [ ] Manual: reproduce a 502 with a bad relayer payload → error banner shows the full text scrollable, Cancel + Try again remain reachable, long-press shows the system Copy menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)