### PR TITLE
ux: Chats tab + relocate Create Group entry from Settings

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -2,6 +2,7 @@ package chat.onym.android
 
 import androidx.fragment.app.FragmentActivity
 import chat.onym.android.chain.NetworkPreferenceProvider
+import chat.onym.android.chats.ChatsViewModel
 import chat.onym.android.group.CreateGroupViewModel
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.settings.AnchorsPickerViewModel
@@ -41,4 +42,7 @@ class AppDependencies(
      *  bound to this; CreateGroupInteractor reads it per call. */
     val networkPreferenceProvider: NetworkPreferenceProvider,
     val makeCreateGroupViewModel: () -> CreateGroupViewModel,
+    /** Chats tab — read-only view over [chat.onym.android.group.GroupRepository.snapshots].
+     *  Mirrors `makeChatsFlow` from onym-ios PR #30. */
+    val makeChatsViewModel: () -> ChatsViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -334,6 +334,9 @@ class OnymApplication : Application() {
                     },
                 )
             },
+            makeChatsViewModel = {
+                chat.onym.android.chats.ChatsViewModel(repository = groupRepository)
+            },
         )
     }
 

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -2,6 +2,7 @@ package chat.onym.android
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
@@ -27,6 +28,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import chat.onym.android.chain.ContractNetwork
 import chat.onym.android.chain.GovernanceType
+import chat.onym.android.chats.ChatsScreen
+import chat.onym.android.chats.ChatsViewModel
 import chat.onym.android.group.CreateGroupViewModel
 import chat.onym.android.group.creategroup.CreateGroupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
