### PR TITLE
ux: light + dark theme support across Create Group flow

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -154,7 +154,14 @@ fun RootScreen(dependencies: AppDependencies) {
                     },
                 )
                 vm.onClose = { navController.popBackStack() }
-                CreateGroupScreen(viewModel = vm)
+                // OnymTheme provides LocalOnymTokens (light or dark
+                // bundle picked off `isSystemInDarkTheme()`) so every
+                // CreateGroup* screen reads the right surface family.
+                // Chats / Settings tabs already adapt via Material's
+                // colorScheme and don't need this wrapper.
+                chat.onym.android.group.OnymTheme {
+                    CreateGroupScreen(viewModel = vm)
+                }
             }
             composable(Tab.Search.route) {
                 SearchScreen()

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
@@ -188,7 +188,7 @@ private fun ChatsRow(
         // same identity the user saw on the Create Group hero. Once
         // group avatars / uploads ship, this becomes the
         // image-or-mark fallback.
-        OnymGroupAvatar(size = 44.dp, accent = OnymAccent.Blue.color)
+        OnymGroupAvatar(size = 44.dp, accent = OnymAccent.Blue.color())
 
         Column(modifier = Modifier.weight(1f)) {
             Text(

--- a/app/src/main/kotlin/chat/onym/android/group/OnymBrand.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/OnymBrand.kt
@@ -7,13 +7,21 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,40 +40,139 @@ import kotlin.math.sin
 // ─── Tokens ──────────────────────────────────────────────────────
 
 /**
- * Dark-theme design tokens for the Create Group flow. Mirrors
- * `OnymTokens` in `OnymBrand.swift` from onym-ios PR #26. Light
- * theme will land later; PR-C ships dark only.
+ * Per-theme design-token bundle for the Create Group flow. Two
+ * pre-built variants live in the companion ([Light] / [Dark]); the
+ * active set is provided at the root by [OnymTheme] and read by
+ * descendant Composables via `LocalOnymTokens.current.X`.
+ *
+ * Lifted from the design's `app.jsx` `THEMES.{light,dark}` block —
+ * same source iOS used. Mirrors `OnymTokens` in `OnymBrand.swift`
+ * from onym-ios PR #31 (the rewrite that flipped from a static
+ * dark-only palette to the dual data class).
  */
-object OnymTokens {
-    val Bg = Color(0xFF000000)
-    val Surface = Color(0xFF0E0E10)
-    val Surface2 = Color(0xFF17171A)
-    val Surface3 = Color(0xFF1F1F23)
-    val Text = Color(0xFFF2F2F4)
-    val Text2 = Color(0xFFF2F2F4).copy(alpha = 0.62f)
-    val Text3 = Color(0xFFF2F2F4).copy(alpha = 0.40f)
-    val Hairline = Color.White.copy(alpha = 0.07f)
-    val HairlineStrong = Color.White.copy(alpha = 0.12f)
-    val Green = Color(0xFF34C759)
-    val Red = Color(0xFFFF453A)
+@Immutable
+data class OnymTokens(
+    val bg: Color,
+    val surface: Color,
+    val surface2: Color,
+    val surface3: Color,
+    val text: Color,
+    val text2: Color,
+    val text3: Color,
+    val hairline: Color,
+    val hairlineStrong: Color,
+    val green: Color,
+    val red: Color,
+    /** Reads on accent fills (button labels, the tyranny crown's
+     *  centre pip, etc.). White on light, black on dark. */
+    val onAccent: Color,
+) {
+    companion object {
+        val Light: OnymTokens = OnymTokens(
+            bg              = Color(0xFFFFFFFF),
+            surface         = Color(0xFFF5F5F7),
+            surface2        = Color(0xFFFFFFFF),
+            surface3        = Color(0xFFEBEBEF),
+            text            = Color(0xFF0A0A0C),
+            text2           = Color(0xFF0A0A0C).copy(alpha = 0.62f),
+            text3           = Color(0xFF0A0A0C).copy(alpha = 0.42f),
+            hairline        = Color.Black.copy(alpha = 0.06f),
+            hairlineStrong  = Color.Black.copy(alpha = 0.12f),
+            green           = Color(0xFF1FA84A),
+            red             = Color(0xFFE5392E),
+            onAccent        = Color.White,
+        )
 
-    /** Reads on accent fills (button labels, etc.). */
-    val OnAccent: Color = Color.Black
+        val Dark: OnymTokens = OnymTokens(
+            bg              = Color(0xFF000000),
+            surface         = Color(0xFF0E0E10),
+            surface2        = Color(0xFF17171A),
+            surface3        = Color(0xFF1F1F23),
+            text            = Color(0xFFF2F2F4),
+            text2           = Color(0xFFF2F2F4).copy(alpha = 0.62f),
+            text3           = Color(0xFFF2F2F4).copy(alpha = 0.40f),
+            hairline        = Color.White.copy(alpha = 0.07f),
+            hairlineStrong  = Color.White.copy(alpha = 0.12f),
+            green           = Color(0xFF34C759),
+            red             = Color(0xFFFF453A),
+            onAccent        = Color.Black,
+        )
+    }
 }
+
+/**
+ * CompositionLocal carrying the active [OnymTokens] set. Defaults
+ * to [OnymTokens.Dark] so any descendant rendered outside an
+ * [OnymTheme] scope still has a sensible value (and matches the
+ * pre-PR-31 dark-only behaviour).
+ *
+ * `staticCompositionLocalOf` (rather than `compositionLocalOf`) is
+ * correct here — the swap on theme change happens via the root
+ * [OnymTheme]'s `CompositionLocalProvider` re-providing, not via
+ * fine-grained recomposition tracking.
+ */
+val LocalOnymTokens = staticCompositionLocalOf { OnymTokens.Dark }
 
 // ─── Accent palette ──────────────────────────────────────────────
 
 /**
- * The six accent colours the Step1 picker offers. Mirrors
- * `OnymAccent` from onym-ios PR #26.
+ * The six accent colours the Step1 picker offers. Each carries both
+ * a [light] (darker, desaturated for legibility on white surfaces)
+ * and [dark] (saturated, bright for dark surfaces) variant; the
+ * active variant is resolved per-call by [color] based on the
+ * provided [LocalOnymTokens] (so a forced theme override propagates
+ * the same way a system theme change does).
+ *
+ * Light/dark hex values lifted from the design's `app.jsx`
+ * `THEMES.{light,dark}.accents` blocks. Mirrors `OnymAccent` from
+ * onym-ios PR #31.
  */
-enum class OnymAccent(val color: Color) {
-    Orange(Color(0xFFFF7A45)),
-    Blue(Color(0xFF3FA8FF)),
-    Green(Color(0xFF3DD66E)),
-    Purple(Color(0xFFB278FF)),
-    Pink(Color(0xFFFF4D6D)),
-    Yellow(Color(0xFFFFC93C)),
+enum class OnymAccent(private val light: Color, private val dark: Color) {
+    Orange(Color(0xFFE85F2A), Color(0xFFFF7A45)),
+    Blue  (Color(0xFF1F86E0), Color(0xFF3FA8FF)),
+    Green (Color(0xFF1FA84A), Color(0xFF3DD66E)),
+    Purple(Color(0xFF8B4DEB), Color(0xFFB278FF)),
+    Pink  (Color(0xFFE03253), Color(0xFFFF4D6D)),
+    Yellow(Color(0xFFD9A400), Color(0xFFFFC93C)),
+    ;
+
+    /** Resolve the active variant against the current
+     *  [LocalOnymTokens]. Identity-checking against
+     *  [OnymTokens.Dark] (rather than [isSystemInDarkTheme]) lets a
+     *  forced-theme override (Settings toggle, Compose preview)
+     *  propagate without an extra branch. */
+    @Composable
+    @ReadOnlyComposable
+    fun color(): Color =
+        if (LocalOnymTokens.current === OnymTokens.Dark) dark else light
+}
+
+// ─── Theme scope ─────────────────────────────────────────────────
+
+/**
+ * Root scope for the Create Group flow. Provides [LocalOnymTokens]
+ * and a matching Material3 `colorScheme` so any nested
+ * `MaterialTheme`-aware widget (TextField cursor, ripple, etc) also
+ * reads the right surface family.
+ *
+ * Wrap the create-group nav route in this; Chats / Settings tabs
+ * already adapt via Material/system colours and don't need it.
+ *
+ * Mirrors the SwiftUI `.preferredColorScheme(_:)` plumbing that iOS
+ * PR #31 added at the `CreateGroupView` root.
+ */
+@Composable
+fun OnymTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val tokens = if (darkTheme) OnymTokens.Dark else OnymTokens.Light
+    CompositionLocalProvider(LocalOnymTokens provides tokens) {
+        MaterialTheme(
+            colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme(),
+            content = content,
+        )
+    }
 }
 
 // ─── OnymMark — broken-ring brand logo ───────────────────────────
@@ -84,7 +191,7 @@ enum class OnymAccent(val color: Color) {
 @Composable
 fun OnymMark(
     size: Dp,
-    color: Color = OnymTokens.Text,
+    color: Color = LocalOnymTokens.current.text,
     strokeRatio: Float = 0.16f,
     spinning: Boolean = false,
     fillOpacity: Float = 0.92f,
@@ -143,7 +250,7 @@ fun OnymMark(
 @Composable
 fun OnymGroupAvatar(
     size: Dp,
-    accent: Color = OnymAccent.Blue.color,
+    accent: Color = OnymAccent.Blue.color(),
     spinning: Boolean = false,
     /** When `true` the mark renders in the accent colour rather than
      *  the neutral text colour — used on the Creating screen. */
@@ -155,7 +262,7 @@ fun OnymGroupAvatar(
     ) {
         OnymMark(
             size = size,
-            color = if (brand) accent else OnymTokens.Text,
+            color = if (brand) accent else LocalOnymTokens.current.text,
             spinning = spinning,
             fillOpacity = if (brand) 1.0f else 0.92f,
         )
@@ -179,7 +286,12 @@ fun OnymGovIcon(
     size: Dp = 44.dp,
     dimmed: Boolean = false,
 ) {
-    val strokeColor = if (dimmed) OnymTokens.Text3 else accent
+    // Resolve theme-dependent colours in the @Composable parent so
+    // the DrawScope helpers below stay pure (no @Composable scope
+    // inside Canvas's draw block).
+    val tokens = LocalOnymTokens.current
+    val strokeColor = if (dimmed) tokens.text3 else accent
+    val pipColor = if (dimmed) tokens.text3 else tokens.onAccent
     Box(
         modifier = Modifier
             .size(size)
@@ -190,7 +302,7 @@ fun OnymGovIcon(
         Canvas(modifier = Modifier.size(size)) {
             val s = this.size.minDimension
             when (type) {
-                OnymUIGovernance.Tyranny -> drawTyrannyMark(s, strokeColor, dimmed)
+                OnymUIGovernance.Tyranny -> drawTyrannyMark(s, strokeColor, pipColor)
                 OnymUIGovernance.OneOnOne -> drawDialogMark(s, strokeColor)
                 OnymUIGovernance.Anarchy -> drawAnarchyMark(s, strokeColor)
             }
@@ -201,7 +313,7 @@ fun OnymGovIcon(
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTyrannyMark(
     s: Float,
     color: Color,
-    dimmed: Boolean,
+    pipColor: Color,
 ) {
     // Crown polygon points — same proportions as iOS (each /44 of
     // canvas), reframed against the `s × s` Compose canvas.
@@ -223,9 +335,10 @@ private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawTyrannyMark(
         size = Size(s * 18f / 44f, s * 3f / 44f),
         cornerRadius = androidx.compose.ui.geometry.CornerRadius(s * 0.8f / 44f),
     )
-    // Center dot.
+    // Center dot — themed via [pipColor] (onAccent in normal state,
+    // text3 when dimmed). Was hardcoded `Color.White` pre-PR-31.
     drawCircle(
-        color = if (dimmed) OnymTokens.Text3 else Color.White,
+        color = pipColor,
         radius = s * 1.2f / 44f,
         center = Offset(s * 22f / 44f, s * 20f / 44f),
     )

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupChrome.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupChrome.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import chat.onym.android.group.OnymTokens
+import chat.onym.android.group.LocalOnymTokens
 
 /**
  * Centered title block used at the top of every screen
@@ -39,14 +39,14 @@ internal fun OnymNavTitle(title: String, subtitle: String? = null) {
     ) {
         Text(
             text = title,
-            color = OnymTokens.Text,
+            color = LocalOnymTokens.current.text,
             style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
         )
         if (subtitle != null) {
             Spacer(Modifier.height(1.dp))
             Text(
                 text = subtitle,
-                color = OnymTokens.Text3,
+                color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 11.sp),
             )
         }
@@ -58,7 +58,7 @@ internal fun OnymNavTitle(title: String, subtitle: String? = null) {
 internal fun OnymSectionLabel(text: String) {
     Text(
         text = text.uppercase(),
-        color = OnymTokens.Text3,
+        color = LocalOnymTokens.current.text3,
         style = TextStyle(
             fontSize = 11.sp,
             fontWeight = FontWeight.SemiBold,
@@ -82,8 +82,8 @@ internal fun OnymPrimaryButton(
     enabled: Boolean = true,
     onClick: () -> Unit,
 ) {
-    val bg = if (enabled) accent else OnymTokens.Surface3
-    val fg = if (enabled) OnymTokens.OnAccent else OnymTokens.Text3
+    val bg = if (enabled) accent else LocalOnymTokens.current.surface3
+    val fg = if (enabled) LocalOnymTokens.current.onAccent else LocalOnymTokens.current.text3
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -121,7 +121,7 @@ internal fun OnymQuietButton(
     ) {
         Text(
             text = title,
-            color = OnymTokens.Text2,
+            color = LocalOnymTokens.current.text2,
             style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
         )
     }
@@ -132,8 +132,8 @@ internal fun OnymQuietButton(
 @Composable
 internal fun OnymCard(
     radius: Int = 14,
-    fill: Color = OnymTokens.Surface2,
-    borderColor: Color = OnymTokens.Hairline,
+    fill: Color = LocalOnymTokens.current.surface2,
+    borderColor: Color = LocalOnymTokens.current.hairline,
     content: @Composable () -> Unit,
 ) {
     Box(

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -46,7 +46,7 @@ import chat.onym.android.group.CreateGroupViewModel
 import chat.onym.android.group.OnymAccent
 import chat.onym.android.group.OnymGovIcon
 import chat.onym.android.group.OnymGroupAvatar
-import chat.onym.android.group.OnymTokens
+import chat.onym.android.group.LocalOnymTokens
 import chat.onym.android.group.OnymUIGovernance
 
 /**
@@ -67,7 +67,7 @@ fun CreateGroupScreen(viewModel: CreateGroupViewModel) {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(OnymTokens.Bg),
+            .background(LocalOnymTokens.current.bg),
     ) {
         AnimatedContent(
             targetState = state.route,
@@ -90,7 +90,7 @@ fun CreateGroupScreen(viewModel: CreateGroupViewModel) {
 @Composable
 private fun Step1Screen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val accent = state.accent.color
+    val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
         OnymNavTitle(title = "New Group", subtitle = "Step 1 of 2")
         Column(
@@ -115,7 +115,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                     value = state.name,
                     onValueChange = viewModel::setName,
                     textStyle = TextStyle(
-                        color = OnymTokens.Text,
+                        color = LocalOnymTokens.current.text,
                         fontSize = 17.sp,
                         fontWeight = FontWeight.Medium,
                     ),
@@ -125,7 +125,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                             if (state.name.isEmpty()) {
                                 Text(
                                     text = state.generatedName.ifEmpty { "Group name" },
-                                    color = OnymTokens.Text3,
+                                    color = LocalOnymTokens.current.text3,
                                     style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Medium),
                                 )
                             }
@@ -141,7 +141,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
             }
             Text(
                 text = "Visible to members. You can change this anytime.",
-                color = OnymTokens.Text3,
+                color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 11.5.sp),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -160,10 +160,10 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                         modifier = Modifier
                             .size(34.dp)
                             .clip(CircleShape)
-                            .background(a.color)
+                            .background(a.color())
                             .then(
                                 if (state.accent == a) {
-                                    Modifier.border(2.dp, a.color, CircleShape)
+                                    Modifier.border(2.dp, a.color(), CircleShape)
                                 } else Modifier,
                             )
                             .clickable { viewModel.setAccent(a) },
@@ -199,7 +199,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
             // Selected explanation
             Spacer(Modifier.height(12.dp))
             OnymCard(
-                fill = OnymTokens.Surface2,
+                fill = LocalOnymTokens.current.surface2,
                 borderColor = accent.copy(alpha = 0.22f),
             ) {
                 Row(
@@ -218,7 +218,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                     Column {
                         Text(
                             text = "${state.governance.sub}. ${state.governance.tooltip}",
-                            color = OnymTokens.Text2,
+                            color = LocalOnymTokens.current.text2,
                             style = TextStyle(fontSize = 13.sp, lineHeight = 18.sp),
                         )
                     }
@@ -227,19 +227,19 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
             Spacer(Modifier.height(18.dp))
 
             // Encrypted footer card
-            OnymCard(fill = OnymTokens.Surface) {
+            OnymCard(fill = LocalOnymTokens.current.surface) {
                 Row(
                     modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     Text(
                         text = "🔒",
-                        color = OnymTokens.Text2,
+                        color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 14.sp),
                     )
                     Text(
                         text = "End-to-end encrypted · published on Stellar so anyone can verify it’s real.",
-                        color = OnymTokens.Text2,
+                        color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                     )
                 }
@@ -276,16 +276,16 @@ private fun GovernanceCard(
     val available = type.isAvailable
     val labelColor = when {
         selected -> accent
-        available -> OnymTokens.Text
-        else -> OnymTokens.Text2
+        available -> LocalOnymTokens.current.text
+        else -> LocalOnymTokens.current.text2
     }
-    val borderColor = if (selected) accent else OnymTokens.Hairline
+    val borderColor = if (selected) accent else LocalOnymTokens.current.hairline
     val bgTint = if (selected) accent.copy(alpha = 0.18f) else Color.Transparent
 
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(18.dp))
-            .background(OnymTokens.Surface2)
+            .background(LocalOnymTokens.current.surface2)
             .background(bgTint)
             .border(width = if (selected) 1.5.dp else 1.dp, color = borderColor, shape = RoundedCornerShape(18.dp))
             .clickable(enabled = available, onClick = onClick)
@@ -295,18 +295,18 @@ private fun GovernanceCard(
         Box(contentAlignment = Alignment.TopEnd) {
             OnymGovIcon(
                 type = type,
-                accent = if (selected) accent else OnymTokens.Text,
+                accent = if (selected) accent else LocalOnymTokens.current.text,
                 size = 42.dp,
                 dimmed = !selected || !available,
             )
             if (!available) {
                 Text(
                     text = "Soon",
-                    color = OnymTokens.Text3,
+                    color = LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 9.sp, fontWeight = FontWeight.SemiBold, letterSpacing = 0.5.sp),
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
-                        .background(OnymTokens.Surface3)
+                        .background(LocalOnymTokens.current.surface3)
                         .padding(horizontal = 6.dp, vertical = 2.dp),
                 )
             }
@@ -319,7 +319,7 @@ private fun GovernanceCard(
         )
         Text(
             text = type.sub,
-            color = OnymTokens.Text2,
+            color = LocalOnymTokens.current.text2,
             style = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium),
         )
     }
@@ -330,7 +330,7 @@ private fun GovernanceCard(
 @Composable
 private fun Step2Screen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val accent = state.accent.color
+    val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
         OnymNavTitle(title = "Add People", subtitle = "Step 2 of 2")
         Column(
@@ -343,7 +343,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
             // Type banner
             OnymCard(
                 radius = 12,
-                fill = OnymTokens.Surface2,
+                fill = LocalOnymTokens.current.surface2,
                 borderColor = accent.copy(alpha = 0.20f),
             ) {
                 Row(
@@ -357,19 +357,19 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                     OnymGovIcon(type = state.governance, accent = accent, size = 28.dp)
                     Text(
                         text = "${state.governance.label}. You'll be the only admin.",
-                        color = OnymTokens.Text2,
+                        color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                         modifier = Modifier.weight(1f),
                     )
                     Box(
                         modifier = Modifier
                             .clip(RoundedCornerShape(50))
-                            .background(OnymTokens.Surface3)
+                            .background(LocalOnymTokens.current.surface3)
                             .padding(horizontal = 8.dp, vertical = 3.dp),
                     ) {
                         Text(
                             text = "${state.invitees.size}",
-                            color = OnymTokens.Text,
+                            color = LocalOnymTokens.current.text,
                             style = TextStyle(fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold),
                         )
                     }
@@ -385,13 +385,13 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                     Spacer(Modifier.height(28.dp))
                     Text(
                         text = "No invitees yet",
-                        color = OnymTokens.Text,
+                        color = LocalOnymTokens.current.text,
                         style = TextStyle(fontSize = 15.sp, fontWeight = FontWeight.SemiBold),
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
                         text = "Use “Invite by inbox key” below to add someone.",
-                        color = OnymTokens.Text2,
+                        color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp),
                         textAlign = TextAlign.Center,
                         modifier = Modifier.padding(horizontal = 24.dp),
@@ -406,7 +406,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .height(1.dp)
-                                        .background(OnymTokens.Hairline),
+                                        .background(LocalOnymTokens.current.hairline),
                                 )
                             }
                             Row(
@@ -420,7 +420,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                                     modifier = Modifier
                                         .size(40.dp)
                                         .clip(CircleShape)
-                                        .background(OnymTokens.Surface3),
+                                        .background(LocalOnymTokens.current.surface3),
                                     contentAlignment = Alignment.Center,
                                 ) {
                                     Text(
@@ -432,12 +432,12 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
                                         text = "Inbox ${invitee.displayLabel}",
-                                        color = OnymTokens.Text,
+                                        color = LocalOnymTokens.current.text,
                                         style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
                                     )
                                     Text(
                                         text = "Direct inbox key",
-                                        color = OnymTokens.Text2,
+                                        color = LocalOnymTokens.current.text2,
                                         style = TextStyle(fontSize = 12.sp),
                                     )
                                 }
@@ -449,7 +449,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                                 ) {
                                     Text(
                                         text = "✕",
-                                        color = OnymTokens.Text3,
+                                        color = LocalOnymTokens.current.text3,
                                         style = TextStyle(fontSize = 16.sp),
                                     )
                                 }
@@ -465,8 +465,8 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
             // Invite-by-key entry row
             OnymCard(
                 radius = 12,
-                fill = OnymTokens.Surface2,
-                borderColor = OnymTokens.HairlineStrong,
+                fill = LocalOnymTokens.current.surface2,
+                borderColor = LocalOnymTokens.current.hairlineStrong,
             ) {
                 Row(
                     modifier = Modifier
@@ -488,18 +488,18 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = "Invite by inbox key",
-                            color = OnymTokens.Text,
+                            color = LocalOnymTokens.current.text,
                             style = TextStyle(fontSize = 13.5.sp, fontWeight = FontWeight.SemiBold),
                         )
                         Text(
                             text = "Paste a 64-char key",
-                            color = OnymTokens.Text2,
+                            color = LocalOnymTokens.current.text2,
                             style = TextStyle(fontSize = 11.5.sp),
                         )
                     }
                     Text(
                         text = "›",
-                        color = OnymTokens.Text3,
+                        color = LocalOnymTokens.current.text3,
                         style = TextStyle(fontSize = 16.sp),
                     )
                 }
@@ -520,7 +520,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
 @Composable
 private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val accent = state.accent.color
+    val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
         OnymNavTitle(
             title = "Invite by Inbox Key",
@@ -538,7 +538,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
                     value = state.inviteeInput,
                     onValueChange = viewModel::setInviteeInput,
                     textStyle = TextStyle(
-                        color = OnymTokens.Text,
+                        color = LocalOnymTokens.current.text,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.Medium,
                     ),
@@ -548,7 +548,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
                             if (state.inviteeInput.isEmpty()) {
                                 Text(
                                     text = "Paste a 64-character hex key…",
-                                    color = OnymTokens.Text3,
+                                    color = LocalOnymTokens.current.text3,
                                     style = TextStyle(fontSize = 14.sp),
                                 )
                             }
@@ -565,13 +565,13 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
             ) {
                 Text(
                     text = "(${state.inviteeInputCleanedLength}/64)",
-                    color = if (state.inviteeInputIsValid) accent else OnymTokens.Text3,
+                    color = if (state.inviteeInputIsValid) accent else LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold),
                 )
                 if (state.inviteeError != null) {
                     Text(
                         text = state.inviteeError!!,
-                        color = OnymTokens.Red,
+                        color = LocalOnymTokens.current.red,
                         style = TextStyle(fontSize = 11.5.sp),
                     )
                 }
@@ -579,7 +579,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
             Spacer(Modifier.height(20.dp))
             Text(
                 text = "The recipient generates this key on their own device. They can find it in Settings → Identity → Inbox Key.",
-                color = OnymTokens.Text3,
+                color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
             )
         }
@@ -601,7 +601,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
 @Composable
 private fun CreatingScreen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val accent = state.accent.color
+    val accent = state.accent.color()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -611,7 +611,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
         Spacer(Modifier.height(20.dp))
         Text(
             text = "Creating ${state.name.ifEmpty { "Group" }}",
-            color = OnymTokens.Text,
+            color = LocalOnymTokens.current.text,
             style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
         )
         Spacer(Modifier.height(24.dp))
@@ -627,7 +627,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(1.dp)
-                                .background(OnymTokens.Hairline),
+                                .background(LocalOnymTokens.current.hairline),
                         )
                     }
                     val status = stepStatus(index, steps.size, state.progress, state.error != null)
@@ -639,8 +639,8 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
         if (state.error != null) {
             Spacer(Modifier.height(12.dp))
             OnymCard(
-                fill = OnymTokens.Red.copy(alpha = 0.10f),
-                borderColor = OnymTokens.Red.copy(alpha = 0.30f),
+                fill = LocalOnymTokens.current.red.copy(alpha = 0.10f),
+                borderColor = LocalOnymTokens.current.red.copy(alpha = 0.30f),
             ) {
                 Column(
                     modifier = Modifier.padding(14.dp),
@@ -662,7 +662,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                     ) {
                         Text(
                             text = state.error?.message ?: "Couldn't create the group",
-                            color = OnymTokens.Red,
+                            color = LocalOnymTokens.current.red,
                             style = TextStyle(
                                 fontSize = 12.sp,
                                 fontFamily = FontFamily.Monospace,
@@ -680,20 +680,20 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                         Box(
                             modifier = Modifier
                                 .clip(RoundedCornerShape(50))
-                                .background(OnymTokens.Surface3)
+                                .background(LocalOnymTokens.current.surface3)
                                 .clickable(onClick = viewModel::cancelFromError)
                                 .padding(horizontal = 18.dp, vertical = 8.dp),
                         ) {
                             Text(
                                 text = "Cancel",
-                                color = OnymTokens.Text2,
+                                color = LocalOnymTokens.current.text2,
                                 style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
                             )
                         }
                         Box(
                             modifier = Modifier
                                 .clip(RoundedCornerShape(50))
-                                .background(OnymTokens.Surface2)
+                                .background(LocalOnymTokens.current.surface2)
                                 .clickable(onClick = viewModel::tappedDismissError)
                                 .padding(horizontal = 18.dp, vertical = 8.dp),
                         ) {
@@ -710,7 +710,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
             Spacer(Modifier.height(14.dp))
             Text(
                 text = "This usually takes a few seconds. It’s safe to close this — we’ll finish in the background.",
-                color = OnymTokens.Text3,
+                color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = 8.dp),
@@ -766,14 +766,14 @@ private fun StepRow(label: String, sub: String, status: StepStatus, accent: Colo
                 .clip(CircleShape)
                 .background(
                     when (status) {
-                        StepStatus.Done -> OnymTokens.Green
+                        StepStatus.Done -> LocalOnymTokens.current.green
                         StepStatus.Active -> accent.copy(alpha = 0.18f)
                         StepStatus.Pending -> Color.Transparent
                     },
                 )
                 .border(
                     width = if (status == StepStatus.Pending) 2.dp else 0.dp,
-                    color = OnymTokens.HairlineStrong,
+                    color = LocalOnymTokens.current.hairlineStrong,
                     shape = CircleShape,
                 ),
             contentAlignment = Alignment.Center,
@@ -795,12 +795,12 @@ private fun StepRow(label: String, sub: String, status: StepStatus, accent: Colo
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = label,
-                color = if (status == StepStatus.Pending) OnymTokens.Text2 else OnymTokens.Text,
+                color = if (status == StepStatus.Pending) LocalOnymTokens.current.text2 else LocalOnymTokens.current.text,
                 style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
             )
             Text(
                 text = sub,
-                color = OnymTokens.Text2,
+                color = LocalOnymTokens.current.text2,
                 style = TextStyle(fontSize = 12.sp),
             )
         }
@@ -812,7 +812,7 @@ private fun StepRow(label: String, sub: String, status: StepStatus, accent: Colo
 @Composable
 private fun SuccessScreen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val accent = state.accent.color
+    val accent = state.accent.color()
     val group = state.createdGroup
     Column(
         modifier = Modifier
@@ -825,13 +825,13 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
         Spacer(Modifier.height(20.dp))
         Text(
             text = group?.name ?: state.name,
-            color = OnymTokens.Text,
+            color = LocalOnymTokens.current.text,
             style = TextStyle(fontSize = 22.sp, fontWeight = FontWeight.Bold),
         )
         Spacer(Modifier.height(6.dp))
         Text(
             text = "Anchored on Stellar testnet",
-            color = OnymTokens.Text2,
+            color = LocalOnymTokens.current.text2,
             style = TextStyle(fontSize = 13.sp),
         )
 
@@ -840,20 +840,20 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
             Column(modifier = Modifier.padding(14.dp)) {
                 Text(
                     text = "Members",
-                    color = OnymTokens.Text3,
+                    color = LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.SemiBold, letterSpacing = 0.88.sp),
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
                     text = "${(group?.members?.size ?: 1)} member" + if ((group?.members?.size ?: 1) == 1) "" else "s",
-                    color = OnymTokens.Text,
+                    color = LocalOnymTokens.current.text,
                     style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
                 )
                 Spacer(Modifier.height(2.dp))
                 Text(
                     text = "${state.invitees.size} invitation" +
                         (if (state.invitees.size == 1) "" else "s") + " sent",
-                    color = OnymTokens.Text2,
+                    color = LocalOnymTokens.current.text2,
                     style = TextStyle(fontSize = 12.5.sp),
                 )
             }
@@ -877,10 +877,10 @@ private fun FlowFooter(content: @Composable () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(OnymTokens.Bg)
+            .background(LocalOnymTokens.current.bg)
             .border(
                 width = 1.dp,
-                color = OnymTokens.Hairline,
+                color = LocalOnymTokens.current.hairline,
                 shape = RoundedCornerShape(0.dp),
             )
             .padding(start = 16.dp, end = 16.dp, top = 12.dp, bottom = 22.dp),


### PR DESCRIPTION
The Create Group flow shipped dark-only because the design's `THEMES.light` palette was never ported. Mirrors onymchat/onym-ios#31: flip `OnymTokens` from a static dark singleton to a per-theme bundle provided via `LocalOnymTokens`, and let `OnymTheme` pick the variant off `isSystemInDarkTheme()`.

## TL;DR

| File | Before | After |
|---|---|---|
| `OnymTokens` | `object` with static dark RGB literals | `@Immutable data class` with `Light` / `Dark` companions |
| `OnymAccent` | Six bright dark-mode hexes via a `val color: Color` property | Each accent carries `light` (darker desaturated) + `dark` (saturated) variants; `@Composable fun color()` resolves against `LocalOnymTokens.current` |
| `OnymTheme` | Didn't exist | Root scope provides `LocalOnymTokens` + matching Material3 `colorScheme`; wraps the `create_group` nav route |
| All `OnymTokens.X` call sites | Singleton property access | `LocalOnymTokens.current.x` |

## Source palette

Lifted straight from iOS PR #31's `OnymBrand.swift` (which came from the design's `app.jsx` `THEMES.{light,dark}` blocks):

- Tokens: bg / surface / surface2 / surface3 / text / text2 / text3 / hairline / hairlineStrong / green / red / onAccent.
- Accents: orange / blue / green / purple / pink / yellow.

`onAccent` is white on light, black on dark — drives the tyranny crown's centre pip + the primary button text colour, which were both hardcoded `Color.White` / `Color.Black` pre-PR-31.

## Compose pattern

`staticCompositionLocalOf { OnymTokens.Dark }` provides a sensible default for any descendant rendered outside an `OnymTheme` scope. Static (not granular) is correct: theme swap happens via the root `CompositionLocalProvider` re-providing, not fine-grained recomposition tracking.

`OnymAccent.color()` is `@Composable @ReadOnlyComposable` — identity-checks the active tokens against `OnymTokens.Dark` rather than calling `isSystemInDarkTheme()` directly so a future Settings forced-theme override would propagate without an extra branch.

## Wiring

`RootScreen.kt`'s `composable(ROUTE_CREATE_GROUP)` wraps `CreateGroupScreen(viewModel = vm)` in `OnymTheme { ... }`. Chats / Settings tabs already adapt via Material's colorScheme + system colours and don't need this wrapper. The OnymMark broken-ring stroke threads the active text token through `LocalOnymTokens.current.text`, so the brand mark follows automatically.

`drawTyrannyMark` now takes an explicit `pipColor` parameter (resolved in the @Composable parent from `LocalOnymTokens`) instead of hardcoding `Color.White` — the DrawScope helpers stay pure (no @Composable inside the Canvas draw block).

## Test plan

- [x] `:app:assembleDebug` — builds clean
- [x] `:app:testDebugUnitTest --tests 'chat.onym.android.group.*' --tests 'chat.onym.android.chats.*'` — all green (the existing default `OnymAccent.Blue` state value still works since `color()` is only resolved at render time)
- [x] `:app:compileDebugAndroidTestKotlin` — instrumented sources still compile
- [x] `python3 scripts/lint-secrets.py` — clean
- [ ] CI's full sweep
- [ ] On-device smoke: cold install → Settings → Create Group → toggle system theme via `adb shell cmd uimode night yes/no` → screen swaps colours within one frame; tyranny pip flips white⇄black; accent buttons stay legible on both backgrounds.

## Out of scope

- Light variants for screens outside Create Group (Chats, Settings) — already use Material/system colours that adapt.
- Forced-theme toggle in Settings — keep following the system.
- Material You / Monet dynamic colour — orthogonal; the brand mark + accent palette stay fixed across system wallpaper changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)