### PR TITLE
chain: OneOnOne payload + canonical Fr groupId (PR-1/3)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.chain
 
 import chat.onym.android.group.GovernanceMember
+import chat.onym.sdk.OneOnOne
 import chat.onym.sdk.Tyranny
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -31,8 +32,11 @@ data class GroupCreateProof(
      *  on the wire). */
     val proof: ByteArray,
     /** SDK's full per-type PI bundle, split into 32-byte chunks.
-     *  Tyranny create returns 4:
-     *  `commitment || Fr(0) || admin_pubkey_commitment || group_id_fr`. */
+     *
+     *  - Tyranny create returns 4:
+     *    `commitment || Fr(0) || admin_pubkey_commitment || group_id_fr`.
+     *  - OneOnOne create returns 2:
+     *    `commitment || Fr(0)` (the contract's symmetric 1v1 PI shape). */
     val publicInputs: List<ByteArray>,
 ) {
     /** First 32 bytes of the PI bundle — the new commitment the
@@ -84,10 +88,20 @@ data class GroupProofCreateInput(
     /** Position of the admin in [members] (after the lex sort). */
     val adminIndex: Int,
     /** 32-byte raw group ID — used directly as the `group_id_fr`
-     *  per-group binding scalar in the Tyranny circuit. */
+     *  per-group binding scalar in the Tyranny circuit. MUST be a
+     *  canonical BLS12-381 Fr scalar (see [CanonicalFr.isCanonical]);
+     *  callers should generate via [CanonicalFr.randomCanonicalFr32]. */
     val groupId: ByteArray,
     /** 32 bytes; LE-mod-r in-circuit. */
     val salt: ByteArray,
+    /** 32 BE Fr — only required when [groupType] is
+     *  [SepGroupType.ONE_ON_ONE]: the SECOND party's BLS secret key,
+     *  fed into `OneOnOne.proveCreate(sk_0, sk_1, salt)` as `sk_1`.
+     *  The OneOnOne FFI rejects `sk_0 == sk_1`, so the creator MUST
+     *  generate a fresh ephemeral scalar (NOT reuse [adminBlsSecretKey])
+     *  and ship it to the invitee inside the sealed invitation envelope.
+     *  `null` for any non-OneOnOne governance type. */
+    val secondaryBlsSecretKey: ByteArray? = null,
 )
 
 /**
@@ -99,10 +113,24 @@ data class GroupProofCreateInput(
  */
 sealed class GroupProofGeneratorError(message: String, cause: Throwable? = null) : Exception(message, cause) {
 
-    /** Caller asked for a governance type other than [SepGroupType.TYRANNY].
-     *  PR-B ships Tyranny only — UI surfaces this as a clear "TBD". */
+    /** Caller asked for a governance type the proof generator hasn't
+     *  wired yet (currently: ANARCHY, DEMOCRACY, OLIGARCHY).
+     *  UI surfaces this as a clear "TBD". */
     class NotYetSupported(val type: SepGroupType) :
         GroupProofGeneratorError("group type not yet supported: $type")
+
+    /** Caller asked for a [SepGroupType.ONE_ON_ONE] proof but did
+     *  not supply [GroupProofCreateInput.secondaryBlsSecretKey]. The
+     *  OneOnOne circuit needs both parties' Fr scalars in the witness
+     *  (and the FFI rejects `sk_0 == sk_1`), so the second key is
+     *  load-bearing and not derivable from the admin secret alone. */
+    object SecondaryBlsSecretKeyRequired :
+        GroupProofGeneratorError(
+            "OneOnOne create requires a second BLS Fr scalar — caller must " +
+                "generate a fresh ephemeral key and pass it as secondaryBlsSecretKey",
+        ) {
+        private fun readResolve(): Any = SecondaryBlsSecretKeyRequired
+    }
 
     /** [GroupProofCreateInput.adminIndex] was negative or `>= members.size`.
      *  Short-circuits before the JNI call so the SDK doesn't have to
@@ -149,12 +177,43 @@ class OnymGroupProofGenerator : GroupProofGenerator {
     override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof =
         when (input.groupType) {
             SepGroupType.TYRANNY -> proveTyrannyCreate(input)
+            SepGroupType.ONE_ON_ONE -> proveOneOnOneCreate(input)
             SepGroupType.ANARCHY,
-            SepGroupType.ONE_ON_ONE,
             SepGroupType.DEMOCRACY,
             SepGroupType.OLIGARCHY,
                 -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
+
+    private suspend fun proveOneOnOneCreate(input: GroupProofCreateInput): GroupCreateProof {
+        val sk1 = input.secondaryBlsSecretKey
+            ?: throw GroupProofGeneratorError.SecondaryBlsSecretKeyRequired
+
+        // CPU-bound — keep it off Dispatchers.IO and off Dispatchers.Main.
+        // The OneOnOne circuit is depth-5 (same as Tyranny SMALL), so
+        // the wall-time profile is comparable.
+        return withContext(Dispatchers.Default) {
+            val raw = try {
+                OneOnOne.proveCreate(
+                    /* secretKey0 = */ input.adminBlsSecretKey,
+                    /* secretKey1 = */ sk1,
+                    /* salt = */ input.salt,
+                )
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            // OneOnOne's CreateProof returns (proof, commitment) as
+            // separate buffers — unlike Tyranny's bundled 128-byte PI
+            // blob. The contract still expects a Vec<BytesN<32>> PI
+            // argument, so we synthesize the 2-element shape the
+            // sep-oneonone circuit verifies: [commitment, fr_zero].
+            // (`fr_zero` is the symmetric placeholder — see
+            // `onym-contracts/plonk/sep-oneonone/src/lib.rs`.)
+            GroupCreateProof(
+                proof = raw.proof,
+                publicInputs = listOf(raw.commitment, ByteArray(32)),
+            )
+        }
+    }
 
     private suspend fun proveTyrannyCreate(input: GroupProofCreateInput): GroupCreateProof {
         if (input.adminIndex < 0 || input.adminIndex >= input.members.size) {

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
@@ -42,6 +42,14 @@ class SepContractClient(
             responseSerializer = SepSubmissionResponse.serializer(),
         )
 
+    suspend fun createGroupOneOnOne(payload: OneOnOneCreateGroupPayload): SepSubmissionResponse =
+        invoke(
+            function = "create_group",
+            payload = payload,
+            payloadSerializer = OneOnOneCreateGroupPayload.serializer(),
+            responseSerializer = SepSubmissionResponse.serializer(),
+        )
+
     suspend fun updateCommitmentTyranny(payload: TyrannyUpdateCommitmentPayload): SepSubmissionResponse =
         invoke(
             function = "update_commitment",

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
@@ -174,6 +174,53 @@ data class TyrannyCreateGroupPayload(
 }
 
 /**
+ * `create_group` payload for the OneOnOne (1v1) contract. Layout
+ * mirrors `add_create_group_args` in `onym-relayer/src/handler.rs`,
+ * `ContractType::OneOnOne` arm — the relayer extracts `caller` from
+ * its config and `group_id` / `commitment` from this payload's
+ * top-level keys, then forwards `--proof` + `--public-inputs` to the
+ * `sep-oneonone` Soroban contract.
+ *
+ * No `tier` (depth=5 is hardcoded in the OneOnOne circuit) and no
+ * `admin_pubkey_commitment` (1v1 has no admin role). The PI vector is
+ * 2 × 32B chunks: `[commitment, fr_zero]` — `fr_zero` is the symmetric
+ * second-element placeholder the OneOnOne contract validates.
+ *
+ * Mirrors `OneOnOneCreateGroupPayload` from onym-ios PR #36.
+ */
+@Serializable
+data class OneOnOneCreateGroupPayload(
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    /** 1601-byte raw PLONK proof — same wire constraint as Tyranny. */
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val proof: ByteArray,
+    /** 2 elements × 32 bytes — `[commitment, fr_zero]`. */
+    val publicInputs: List<@Serializable(with = Base64ByteArraySerializer::class) ByteArray>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OneOnOneCreateGroupPayload) return false
+        return groupId.contentEquals(other.groupId) &&
+            commitment.contentEquals(other.commitment) &&
+            proof.contentEquals(other.proof) &&
+            publicInputs.size == other.publicInputs.size &&
+            publicInputs.zip(other.publicInputs).all { (a, b) -> a.contentEquals(b) }
+    }
+
+    override fun hashCode(): Int {
+        var h = groupId.contentHashCode()
+        h = 31 * h + commitment.contentHashCode()
+        h = 31 * h + proof.contentHashCode()
+        for (p in publicInputs) h = 31 * h + p.contentHashCode()
+        return h
+    }
+}
+
+/**
  * `update_commitment` payload — Tyranny variant. The SDK's
  * `Tyranny.UpdateProof.publicInputs` is 160 bytes = 5 × 32B
  * (`c_old || epoch_old || c_new || admin_pubkey_commitment || group_id_fr`).

--- a/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
@@ -28,12 +28,25 @@ class GroupProofGeneratorTest {
     }
 
     @Test
-    fun proveCreate_oneOnOne_throwsNotYetSupported() = runTest {
-        val input = stubInput(SepGroupType.ONE_ON_ONE)
+    fun proveCreate_democracy_throwsNotYetSupported() = runTest {
+        val input = stubInput(SepGroupType.DEMOCRACY)
         val thrown = assertThrows(GroupProofGeneratorError.NotYetSupported::class.java) {
             kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
         }
-        assertEquals(SepGroupType.ONE_ON_ONE, thrown.type)
+        assertEquals(SepGroupType.DEMOCRACY, thrown.type)
+    }
+
+    @Test
+    fun proveCreate_oneOnOne_withoutSecondaryKey_throws() = runTest {
+        // OneOnOne is now wired (no longer NotYetSupported), but the
+        // secondaryBlsSecretKey is mandatory and short-circuits before
+        // any FFI call when missing.
+        val input = stubInput(SepGroupType.ONE_ON_ONE)
+        val thrown = assertThrows(GroupProofGeneratorError.SecondaryBlsSecretKeyRequired::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        // Sanity: object-singleton, not a class with state to inspect.
+        assertEquals(GroupProofGeneratorError.SecondaryBlsSecretKeyRequired, thrown)
     }
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
@@ -101,6 +101,46 @@ class SepContractClientTest {
     }
 
     @Test
+    fun createGroupOneOnOne_sendsCreateGroupFunction_withTwoChunkPI_andNoTier() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """{"accepted":true,"transactionHash":"oo123"}""",
+        )
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.ONE_ON_ONE,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        val payload = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0x42 },
+            commitment = ByteArray(32) { 0x55 },
+            proof = ByteArray(1601) { 0x77 },
+            publicInputs = listOf(ByteArray(32) { 0x55 }, ByteArray(32)),
+        )
+        val response = client.createGroupOneOnOne(payload)
+        assertTrue(response.accepted)
+        assertEquals("oo123", response.transactionHash)
+
+        assertEquals("create_group", transport.lastFunction)
+        val invocation = transport.lastInvocationJson!!
+        assertEquals("oneonone", invocation["contractType"]!!.jsonPrimitive.contentOrNull)
+
+        val payloadJson = transport.lastPayloadJson!!
+        assertNotNull("group_id required", payloadJson["group_id"])
+        assertNotNull("commitment required", payloadJson["commitment"])
+        assertNotNull("proof required", payloadJson["proof"])
+        assertEquals("OneOnOne sends no tier", null, payloadJson["tier"])
+        assertEquals(
+            "OneOnOne sends no admin_pubkey_commitment",
+            null,
+            payloadJson["admin_pubkey_commitment"],
+        )
+        val pi = payloadJson["publicInputs"] as JsonArray
+        assertEquals(2, pi.size)
+    }
+
+    @Test
     fun updateCommitmentTyranny_routesToUpdateFunction_with5ChunkPI() = runTest {
         val transport = FakeSepContractTransport(
             cannedResponseJson = """{"accepted":true}""",

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
@@ -163,6 +163,59 @@ class SepContractTypesTest {
         assertEquals(original, decoded)
     }
 
+    // ─── OneOnOneCreateGroupPayload ───────────────────────────────
+
+    @Test
+    fun oneOnOneCreateGroupPayload_emitsExpectedKeys() {
+        val payload = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0xAB.toByte() },
+            commitment = ByteArray(32) { 0xCD.toByte() },
+            proof = ByteArray(1601) { 0x01 },
+            publicInputs = listOf(
+                ByteArray(32) { 0xCD.toByte() },
+                ByteArray(32),
+            ),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(OneOnOneCreateGroupPayload.serializer(), payload),
+        ).jsonObject
+
+        assertNotNull("group_id required", obj["group_id"])
+        assertNotNull("commitment required", obj["commitment"])
+        assertNotNull("proof required", obj["proof"])
+        // No `tier` and no `admin_pubkey_commitment` — OneOnOne is
+        // depth-5 hardcoded with no admin role.
+        assertNull("tier must NOT appear", obj["tier"])
+        assertNull("admin_pubkey_commitment must NOT appear", obj["admin_pubkey_commitment"])
+
+        val pi = obj["publicInputs"] as JsonArray
+        assertEquals("OneOnOne PI is 2 × 32B (commitment, fr_zero)", 2, pi.size)
+        for (element in pi) {
+            val raw = Base64.getDecoder().decode(element.jsonPrimitive.content)
+            assertEquals(32, raw.size)
+        }
+
+        val proofBytes = Base64.getDecoder().decode(obj["proof"]!!.jsonPrimitive.content)
+        assertEquals(1601, proofBytes.size)
+        assertArrayEquals(payload.proof, proofBytes)
+    }
+
+    @Test
+    fun oneOnOneCreateGroupPayload_roundtripPreservesAllFields() {
+        val original = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0x11 },
+            commitment = ByteArray(32) { 0x22 },
+            proof = ByteArray(1601) { 0x33 },
+            publicInputs = listOf(
+                ByteArray(32) { 0x22 },
+                ByteArray(32),
+            ),
+        )
+        val encoded = json.encodeToString(OneOnOneCreateGroupPayload.serializer(), original)
+        val decoded = json.decodeFromString(OneOnOneCreateGroupPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
     // ─── TyrannyUpdateCommitmentPayload ───────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

PR-1 of the OneOnOne governance stack (PR-2 wires the interactor; PR-3 toggles the UI). Mirrors onym-ios PR #36.

- `OneOnOneCreateGroupPayload` — wire shape for `create_group` on the `sep-oneonone` contract: 2-element PI (`[commitment, fr_zero]`), no `tier`, no `admin_pubkey_commitment`. Matches `add_create_group_args` `ContractType::OneOnOne` in `onym-relayer/src/handler.rs`.
- `SepContractClient.createGroupOneOnOne(payload)` — same envelope shape as Tyranny.
- `GroupProofGenerator` gains a `SepGroupType.ONE_ON_ONE` branch calling `chat.onym.sdk.OneOnOne.proveCreate(sk_0, sk_1, salt)`. New `secondaryBlsSecretKey: ByteArray?` on `GroupProofCreateInput` is required for OneOnOne; short-circuits with `SecondaryBlsSecretKeyRequired` when missing (the FFI rejects `sk_0 == sk_1`, so the creator must generate a fresh ephemeral scalar and ship it to the invitee — that's PR-2).
- `CanonicalFr.randomCanonicalFr32()` — rejection-samples against the BLS12-381 Fr modulus. `CreateGroupInteractor` now uses it for `groupId` instead of `SecureRandom.nextBytes(32)`. **This is the actual fix** for the `Error(Contract, #15) InvalidCommitmentEncoding` on run #25262987336: the failing `group_id` started with `0xea`, which exceeds `r`. Uniform random bytes hit non-canonical ~45% of the time.
- Drops the `@Ignore` on `CreateGroupTyrannyE2ETest` — unblocked by the same canonical-Fr fix.

## Test plan

- [x] `:app:testDebugUnitTest --tests CanonicalFrTest --tests SepContractTypesTest --tests SepContractClientTest --tests GroupProofGeneratorTest` — all green locally
- [ ] CI release dispatch — Tyranny E2E should now land on testnet without `InvalidCommitmentEncoding`
- [ ] PR-2 will exercise the OneOnOne FFI end-to-end (no JNI in unit tests, so the real proof path is covered there + by `CreateGroupInteractorTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)