@@ -107,9 +110,20 @@ fun RootScreen(dependencies: AppDependencies) {
     ) { padding ->
         NavHost(
             navController = navController,
-            startDestination = Tab.Settings.route,
+            startDestination = Tab.Chats.route,
             modifier = androidx.compose.ui.Modifier.padding(padding),
         ) {
+            composable(Tab.Chats.route) {
+                val vm: ChatsViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeChatsViewModel() }
+                    },
+                )
+                ChatsScreen(
+                    viewModel = vm,
+                    onCreateGroup = { navController.navigate(ROUTE_CREATE_GROUP) },
+                )
+            }
             composable(Tab.Settings.route) {
                 val networkFlow = remember(dependencies) {
                     dependencies.networkPreferenceProvider.flow
@@ -122,7 +136,6 @@ fun RootScreen(dependencies: AppDependencies) {
                     onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
                     onRelayerClick = { navController.navigate(ROUTE_RELAYER_SETTINGS) },
                     onAnchorsClick = { navController.navigate(ROUTE_ANCHORS_ROOT) },
-                    onCreateGroupClick = { navController.navigate(ROUTE_CREATE_GROUP) },
                     useMainnet = networkPref == chat.onym.android.chain.AppNetwork.Mainnet,
                     onToggleMainnet = { on ->
                         coroutineScope.launch {
@@ -230,11 +243,14 @@ fun RootScreen(dependencies: AppDependencies) {
 }
 
 private enum class Tab(val route: String, val labelRes: Int) {
+    // Chats is the leftmost + default tab post-PR-30.
+    Chats("chats", R.string.chats_tab),
     Settings("settings", R.string.settings),
     Search("search", R.string.search);
 
     @Composable
     fun icon() = when (this) {
+        Chats -> Icons.Filled.Forum
         Settings -> Icons.Filled.Settings
         Search -> Icons.Filled.Search
     }
@@ -244,4 +260,4 @@ private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"
-private val TAB_ROUTES = setOf(Tab.Settings.route, Tab.Search.route)
+private val TAB_ROUTES = setOf(Tab.Chats.route, Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
@@ -1,0 +1,236 @@
+package chat.onym.android.chats
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.OnymAccent
+import chat.onym.android.group.OnymGroupAvatar
+
+/**
+ * Chats tab — root list of groups the user has created. PR-C only
+ * supports Tyranny groups; this list is whatever
+ * [chat.onym.android.group.GroupRepository.snapshots] emits. Tapping
+ * a row is a no-op for now (chat screen is a future slice). The
+ * empty-state CTA + the toolbar plus button are the only entry
+ * points to Create Group.
+ *
+ * Mirrors `ChatsView` from onym-ios PR #30.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatsScreen(
+    viewModel: ChatsViewModel,
+    onCreateGroup: () -> Unit,
+) {
+    val groups by viewModel.groups.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.chats_title)) },
+                actions = {
+                    // Plus button mirrors Mail / Messages — useful
+                    // once the user has at least one chat. Hidden in
+                    // the empty state because the central CTA already
+                    // covers it.
+                    if (groups.isNotEmpty()) {
+                        IconButton(
+                            onClick = onCreateGroup,
+                            modifier = Modifier.testTag("chats.create_group_toolbar"),
+                        ) {
+                            Icon(
+                                Icons.Outlined.Edit,
+                                contentDescription = stringResource(R.string.chats_create_group),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        if (groups.isEmpty()) {
+            EmptyState(padding = padding, onCreateGroup = onCreateGroup)
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+            ) {
+                items(groups, key = { it.id }) { group ->
+                    ChatsRow(group = group, onClick = { /* TODO: chat screen */ })
+                    HorizontalDivider(thickness = 0.5.dp)
+                }
+            }
+        }
+    }
+}
+
+// ─── Empty state ────────────────────────────────────────────────
+
+@Composable
+private fun EmptyState(
+    padding: PaddingValues,
+    onCreateGroup: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .padding(padding)
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(88.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.10f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.Forum,
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Spacer(Modifier.height(18.dp))
+        Text(
+            text = stringResource(R.string.chats_empty_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = stringResource(R.string.chats_empty_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(20.dp))
+        Button(
+            onClick = onCreateGroup,
+            modifier = Modifier
+                .heightIn(min = 50.dp)
+                .widthIn(min = 220.dp)
+                .testTag("chats.create_group_empty_cta"),
+        ) {
+            Text(
+                text = stringResource(R.string.chats_create_group),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+// ─── Row ────────────────────────────────────────────────────────
+
+@Composable
+private fun ChatsRow(
+    group: ChatGroup,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .testTag("chats.row.${group.id}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Reuse the broken-ring brand mark as the per-chat avatar —
+        // same identity the user saw on the Create Group hero. Once
+        // group avatars / uploads ship, this becomes the
+        // image-or-mark fallback.
+        OnymGroupAvatar(size = 44.dp, accent = OnymAccent.Blue.color)
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = group.name.ifEmpty { stringResource(R.string.chats_unnamed_group) },
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+            )
+            Text(
+                text = subtitleFor(group),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+
+        if (group.isPublishedOnChain) {
+            Icon(
+                Icons.Filled.Verified,
+                contentDescription = stringResource(R.string.chats_published_on_chain),
+                tint = Color(0xFF34C759),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun subtitleFor(group: ChatGroup): String {
+    val label = when (group.groupType) {
+        SepGroupType.TYRANNY -> "Tyranny"
+        SepGroupType.ANARCHY -> "Anarchy"
+        SepGroupType.ONE_ON_ONE -> "1-on-1"
+        SepGroupType.DEMOCRACY -> "Democracy"
+        SepGroupType.OLIGARCHY -> "Oligarchy"
+    }
+    val now = System.currentTimeMillis()
+    val relative = DateUtils.getRelativeTimeSpanString(
+        group.createdAtMillis,
+        now,
+        DateUtils.MINUTE_IN_MILLIS,
+        DateUtils.FORMAT_ABBREV_RELATIVE,
+    ).toString()
+    return "$label · $relative"
+}

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatsViewModel.kt
@@ -1,0 +1,37 @@
+package chat.onym.android.chats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GroupRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Read-only ViewModel for the Chats tab. Drains
+ * [GroupRepository.snapshots] into a [StateFlow] the screen collects
+ * via `collectAsStateWithLifecycle()`. No mutating intents — the
+ * row UI is read-only and the only action ("open Create Group") is
+ * a navigation callback the screen passes up.
+ *
+ * `SharingStarted.WhileSubscribed(5_000)` keeps the upstream
+ * collector alive across short configuration changes (rotation)
+ * without churning the underlying flow. The repository's
+ * [StateFlow] already replays the current value on subscribe, so
+ * the screen always renders something on first composition.
+ *
+ * Mirrors `ChatsFlow` from onym-ios PR #30 (the iOS twin uses an
+ * `Observable @MainActor` driver pumping `AsyncStream`; same role,
+ * Android-idiomatic types).
+ */
+class ChatsViewModel(
+    private val repository: GroupRepository,
+) : ViewModel() {
+
+    val groups: StateFlow<List<ChatGroup>> = repository.snapshots.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = repository.snapshots.value,
+    )
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Cloud
-import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.Icon
@@ -64,7 +63,6 @@ fun SettingsScreen(
     onBackupClick: () -> Unit,
     onRelayerClick: () -> Unit,
     onAnchorsClick: () -> Unit,
-    onCreateGroupClick: () -> Unit,
     /** App-wide network preference. Bound to the Settings → Network
      *  → "Use Mainnet" Switch. */
     useMainnet: Boolean,
@@ -84,44 +82,8 @@ fun SettingsScreen(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
         LazyColumn(contentPadding = padding) {
-            // Groups section — Create Group flow entry point. Mirrors
-            // the iOS PR #26 ordering (Groups first, above Security).
-            item { SectionHeader(stringResource(R.string.settings_groups)) }
-            item {
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.settings_create_group)) },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = Icons.Filled.Group,
-                            background = Color(0xFF34C759),
-                        )
-                    },
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        )
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onCreateGroupClick)
-                        .testTag("settings.create_group_row"),
-                )
-            }
-            item {
-                Text(
-                    stringResource(R.string.settings_groups_footer),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
-                )
-            }
-
+            // Groups section moved to the Chats tab (PR-30) — Settings
+            // now opens straight to the Security section.
             item {
                 SectionHeader(stringResource(R.string.security))
             }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -70,10 +70,14 @@
     <string name="security_footer_view_recovery_phrase">Просмотрите свою фразу восстановления из 12 слов. Она понадобится для восстановления личности на новом устройстве.</string>
     <string name="search_placeholder_body">Поиск появится в одном из следующих обновлений.</string>
 
-    <!-- ─── Settings → Groups section (PR-C of Create Group) ─────── -->
-    <string name="settings_groups">Группы</string>
-    <string name="settings_create_group">Создать группу</string>
-    <string name="settings_groups_footer">Создайте сквозно зашифрованную группу, закреплённую на тестнете Stellar. Сейчас доступна только Тирания.</string>
+    <!-- ─── Chats tab (PR-30) ─────────────────────────────────────── -->
+    <string name="chats_tab">Чаты</string>
+    <string name="chats_title">Чаты</string>
+    <string name="chats_create_group">Создать группу</string>
+    <string name="chats_empty_title">Чатов пока нет</string>
+    <string name="chats_empty_body">Создайте сквозно зашифрованную группу, закреплённую на Stellar.</string>
+    <string name="chats_unnamed_group">(Без названия)</string>
+    <string name="chats_published_on_chain">Опубликовано в блокчейне</string>
 
     <!-- ─── Settings → Network section (umbrella) ────────────────── -->
     <string name="settings_network">Сеть</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,10 +73,14 @@
     <string name="security_footer_view_recovery_phrase">View your 12-word recovery phrase. You will need it to restore your identity on a new device.</string>
     <string name="search_placeholder_body">Search lands in a later chunk.</string>
 
-    <!-- ─── Settings → Groups section (PR-C of Create Group) ─────── -->
-    <string name="settings_groups">Groups</string>
-    <string name="settings_create_group">Create Group</string>
-    <string name="settings_groups_footer">Create an end-to-end encrypted group anchored on Stellar testnet. Only Tyranny is available right now.</string>
+    <!-- ─── Chats tab (PR-30) ─────────────────────────────────────── -->
+    <string name="chats_tab">Chats</string>
+    <string name="chats_title">Chats</string>
+    <string name="chats_create_group">Create Group</string>
+    <string name="chats_empty_title">No chats yet</string>
+    <string name="chats_empty_body">Create an end-to-end encrypted group anchored on Stellar.</string>
+    <string name="chats_unnamed_group">(Unnamed)</string>
+    <string name="chats_published_on_chain">Published on chain</string>
 
     <!-- ─── Settings → Network section (umbrella) ────────────────── -->
     <!-- Mirrors the chain-UI catalog from onym-ios PR #21. -->

--- a/app/src/test/kotlin/chat/onym/android/chats/ChatsViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chats/ChatsViewModelTest.kt
@@ -1,0 +1,99 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.chats
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GroupRepository
+import chat.onym.android.support.InMemoryGroupStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [ChatsViewModel]. Backed by [InMemoryGroupStore] +
+ * a real [GroupRepository] — the in-memory store is the same one
+ * `GroupRepositoryTest` exercises, so these tests verify the VM's
+ * subscribe → re-emit path without standing up Room or
+ * `StorageEncryption`.
+ *
+ * Mirrors the iOS `ChatsFlow` test surface (one-test, two-test
+ * minimum) from onym-ios PR #30.
+ */
+class ChatsViewModelTest {
+
+    @Before fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun groups_startsEmpty_whenRepositoryHasNoRows() = runTest {
+        val store = InMemoryGroupStore()
+        val repository = GroupRepository(store)
+        repository.reload()
+
+        val vm = ChatsViewModel(repository)
+
+        assertEquals(emptyList<ChatGroup>(), vm.groups.value)
+    }
+
+    @Test
+    fun groups_reflectsRepositoryUpdates() = runTest {
+        val store = InMemoryGroupStore()
+        val repository = GroupRepository(store)
+        repository.reload()
+        val vm = ChatsViewModel(repository)
+        // Touch the StateFlow so the subscribe-side collector starts
+        // (SharingStarted.WhileSubscribed). Without `first()` the
+        // upstream wouldn't be active when `insert` fires.
+        vm.groups.first()
+
+        repository.insert(makeGroup(id = "aa".repeat(32), name = "Friends"))
+
+        val snapshot = vm.groups.value
+        assertEquals(1, snapshot.size)
+        assertEquals("Friends", snapshot.single().name)
+        assertTrue("group is unpublished by default", !snapshot.single().isPublishedOnChain)
+    }
+
+    @Test
+    fun groups_sortedByCreatedAtDescending() = runTest {
+        val store = InMemoryGroupStore()
+        val repository = GroupRepository(store)
+        repository.insert(makeGroup(id = "01".repeat(32), name = "older", createdAtMillis = 1_700_000_000_000L))
+        repository.insert(makeGroup(id = "02".repeat(32), name = "newer", createdAtMillis = 1_700_000_500_000L))
+        repository.reload()
+
+        val vm = ChatsViewModel(repository)
+        val snapshot = vm.groups.first()
+
+        assertEquals(listOf("newer", "older"), snapshot.map { it.name })
+    }
+
+    private fun makeGroup(
+        id: String,
+        name: String,
+        createdAtMillis: Long = 1_700_000_000_000L,
+    ) = ChatGroup(
+        id = id,
+        name = name,
+        groupSecret = ByteArray(32),
+        createdAtMillis = createdAtMillis,
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32),
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = null,
+        isPublishedOnChain = false,
+    )
+}


### PR DESCRIPTION
Mirrors onymchat/onym-ios#30. Same UX shift: add a leftmost Chats tab listing the user's created groups, move the Create Group entry point there, drop the duplicate row from Settings.

## TL;DR

| What | Before | After |
|---|---|---|
| Tabs | Settings (left, default), Search (right) | **Chats** (left, default), Settings, Search |
| Create Group entry | Settings → Groups section row | Chats tab — empty-state CTA + toolbar plus button when populated |
| Group list view | Doesn't exist | `ChatsScreen` reading from `GroupRepository` |

## What lands

- `chats/ChatsViewModel.kt` — `StateFlow<List<ChatGroup>>` from `GroupRepository.snapshots.stateIn(viewModelScope, WhileSubscribed(5_000), …)`. Read-only — no mutating intents.
- `chats/ChatsScreen.kt` — TopAppBar with conditional plus IconButton when groups non-empty; LazyColumn of `ChatsRow` (OnymMark avatar + name + \"Tyranny · 2 hr ago\" subtitle + green Verified seal when `isPublishedOnChain`); centered `EmptyState` with the \"Create Group\" CTA. Tap on a row is a no-op (chat screen is a future slice).
- `RootScreen.kt` — Chats added as the leftmost + start destination; `chats` tab + 3-tab `Tab` enum + updated `TAB_ROUTES` set + bottom bar icon `Icons.Filled.Forum`.
- `SettingsScreen.kt` — Groups section + `onCreateGroupClick` param removed. Settings opens straight to Security now.
- `AppDependencies` + `OnymApplication` — new `makeChatsViewModel` factory closure; `makeCreateGroupViewModel` stays (the Chats CTA + toolbar button still navigate to the existing `create_group` route).
- `res/values/strings.xml` + `values-ru/strings.xml` — added 7 new `chats_*` keys (en + ru); dropped 3 dead `settings_groups*` keys.

## Stack mappings

| iOS | Android |
|---|---|
| `TabView` + `Tab(value:)` | `NavigationBar` + `NavigationBarItem` (existing pattern from PR #6 RootScreen) |
| `@Observable @MainActor ChatsFlow` draining `AsyncStream` | `ViewModel` exposing `StateFlow<List<ChatGroup>>` collected from `GroupRepository.snapshots` |
| `RelativeDateTimeFormatter` | `android.text.format.DateUtils.getRelativeTimeSpanString` |
| `Image(systemName: \"checkmark.seal.fill\")` | `Icon(Icons.Filled.Verified, …)` |
| `Image(systemName: \"bubble.left.and.bubble.right.fill\")` (empty hero) | `Icon(Icons.Filled.Forum, …)` |
| `.fullScreenCover` for Create Group | Existing Compose Navigation `composable(\"create_group\")` route from PR-C — no `Dialog` needed |

## Test plan

- [x] `:app:assembleDebug` — production compiles
- [x] `:app:testDebugUnitTest --tests 'chat.onym.android.chats.*'` — 3 cases pass (empty start, reflects updates, sorts by createdAt desc)
- [x] `:app:compileDebugAndroidTestKotlin` — instrumented sources still compile
- [x] `python3 scripts/lint-secrets.py` — clean
- [ ] CI's full sweep
- [ ] On-device smoke: cold install → opens to Chats tab → empty state CTA tap → Create Group → success → return to Chats with the new row + on-chain checkmark

## Out of scope

- Chat screen (tap on a row is a no-op; lands in a future slice).
- Group avatar uploads — broken-ring brand mark stays as the placeholder.
- Search tab content — still placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)