### PR TITLE
ci: fix android-test step — collapse gradle invocation onto one line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,13 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            ./gradlew :app:connectedDebugAndroidTest --no-daemon \
-              -Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1 \
-              -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_URL=https://relayer.onym.chat \
-              -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_AUTH_TOKEN="$RELAYER_AUTH_TOKEN"
+          # One line on purpose: `reactivecircus/android-emulator-runner`
+          # invokes the script via `sh -c <script>` without quoting,
+          # so YAML-block backslash continuations (`\<newline>`) get
+          # split into separate sh arguments and gradle sees a literal
+          # `\` task name. Run #25262842752 failed exactly that way;
+          # keep the gradle invocation single-line to dodge the issue.
+          script: ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1 -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_URL=https://relayer.onym.chat -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_AUTH_TOKEN="$RELAYER_AUTH_TOKEN"
 
       - name: Upload androidTest report on failure
         if: failure()


### PR DESCRIPTION
## Why

[Run #25262842752's `android-test` job](https://github.com/onymchat/onym-android/actions/runs/25262842752/job/74072819139) failed with:

```
Task '\' not found in root project 'onym-android' and its subprojects.
```

The multi-line YAML `script: |` block from PR #33:

```yaml
script: |
  ./gradlew :app:connectedDebugAndroidTest --no-daemon \
    -Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1 \
    ...
```

was invoked by `reactivecircus/android-emulator-runner` as `sh -c <script>` without re-quoting, so each backslash continuation got split into a separate sh argument and gradle saw a literal `\` task name.

## What

Collapsed the gradle invocation onto one line. Same instrumentation-arg semantics, same `RELAYER_AUTH_TOKEN` env plumbing — only the formatting changed.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` — YAML parses
- [ ] Manual: re-dispatch Release `v0.0.2` once this merges; expect `android-test` to actually run the suite (incl. the gated E2E) instead of failing on argument parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)