### PR TITLE
ci: run Tyranny E2E test as part of release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,22 @@ name: Release
 #   ANDROID_KEY_PASSWORD       — password for that alias
 #   RELAYER_AUTH_TOKEN         — Bearer token the relayer's
 #                                 `validate_auth` requires on every
-#                                 contract-call POST. Inlined into
+#                                 contract-call POST. Two consumers:
+#                                 (1) `android-test` job — passed as
+#                                 the `ONYM_RELAYER_AUTH_TOKEN`
+#                                 instrumentation arg so
+#                                 `CreateGroupTyrannyE2ETest` can
+#                                 anchor a real group on testnet
+#                                 against the deployed relayer.
+#                                 (2) `build` job — inlined into
 #                                 `BuildConfig.RELAYER_AUTH_TOKEN` at
 #                                 assembleRelease and consumed at
 #                                 runtime by `BearerAuthInterceptor`.
-#                                 Without this secret, release builds
-#                                 still compile but every relayer call
-#                                 401s with "missing bearer" (the
-#                                 interceptor skips the header on a
-#                                 blank token rather than sending
-#                                 `Bearer ""`).
+#                                 Without this secret, the E2E test
+#                                 401s and the release APK ships with
+#                                 a blank token (the interceptor
+#                                 skips the header on blank rather
+#                                 than sending `Bearer ""`).
 
 on:
   workflow_dispatch:
@@ -124,6 +130,14 @@ jobs:
           script: echo "AVD warm snapshot created"
 
       - name: Run instrumented tests on emulator
+        # `ONYM_INTEGRATION=1` opts the gated E2E test
+        # (`CreateGroupTyrannyE2ETest`) into running. Without it, the
+        # @Before `Assume.assumeTrue` skips it cleanly, but on release
+        # builds we want the real-testnet anchor to verify.
+        # `ONYM_RELAYER_AUTH_TOKEN` is the same secret assembleRelease
+        # uses (PR #28 documented it).
+        env:
+          RELAYER_AUTH_TOKEN: ${{ secrets.RELAYER_AUTH_TOKEN }}
         uses: reactivecircus/android-emulator-runner@70f4dee990796918b78d040e3278474bdbd348a7  # v2.37.0
         with:
           api-level: 34
@@ -132,7 +146,11 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew :app:connectedDebugAndroidTest --no-daemon
+          script: |
+            ./gradlew :app:connectedDebugAndroidTest --no-daemon \
+              -Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1 \
+              -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_URL=https://relayer.onym.chat \
+              -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_AUTH_TOKEN="$RELAYER_AUTH_TOKEN"
 
       - name: Upload androidTest report on failure
         if: failure()


### PR DESCRIPTION
PR #32 added `CreateGroupTyrannyE2ETest` gated on the `ONYM_INTEGRATION` instrumentation arg — without it, the `@Before` `Assume.assumeTrue` skips the test cleanly. With contracts PR #31 shipped + a fresh release cut, we now want the E2E to run on every release so a relayer / wire-format regression breaks the build instead of silently sitting in the \"skipped\" column.

## What changes

`android-test` job's `Run instrumented tests on emulator` step now passes:
- `RELAYER_AUTH_TOKEN: ${{ secrets.RELAYER_AUTH_TOKEN }}` via env (so the secret is interpolated into the emulator-runner shell)
- `-Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1` (opts the gated test in)
- `-Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_URL=https://relayer.onym.chat` (default, but explicit so the target is grep-able in the log)
- `-Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_AUTH_TOKEN="$RELAYER_AUTH_TOKEN"` (satisfies the test's other gate)

Workflow-header doc on `RELAYER_AUTH_TOKEN` extended to mention both consumers (`android-test` for the E2E, `build` for the inlined `BuildConfig.RELAYER_AUTH_TOKEN`).

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` — YAML parses
- [ ] Manual: `gh workflow run Release -f tag=v0.1.0` once contracts PR #31 + a fresh contracts release ship; expect `CreateGroupTyrannyE2ETest` to run (not skip) and pass

## Why now

Per the user's note: contracts PR #31 (unrestrict bench contracts) is shipped + a contracts release with the unrestricted Tyranny binding has been cut. Pre-PR-31 this would have failed with `Error(Contract, #14) AdminOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)