### PR TITLE
ux: enable 1-on-1 governance in Create Group (PR-3/3)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
@@ -325,6 +325,111 @@ class CreateGroupInteractorTest {
         }
     }
 
+    // ─── OneOnOne ─────────────────────────────────────────────────
+
+    @Test
+    fun create_oneOnOne_zeroInvitees_throwsExactCountError() = runBlocking {
+        // Manifest needs a OneOnOne entry for the binding lookup to
+        // get past `NoContractBinding` — but the validation fails
+        // before that anyway. Re-seed contracts with both bindings
+        // so the test stays focused on the count check.
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = emptyList(),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected OneOnOneRequiresExactlyOneInvitee")
+        } catch (e: CreateGroupError.OneOnOneRequiresExactlyOneInvitee) {
+            assertEquals(0, e.actual)
+        }
+    }
+
+    @Test
+    fun create_oneOnOne_twoInvitees_throwsExactCountError() = runBlocking {
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = listOf(ByteArray(32), ByteArray(32) { 0xAA.toByte() }),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected OneOnOneRequiresExactlyOneInvitee")
+        } catch (e: CreateGroupError.OneOnOneRequiresExactlyOneInvitee) {
+            assertEquals(2, e.actual)
+        }
+    }
+
+    @Test
+    fun create_oneOnOne_oneInvitee_anchorsViaOneOnOnePayload_andShipsInviteeBlsSecret() = runBlocking {
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+
+        val invitee = ByteArray(32) { 0xCC.toByte() }
+        val group = interactor.create(
+            name = "Talk",
+            invitees = listOf(invitee),
+            groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+        )
+
+        assertEquals(chat.onym.android.chain.SepGroupType.ONE_ON_ONE, group.groupType)
+        assertTrue(group.isPublishedOnChain)
+        // OneOnOne has no admin role.
+        assertEquals(null, group.adminPubkeyHex)
+
+        // The invocation went out as a OneOnOne payload (no `tier`,
+        // no `admin_pubkey_commitment`, 2-element PI).
+        val invocations = contractTransport.invocations()
+        assertEquals(1, invocations.size)
+        assertEquals("create_group", invocations.single().function)
+
+        // Exactly one invitation envelope was sealed + sent.
+        val sends = inboxTransport.sends()
+        assertEquals(1, sends.size)
+    }
+
+    @Test
+    fun create_oneOnOne_noOneOnOneBinding_throwsNoContractBinding() = runBlocking {
+        // Default contracts only has Tyranny — selecting OneOnOne
+        // must raise NoContractBinding(OneOnOne), not silently fall
+        // through to the Tyranny binding.
+        val interactor = makeInteractor()
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = listOf(ByteArray(32) { 0xCC.toByte() }),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected NoContractBinding(OneOnOne)")
+        } catch (e: CreateGroupError.NoContractBinding) {
+            assertEquals(GovernanceType.OneOnOne, e.type)
+        }
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private fun makeInteractor(
@@ -332,6 +437,7 @@ class CreateGroupInteractorTest {
             chat.onym.android.chain.StaticNetworkPreferenceProvider(
                 chat.onym.android.chain.AppNetwork.Testnet,
             ),
+        contracts: ContractsRepository = this.contracts,
     ) = CreateGroupInteractor(
         identity = identity,
         relayers = relayers,
@@ -343,14 +449,26 @@ class CreateGroupInteractorTest {
         makeContractTransport = { contractTransport },
     )
 
-    private fun makeManifest(includeTyranny: Boolean): ContractsManifest {
-        val entries: List<ContractEntry> = if (includeTyranny) {
-            listOf(ContractEntry(
-                network = ContractNetwork.Testnet,
-                type = GovernanceType.Tyranny,
-                id = "CTYRANNYTEST00000000000000000000000000000000000000000000",
-            ))
-        } else emptyList()
+    private fun makeManifest(
+        includeTyranny: Boolean,
+        includeOneOnOne: Boolean = false,
+    ): ContractsManifest {
+        val entries = buildList<ContractEntry> {
+            if (includeTyranny) {
+                add(ContractEntry(
+                    network = ContractNetwork.Testnet,
+                    type = GovernanceType.Tyranny,
+                    id = "CTYRANNYTEST00000000000000000000000000000000000000000000",
+                ))
+            }
+            if (includeOneOnOne) {
+                add(ContractEntry(
+                    network = ContractNetwork.Testnet,
+                    type = GovernanceType.OneOnOne,
+                    id = "CONEONONETEST0000000000000000000000000000000000000000000",
+                ))
+            }
+        }
         return ContractsManifest(
             version = 1,
             releases = listOf(

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -329,8 +329,13 @@ class OnymApplication : Application() {
                     inboxTransport = inboxTransport,
                 )
                 CreateGroupViewModel(
-                    createGroup = { name, invitees, onProgress ->
-                        interactor.create(name = name, invitees = invitees, onProgress = onProgress)
+                    createGroup = { name, invitees, groupType, onProgress ->
+                        interactor.create(
+                            name = name,
+                            invitees = invitees,
+                            groupType = groupType,
+                            onProgress = onProgress,
+                        )
                     },
                 )
             },

--- a/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.chain
 
 import chat.onym.android.group.GovernanceMember
+import chat.onym.sdk.OneOnOne
 import chat.onym.sdk.Tyranny
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -31,8 +32,11 @@ data class GroupCreateProof(
      *  on the wire). */
     val proof: ByteArray,
     /** SDK's full per-type PI bundle, split into 32-byte chunks.
-     *  Tyranny create returns 4:
-     *  `commitment || Fr(0) || admin_pubkey_commitment || group_id_fr`. */
+     *
+     *  - Tyranny create returns 4:
+     *    `commitment || Fr(0) || admin_pubkey_commitment || group_id_fr`.
+     *  - OneOnOne create returns 2:
+     *    `commitment || Fr(0)` (the contract's symmetric 1v1 PI shape). */
     val publicInputs: List<ByteArray>,
 ) {
     /** First 32 bytes of the PI bundle — the new commitment the
@@ -84,10 +88,20 @@ data class GroupProofCreateInput(
     /** Position of the admin in [members] (after the lex sort). */
     val adminIndex: Int,
     /** 32-byte raw group ID — used directly as the `group_id_fr`
-     *  per-group binding scalar in the Tyranny circuit. */
+     *  per-group binding scalar in the Tyranny circuit. MUST be a
+     *  canonical BLS12-381 Fr scalar (see [CanonicalFr.isCanonical]);
+     *  callers should generate via [CanonicalFr.randomCanonicalFr32]. */
     val groupId: ByteArray,
     /** 32 bytes; LE-mod-r in-circuit. */
     val salt: ByteArray,
+    /** 32 BE Fr — only required when [groupType] is
+     *  [SepGroupType.ONE_ON_ONE]: the SECOND party's BLS secret key,
+     *  fed into `OneOnOne.proveCreate(sk_0, sk_1, salt)` as `sk_1`.
+     *  The OneOnOne FFI rejects `sk_0 == sk_1`, so the creator MUST
+     *  generate a fresh ephemeral scalar (NOT reuse [adminBlsSecretKey])
+     *  and ship it to the invitee inside the sealed invitation envelope.
+     *  `null` for any non-OneOnOne governance type. */
+    val secondaryBlsSecretKey: ByteArray? = null,
 )
 
 /**
@@ -99,10 +113,24 @@ data class GroupProofCreateInput(
  */
 sealed class GroupProofGeneratorError(message: String, cause: Throwable? = null) : Exception(message, cause) {
 
-    /** Caller asked for a governance type other than [SepGroupType.TYRANNY].
-     *  PR-B ships Tyranny only — UI surfaces this as a clear "TBD". */
+    /** Caller asked for a governance type the proof generator hasn't
+     *  wired yet (currently: ANARCHY, DEMOCRACY, OLIGARCHY).
+     *  UI surfaces this as a clear "TBD". */
     class NotYetSupported(val type: SepGroupType) :
         GroupProofGeneratorError("group type not yet supported: $type")
+
+    /** Caller asked for a [SepGroupType.ONE_ON_ONE] proof but did
+     *  not supply [GroupProofCreateInput.secondaryBlsSecretKey]. The
+     *  OneOnOne circuit needs both parties' Fr scalars in the witness
+     *  (and the FFI rejects `sk_0 == sk_1`), so the second key is
+     *  load-bearing and not derivable from the admin secret alone. */
+    object SecondaryBlsSecretKeyRequired :
+        GroupProofGeneratorError(
+            "OneOnOne create requires a second BLS Fr scalar — caller must " +
+                "generate a fresh ephemeral key and pass it as secondaryBlsSecretKey",
+        ) {
+        private fun readResolve(): Any = SecondaryBlsSecretKeyRequired
+    }
 
     /** [GroupProofCreateInput.adminIndex] was negative or `>= members.size`.
      *  Short-circuits before the JNI call so the SDK doesn't have to
@@ -149,12 +177,43 @@ class OnymGroupProofGenerator : GroupProofGenerator {
     override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof =
         when (input.groupType) {
             SepGroupType.TYRANNY -> proveTyrannyCreate(input)
+            SepGroupType.ONE_ON_ONE -> proveOneOnOneCreate(input)
             SepGroupType.ANARCHY,
-            SepGroupType.ONE_ON_ONE,
             SepGroupType.DEMOCRACY,
             SepGroupType.OLIGARCHY,
                 -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
+
+    private suspend fun proveOneOnOneCreate(input: GroupProofCreateInput): GroupCreateProof {
+        val sk1 = input.secondaryBlsSecretKey
+            ?: throw GroupProofGeneratorError.SecondaryBlsSecretKeyRequired
+
+        // CPU-bound — keep it off Dispatchers.IO and off Dispatchers.Main.
+        // The OneOnOne circuit is depth-5 (same as Tyranny SMALL), so
+        // the wall-time profile is comparable.
+        return withContext(Dispatchers.Default) {
+            val raw = try {
+                OneOnOne.proveCreate(
+                    /* secretKey0 = */ input.adminBlsSecretKey,
+                    /* secretKey1 = */ sk1,
+                    /* salt = */ input.salt,
+                )
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            // OneOnOne's CreateProof returns (proof, commitment) as
+            // separate buffers — unlike Tyranny's bundled 128-byte PI
+            // blob. The contract still expects a Vec<BytesN<32>> PI
+            // argument, so we synthesize the 2-element shape the
+            // sep-oneonone circuit verifies: [commitment, fr_zero].
+            // (`fr_zero` is the symmetric placeholder — see
+            // `onym-contracts/plonk/sep-oneonone/src/lib.rs`.)
+            GroupCreateProof(
+                proof = raw.proof,
+                publicInputs = listOf(raw.commitment, ByteArray(32)),
+            )
+        }
+    }
 
     private suspend fun proveTyrannyCreate(input: GroupProofCreateInput): GroupCreateProof {
         if (input.adminIndex < 0 || input.adminIndex >= input.members.size) {

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
@@ -42,6 +42,14 @@ class SepContractClient(
             responseSerializer = SepSubmissionResponse.serializer(),
         )
 
+    suspend fun createGroupOneOnOne(payload: OneOnOneCreateGroupPayload): SepSubmissionResponse =
+        invoke(
+            function = "create_group",
+            payload = payload,
+            payloadSerializer = OneOnOneCreateGroupPayload.serializer(),
+            responseSerializer = SepSubmissionResponse.serializer(),
+        )
+
     suspend fun updateCommitmentTyranny(payload: TyrannyUpdateCommitmentPayload): SepSubmissionResponse =
         invoke(
             function = "update_commitment",

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
@@ -174,6 +174,53 @@ data class TyrannyCreateGroupPayload(
 }
 
 /**
+ * `create_group` payload for the OneOnOne (1v1) contract. Layout
+ * mirrors `add_create_group_args` in `onym-relayer/src/handler.rs`,
+ * `ContractType::OneOnOne` arm — the relayer extracts `caller` from
+ * its config and `group_id` / `commitment` from this payload's
+ * top-level keys, then forwards `--proof` + `--public-inputs` to the
+ * `sep-oneonone` Soroban contract.
+ *
+ * No `tier` (depth=5 is hardcoded in the OneOnOne circuit) and no
+ * `admin_pubkey_commitment` (1v1 has no admin role). The PI vector is
+ * 2 × 32B chunks: `[commitment, fr_zero]` — `fr_zero` is the symmetric
+ * second-element placeholder the OneOnOne contract validates.
+ *
+ * Mirrors `OneOnOneCreateGroupPayload` from onym-ios PR #36.
+ */
+@Serializable
+data class OneOnOneCreateGroupPayload(
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    /** 1601-byte raw PLONK proof — same wire constraint as Tyranny. */
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val proof: ByteArray,
+    /** 2 elements × 32 bytes — `[commitment, fr_zero]`. */
+    val publicInputs: List<@Serializable(with = Base64ByteArraySerializer::class) ByteArray>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OneOnOneCreateGroupPayload) return false
+        return groupId.contentEquals(other.groupId) &&
+            commitment.contentEquals(other.commitment) &&
+            proof.contentEquals(other.proof) &&
+            publicInputs.size == other.publicInputs.size &&
+            publicInputs.zip(other.publicInputs).all { (a, b) -> a.contentEquals(b) }
+    }
+
+    override fun hashCode(): Int {
+        var h = groupId.contentHashCode()
+        h = 31 * h + commitment.contentHashCode()
+        h = 31 * h + proof.contentHashCode()
+        for (p in publicInputs) h = 31 * h + p.contentHashCode()
+        return h
+    }
+}
+
+/**
  * `update_commitment` payload — Tyranny variant. The SDK's
  * `Tyranny.UpdateProof.publicInputs` is 160 bytes = 5 × 32B
  * (`c_old || epoch_old || c_new || admin_pubkey_commitment || group_id_fr`).

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -10,6 +10,7 @@ import chat.onym.android.chain.GroupProofGenerator
 import chat.onym.android.chain.GroupProofGeneratorError
 import chat.onym.android.chain.NetworkPreferenceProvider
 import chat.onym.android.chain.OkHttpSepContractTransport
+import chat.onym.android.chain.OneOnOneCreateGroupPayload
 import chat.onym.android.chain.OnymGroupProofGenerator
 import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.chain.SepContractClient
@@ -87,6 +88,7 @@ open class CreateGroupInteractor(
     open suspend fun create(
         name: String,
         invitees: List<ByteArray>,
+        groupType: SepGroupType = SepGroupType.TYRANNY,
         onProgress: (CreateGroupProgress) -> Unit = {},
     ): ChatGroup {
         // 1. Validate
@@ -96,19 +98,27 @@ open class CreateGroupInteractor(
         for ((index, key) in invitees.withIndex()) {
             if (key.size != 32) throw CreateGroupError.InvalidInviteeKey(index)
         }
+        // OneOnOne is a strict 2-party group — exactly 1 invitee
+        // (the second party). Tyranny tolerates any count including
+        // zero.
+        if (groupType == SepGroupType.ONE_ON_ONE && invitees.size != 1) {
+            throw CreateGroupError.OneOnOneRequiresExactlyOneInvitee(actual = invitees.size)
+        }
 
-        // 2. Resolve relayer + contract binding
+        val governanceType = groupType.toGovernanceType()
+            ?: throw CreateGroupError.UnsupportedGroupType(groupType)
+
+        // 2. Resolve relayer + contract binding for the requested
+        //    governance type. Same key drives both `binding.contractId`
+        //    and the wire payload's top-level `contractType`.
         val relayerUrl = relayers.selectUrl() ?: throw CreateGroupError.NoActiveRelayer
-        // Resolve the contract binding for whichever network the
-        // user has selected — same key is reused for the wire
-        // payload's top-level `network` field below.
         val activeNetwork = networkPreference.current()
         val key = AnchorSelectionKey(
             network = activeNetwork.contractNetwork,
-            type = GovernanceType.Tyranny,
+            type = governanceType,
         )
         val binding = contracts.snapshots.value.binding(key)
-            ?: throw CreateGroupError.NoContractBinding(GovernanceType.Tyranny)
+            ?: throw CreateGroupError.NoContractBinding(governanceType)
 
         // 3. Group params.
         // `groupId` MUST be a canonical bls12-381 Fr (BE value < r) —
@@ -121,15 +131,14 @@ open class CreateGroupInteractor(
         val groupId = CanonicalFr.randomCanonicalFr32()
         val groupSecret = randomBytes(32)
         val salt = GroupCommitmentBuilder.generateSalt()
-        val tier = SepTier.SMALL
+        val tier = SepTier.SMALL  // OneOnOne ignores tier (depth=5 hardcoded)
 
-        // 4. Creator member — the one BLS Fr scalar read outside
-        // IdentityRepository this layer needs. The bytes pass straight
-        // into Tyranny.proveCreate (via GroupProofGenerator) and into
-        // computeLeafHash, then fall out of scope at the end of this
-        // method. IdentityRepository pins the "do not retain" contract
-        // on the accessor; this is the proof-generation hop the
-        // contract authorises.
+        // 4. Creator's BLS key. The bytes pass straight into the
+        //    proof generator and into `computeLeafHash`, then fall
+        //    out of scope at the end of this method.
+        //    IdentityRepository pins the "do not retain" contract on
+        //    the accessor; this is the proof-generation hop the
+        //    contract authorises.
         val blsSecret = try {
             // onym:allow-secret-read
             identity.blsSecretKey()
@@ -146,48 +155,77 @@ open class CreateGroupInteractor(
         } catch (e: Throwable) {
             throw CreateGroupError.SdkFailure(e.message ?: e.toString())
         }
-        val members = listOf(creatorMember)  // single-member roster, already sorted
+        val members = listOf(creatorMember)  // local creator-only roster
+
+        // OneOnOne: generate a fresh ephemeral BLS Fr for the second
+        // party and use it as `sk_1` in the founding ceremony. The
+        // FFI rejects `sk_0 == sk_1`, so retry on the (vanishing)
+        // chance the canonical sample collides with the creator's key.
+        val secondaryBlsSecret: ByteArray? = if (groupType == SepGroupType.ONE_ON_ONE) {
+            var candidate: ByteArray
+            do {
+                candidate = CanonicalFr.randomCanonicalFr32()
+            } while (candidate.contentEquals(blsSecret))
+            candidate
+        } else {
+            null
+        }
 
         // 5. Generate proof
         onProgress(CreateGroupProgress.Proving)
-        val input = GroupProofCreateInput(
-            groupType = SepGroupType.TYRANNY,
+        val proofInput = GroupProofCreateInput(
+            groupType = groupType,
             tier = tier,
             members = members,
             adminBlsSecretKey = blsSecret,
             adminIndex = 0,
             groupId = groupId,
             salt = salt,
+            secondaryBlsSecretKey = secondaryBlsSecret,
         )
         val proof: GroupCreateProof = try {
-            proofGenerator.proveCreate(input)
+            proofGenerator.proveCreate(proofInput)
         } catch (e: GroupProofGeneratorError) {
             throw CreateGroupError.ProofGenerationFailed(e)
         } catch (e: Throwable) {
             throw CreateGroupError.SdkFailure(e.message ?: e.toString())
         }
 
-        // 6. Anchor on chain
+        // 6. Anchor on chain — per-type payload + relayer call.
         onProgress(CreateGroupProgress.Anchoring)
         val transport = makeContractTransport(relayerUrl)
         val client = SepContractClient(
             contractID = binding.contractId,
-            contractType = SepGroupType.TYRANNY,
+            contractType = groupType,
             network = activeNetwork.sepNetwork,
             transport = transport,
         )
-        val payload = TyrannyCreateGroupPayload(
-            groupId = groupId,
-            commitment = proof.commitment,
-            tier = tier.rawValue,
-            adminPubkeyCommitment = proof.adminPubkeyCommitment,
-            proof = proof.proof,
-            publicInputs = proof.publicInputs,
-        )
         val response = try {
-            client.createGroupTyranny(payload)
+            when (groupType) {
+                SepGroupType.TYRANNY -> client.createGroupTyranny(
+                    TyrannyCreateGroupPayload(
+                        groupId = groupId,
+                        commitment = proof.commitment,
+                        tier = tier.rawValue,
+                        adminPubkeyCommitment = proof.adminPubkeyCommitment,
+                        proof = proof.proof,
+                        publicInputs = proof.publicInputs,
+                    ),
+                )
+                SepGroupType.ONE_ON_ONE -> client.createGroupOneOnOne(
+                    OneOnOneCreateGroupPayload(
+                        groupId = groupId,
+                        commitment = proof.commitment,
+                        proof = proof.proof,
+                        publicInputs = proof.publicInputs,
+                    ),
+                )
+                else -> throw CreateGroupError.UnsupportedGroupType(groupType)
+            }
         } catch (e: SepContractError) {
             throw CreateGroupError.AnchorTransport(e.message ?: "transport error")
+        } catch (e: CreateGroupError) {
+            throw e
         } catch (e: Throwable) {
             throw CreateGroupError.AnchorTransport(e.message ?: "unknown")
         }
@@ -195,9 +233,15 @@ open class CreateGroupInteractor(
             throw CreateGroupError.AnchorRejected(response.message)
         }
 
-        // 7. Save locally
+        // 7. Save locally. For OneOnOne we don't surface an
+        //    `adminPubkeyHex` (no admin role on chain); leaving it
+        //    null lets the receiver-side decoder branch on it.
         val groupIdHex = groupId.toHex()
-        val adminPubkeyHex = identitySnapshot.blsPublicKey.toHex()
+        val adminPubkeyHex = if (groupType == SepGroupType.TYRANNY) {
+            identitySnapshot.blsPublicKey.toHex()
+        } else {
+            null
+        }
         val group = ChatGroup(
             id = groupIdHex,
             name = trimmedName,
@@ -208,38 +252,41 @@ open class CreateGroupInteractor(
             salt = salt,
             commitment = proof.commitment,
             tier = tier,
-            groupType = SepGroupType.TYRANNY,
+            groupType = groupType,
             adminPubkeyHex = adminPubkeyHex,
             isPublishedOnChain = false,
         )
         groups.insert(group)
         groups.markPublished(group.id, proof.commitment)
 
-        // 8. Send invitations (group is already on disk; failures
-        //    throw but a future "retry invites" UI can pick up the
-        //    half-delivered state).
+        // 8. Send invitations. For OneOnOne the (sole) invitee gets
+        //    the ephemeral `secondaryBlsSecret` so they can act as
+        //    the second party of the immutable group.
         if (invitees.isNotEmpty()) {
             onProgress(CreateGroupProgress.SendingInvitations(invitees.size))
-            val invitePayload = GroupInvitationPayload(
-                version = 1,
-                groupId = groupId,
-                groupSecret = groupSecret,
-                name = trimmedName,
-                members = members,
-                epoch = 0uL,
-                salt = salt,
-                commitment = proof.commitment,
-                tierRaw = tier.rawValue,
-                groupTypeRaw = SepGroupType.TYRANNY.wireValue,
-                adminPubkeyHex = adminPubkeyHex,
-            )
-            val payloadBytes = try {
-                jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)
-                    .toByteArray(Charsets.UTF_8)
-            } catch (_: Throwable) {
-                throw CreateGroupError.InvitationEncodingFailed
-            }
             for ((index, inboxKey) in invitees.withIndex()) {
+                val invitePayload = GroupInvitationPayload(
+                    version = 1,
+                    groupId = groupId,
+                    groupSecret = groupSecret,
+                    name = trimmedName,
+                    members = members,
+                    epoch = 0uL,
+                    salt = salt,
+                    commitment = proof.commitment,
+                    tierRaw = tier.rawValue,
+                    groupTypeRaw = groupType.wireValue,
+                    adminPubkeyHex = adminPubkeyHex,
+                    inviteeBlsSecretKey = secondaryBlsSecret,
+                )
+                val payloadBytes = try {
+                    jsonFormat.encodeToString(
+                        GroupInvitationPayload.serializer(),
+                        invitePayload,
+                    ).toByteArray(Charsets.UTF_8)
+                } catch (_: Throwable) {
+                    throw CreateGroupError.InvitationEncodingFailed
+                }
                 val sealed = try {
                     identity.sealInvitation(payloadBytes, inboxKey)
                 } catch (e: Throwable) {
@@ -264,6 +311,18 @@ open class CreateGroupInteractor(
         // the caller sees `isPublishedOnChain = true`.
         return groups.snapshots.value.firstOrNull { it.id == group.id }
             ?: group.copy(isPublishedOnChain = true)
+    }
+
+    /** Bridge the wire-typed [SepGroupType] to the binding-key
+     *  [GovernanceType]. Returns `null` for governance flavours that
+     *  don't have a contract slot today (e.g. `democracy`,
+     *  `oligarchy` until they ship). */
+    private fun SepGroupType.toGovernanceType(): GovernanceType? = when (this) {
+        SepGroupType.TYRANNY -> GovernanceType.Tyranny
+        SepGroupType.ONE_ON_ONE -> GovernanceType.OneOnOne
+        SepGroupType.ANARCHY -> GovernanceType.Anarchy
+        SepGroupType.DEMOCRACY -> GovernanceType.Democracy
+        SepGroupType.OLIGARCHY -> GovernanceType.Oligarchy
     }
 
     private companion object {
@@ -320,6 +379,14 @@ sealed class CreateGroupError(message: String) : Exception(message) {
 
     class InvalidInviteeKey(val index: Int) :
         CreateGroupError("Invitee #${index + 1} is not a 32-byte X25519 public key")
+
+    class OneOnOneRequiresExactlyOneInvitee(val actual: Int) :
+        CreateGroupError(
+            "1-on-1 groups need exactly one invitee — you added $actual.",
+        )
+
+    class UnsupportedGroupType(val type: SepGroupType) :
+        CreateGroupError("$type groups can't be created yet")
 
     object MissingIdentity : CreateGroupError("No identity is loaded — bootstrap or restore first") {
         private fun readResolve(): Any = MissingIdentity

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -145,6 +145,7 @@ data class CreateGroupState(
 typealias GroupCreator = suspend (
     name: String,
     invitees: List<ByteArray>,
+    groupType: SepGroupType,
     onProgress: (CreateGroupProgress) -> Unit,
 ) -> ChatGroup
 
@@ -293,6 +294,7 @@ class CreateGroupViewModel(
             val group = createGroup(
                 current.effectiveName,
                 current.invitees.map { it.inboxPublicKey },
+                current.governance.sepGroupType,
             ) { p -> _state.value = _state.value.copy(progress = p) }
             _state.value = _state.value.copy(
                 createdGroup = group,

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -91,9 +91,10 @@ data class CreateGroupState(
      *  screen content. */
     val createdGroup: ChatGroup? = null,
 ) {
-    /** True when the selected governance type is wired (Tyranny only
-     *  in PR-C). The name no longer gates advance — submit falls back
-     *  to [generatedName] when the field is empty. */
+    /** True when the selected governance type is wired to the chain
+     *  layer. Tyranny + 1-on-1 are wired; Anarchy is still TBD. The
+     *  name no longer gates advance — submit falls back to
+     *  [generatedName] when the field is empty. */
     val canAdvanceToStep2: Boolean
         get() = governance.isAvailable
 
@@ -102,12 +103,32 @@ data class CreateGroupState(
     val effectiveName: String
         get() = name.trim().ifEmpty { generatedName }
 
-    /** Label for the primary "Create" CTA on Step2. */
+    /** Label for the primary "Create" CTA on Step2. Per-governance:
+     *  - Tyranny tolerates 0..N invitees ("Create empty group" / "with N").
+     *  - 1-on-1 needs exactly 1 invitee — the CTA spells out the gate
+     *    so the user understands why it's disabled. */
     val createCtaLabel: String
-        get() = when (invitees.size) {
-            0 -> "Create empty group"
-            1 -> "Create with 1 person"
-            else -> "Create with ${invitees.size} people"
+        get() = when (governance) {
+            OnymUIGovernance.OneOnOne -> when (invitees.size) {
+                0 -> "Add the other person"
+                1 -> "Start 1-on-1"
+                else -> "1-on-1 needs exactly one"
+            }
+            else -> when (invitees.size) {
+                0 -> "Create empty group"
+                1 -> "Create with 1 person"
+                else -> "Create with ${invitees.size} people"
+            }
+        }
+
+    /** Whether the Create CTA on Step2 is enabled. Tyranny is always
+     *  enabled (zero invitees = creator-only group); 1-on-1 requires
+     *  exactly one invitee — the chain leg would reject otherwise
+     *  (PR-2's `OneOnOneRequiresExactlyOneInvitee`). */
+    val canSubmit: Boolean
+        get() = when (governance) {
+            OnymUIGovernance.OneOnOne -> invitees.size == 1
+            else -> governance.isAvailable
         }
 
     /** Live char count for the InviteByKey field — matches the
@@ -284,6 +305,18 @@ class CreateGroupViewModel(
             )
             return
         }
+        // 1-on-1 needs exactly one invitee — surface the error here
+        // rather than letting the interactor throw mid-pipeline.
+        if (current.governance == OnymUIGovernance.OneOnOne &&
+            current.invitees.size != 1
+        ) {
+            _state.value = current.copy(
+                error = CreateGroupError.OneOnOneRequiresExactlyOneInvitee(
+                    actual = current.invitees.size,
+                ),
+            )
+            return
+        }
         _state.value = current.copy(
             error = null,
             progress = CreateGroupProgress.Validating,
@@ -409,8 +442,20 @@ enum class OnymUIGovernance(
     ),
     ;
 
-    /** Per-PR-C scope: only Tyranny is wired to the chain layer. */
-    val isAvailable: Boolean get() = this == Tyranny
+    /** Tyranny + 1-on-1 are wired to the chain layer; Anarchy is
+     *  still TBD (no FFI proof generator and no contract slot). */
+    val isAvailable: Boolean get() = this == Tyranny || this == OneOnOne
+
+    /** One-line addendum rendered in the Step-2 banner under the
+     *  governance label. Type-specific because the implications
+     *  differ — Tyranny mentions the admin role, 1-on-1 mentions the
+     *  exact-one-invitee constraint. */
+    val step2Hint: String
+        get() = when (this) {
+            Tyranny -> "You'll be the only admin."
+            OneOnOne -> "Pick exactly one person."
+            Anarchy -> "Everyone shares control."
+        }
 
     val sepGroupType: SepGroupType
         get() = when (this) {

--- a/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
@@ -57,6 +57,21 @@ data class GroupInvitationPayload(
      *  `null` for ANARCHY / ONE_ON_ONE. */
     @SerialName("admin_pubkey_hex")
     val adminPubkeyHex: String? = null,
+    /** **OneOnOne only.** 32 BE Fr — the ephemeral BLS secret the
+     *  creator generated for this invitee and used as `sk_1` in the
+     *  founding `OneOnOne.proveCreate(sk_0, sk_1, salt)` call. The
+     *  receiver needs this to act as the second party of the
+     *  immutable 1v1 group.
+     *
+     *  `null` for every other governance type — those flows let the
+     *  receiver bring their own BLS identity.
+     *
+     *  ⚠ Carries a private key. Sealed by
+     *  [chat.onym.android.identity.IdentityRepository.sealInvitation]
+     *  before it leaves the device — never logged, never echoed. */
+    @SerialName("invitee_bls_secret_key")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val inviteeBlsSecretKey: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -71,7 +86,9 @@ data class GroupInvitationPayload(
             (commitment?.contentEquals(other.commitment) ?: (other.commitment == null)) &&
             tierRaw == other.tierRaw &&
             groupTypeRaw == other.groupTypeRaw &&
-            adminPubkeyHex == other.adminPubkeyHex
+            adminPubkeyHex == other.adminPubkeyHex &&
+            (inviteeBlsSecretKey?.contentEquals(other.inviteeBlsSecretKey)
+                ?: (other.inviteeBlsSecretKey == null))
     }
 
     override fun hashCode(): Int {
@@ -86,6 +103,7 @@ data class GroupInvitationPayload(
         h = 31 * h + tierRaw
         h = 31 * h + groupTypeRaw.hashCode()
         h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
+        h = 31 * h + (inviteeBlsSecretKey?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -356,7 +356,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                 ) {
                     OnymGovIcon(type = state.governance, accent = accent, size = 28.dp)
                     Text(
-                        text = "${state.governance.label}. You'll be the only admin.",
+                        text = "${state.governance.label}. ${state.governance.step2Hint}",
                         color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                         modifier = Modifier.weight(1f),
@@ -508,6 +508,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
             OnymPrimaryButton(
                 title = state.createCtaLabel,
                 accent = accent,
+                enabled = state.canSubmit,
                 onClick = viewModel::tappedCreate,
             )
             OnymQuietButton(title = "Back", onClick = viewModel::tappedBackFromStep2)

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
@@ -16,18 +16,29 @@ import chat.onym.android.chain.SepGroupType
  * in the follow-up to drop the parsed-1568 + epoch-pair shape).
  */
 class StubGroupProofGenerator : GroupProofGenerator {
-    override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof {
-        if (input.groupType != SepGroupType.TYRANNY) {
-            throw GroupProofGeneratorError.NotYetSupported(input.groupType)
+    override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof =
+        when (input.groupType) {
+            SepGroupType.TYRANNY -> GroupCreateProof(
+                proof = ByteArray(1601) { 0xAB.toByte() },
+                publicInputs = listOf(
+                    ByteArray(32) { 0xCD.toByte() },  // commitment
+                    ByteArray(32),                     // Fr(0)
+                    ByteArray(32) { 0xEE.toByte() },  // admin_pubkey_commitment
+                    ByteArray(32) { 0xFF.toByte() },  // group_id_fr
+                ),
+            )
+            SepGroupType.ONE_ON_ONE -> {
+                if (input.secondaryBlsSecretKey == null) {
+                    throw GroupProofGeneratorError.SecondaryBlsSecretKeyRequired
+                }
+                GroupCreateProof(
+                    proof = ByteArray(1601) { 0x12.toByte() },
+                    publicInputs = listOf(
+                        ByteArray(32) { 0x34.toByte() },  // commitment
+                        ByteArray(32),                     // Fr(0)
+                    ),
+                )
+            }
+            else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
-        return GroupCreateProof(
-            proof = ByteArray(1601) { 0xAB.toByte() },
-            publicInputs = listOf(
-                ByteArray(32) { 0xCD.toByte() },  // commitment
-                ByteArray(32),                      // Fr(0)
-                ByteArray(32) { 0xEE.toByte() },  // admin_pubkey_commitment
-                ByteArray(32) { 0xFF.toByte() },  // group_id_fr
-            ),
-        )
-    }
 }

--- a/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
@@ -28,12 +28,25 @@ class GroupProofGeneratorTest {
     }
 
     @Test
-    fun proveCreate_oneOnOne_throwsNotYetSupported() = runTest {
-        val input = stubInput(SepGroupType.ONE_ON_ONE)
+    fun proveCreate_democracy_throwsNotYetSupported() = runTest {
+        val input = stubInput(SepGroupType.DEMOCRACY)
         val thrown = assertThrows(GroupProofGeneratorError.NotYetSupported::class.java) {
             kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
         }
-        assertEquals(SepGroupType.ONE_ON_ONE, thrown.type)
+        assertEquals(SepGroupType.DEMOCRACY, thrown.type)
+    }
+
+    @Test
+    fun proveCreate_oneOnOne_withoutSecondaryKey_throws() = runTest {
+        // OneOnOne is now wired (no longer NotYetSupported), but the
+        // secondaryBlsSecretKey is mandatory and short-circuits before
+        // any FFI call when missing.
+        val input = stubInput(SepGroupType.ONE_ON_ONE)
+        val thrown = assertThrows(GroupProofGeneratorError.SecondaryBlsSecretKeyRequired::class.java) {
+            kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
+        }
+        // Sanity: object-singleton, not a class with state to inspect.
+        assertEquals(GroupProofGeneratorError.SecondaryBlsSecretKeyRequired, thrown)
     }
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
@@ -101,6 +101,46 @@ class SepContractClientTest {
     }
 
     @Test
+    fun createGroupOneOnOne_sendsCreateGroupFunction_withTwoChunkPI_andNoTier() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """{"accepted":true,"transactionHash":"oo123"}""",
+        )
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.ONE_ON_ONE,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        val payload = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0x42 },
+            commitment = ByteArray(32) { 0x55 },
+            proof = ByteArray(1601) { 0x77 },
+            publicInputs = listOf(ByteArray(32) { 0x55 }, ByteArray(32)),
+        )
+        val response = client.createGroupOneOnOne(payload)
+        assertTrue(response.accepted)
+        assertEquals("oo123", response.transactionHash)
+
+        assertEquals("create_group", transport.lastFunction)
+        val invocation = transport.lastInvocationJson!!
+        assertEquals("oneonone", invocation["contractType"]!!.jsonPrimitive.contentOrNull)
+
+        val payloadJson = transport.lastPayloadJson!!
+        assertNotNull("group_id required", payloadJson["group_id"])
+        assertNotNull("commitment required", payloadJson["commitment"])
+        assertNotNull("proof required", payloadJson["proof"])
+        assertEquals("OneOnOne sends no tier", null, payloadJson["tier"])
+        assertEquals(
+            "OneOnOne sends no admin_pubkey_commitment",
+            null,
+            payloadJson["admin_pubkey_commitment"],
+        )
+        val pi = payloadJson["publicInputs"] as JsonArray
+        assertEquals(2, pi.size)
+    }
+
+    @Test
     fun updateCommitmentTyranny_routesToUpdateFunction_with5ChunkPI() = runTest {
         val transport = FakeSepContractTransport(
             cannedResponseJson = """{"accepted":true}""",

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
@@ -163,6 +163,59 @@ class SepContractTypesTest {
         assertEquals(original, decoded)
     }
 
+    // ─── OneOnOneCreateGroupPayload ───────────────────────────────
+
+    @Test
+    fun oneOnOneCreateGroupPayload_emitsExpectedKeys() {
+        val payload = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0xAB.toByte() },
+            commitment = ByteArray(32) { 0xCD.toByte() },
+            proof = ByteArray(1601) { 0x01 },
+            publicInputs = listOf(
+                ByteArray(32) { 0xCD.toByte() },
+                ByteArray(32),
+            ),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(OneOnOneCreateGroupPayload.serializer(), payload),
+        ).jsonObject
+
+        assertNotNull("group_id required", obj["group_id"])
+        assertNotNull("commitment required", obj["commitment"])
+        assertNotNull("proof required", obj["proof"])
+        // No `tier` and no `admin_pubkey_commitment` — OneOnOne is
+        // depth-5 hardcoded with no admin role.
+        assertNull("tier must NOT appear", obj["tier"])
+        assertNull("admin_pubkey_commitment must NOT appear", obj["admin_pubkey_commitment"])
+
+        val pi = obj["publicInputs"] as JsonArray
+        assertEquals("OneOnOne PI is 2 × 32B (commitment, fr_zero)", 2, pi.size)
+        for (element in pi) {
+            val raw = Base64.getDecoder().decode(element.jsonPrimitive.content)
+            assertEquals(32, raw.size)
+        }
+
+        val proofBytes = Base64.getDecoder().decode(obj["proof"]!!.jsonPrimitive.content)
+        assertEquals(1601, proofBytes.size)
+        assertArrayEquals(payload.proof, proofBytes)
+    }
+
+    @Test
+    fun oneOnOneCreateGroupPayload_roundtripPreservesAllFields() {
+        val original = OneOnOneCreateGroupPayload(
+            groupId = ByteArray(32) { 0x11 },
+            commitment = ByteArray(32) { 0x22 },
+            proof = ByteArray(1601) { 0x33 },
+            publicInputs = listOf(
+                ByteArray(32) { 0x22 },
+                ByteArray(32),
+            ),
+        )
+        val encoded = json.encodeToString(OneOnOneCreateGroupPayload.serializer(), original)
+        val decoded = json.decodeFromString(OneOnOneCreateGroupPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
     // ─── TyrannyUpdateCommitmentPayload ───────────────────────────
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -250,6 +250,55 @@ class CreateGroupViewModelTest {
         assertEquals("Create with 2 people", vm.state.value.createCtaLabel)
     }
 
+    // ─── OneOnOne governance ──────────────────────────────────────
+
+    @Test
+    fun oneOnOne_isSelectable_andAdvancesToStep2() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        assertEquals(OnymUIGovernance.OneOnOne, vm.state.value.governance)
+        assertTrue(vm.state.value.canAdvanceToStep2)
+    }
+
+    @Test
+    fun oneOnOne_canSubmitOnly_whenInviteeCountIsExactlyOne() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        // Zero invitees → cannot submit.
+        assertTrue("zero invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
+        // One invitee → enabled.
+        vm.setInviteeInput("aa".repeat(32))
+        vm.tappedAddInvitee()
+        assertTrue("one invitee enables 1-on-1 submit", vm.state.value.canSubmit)
+        // Two invitees → blocked again.
+        vm.tappedInviteByKey()
+        vm.setInviteeInput("bb".repeat(32))
+        vm.tappedAddInvitee()
+        assertTrue("two invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
+    }
+
+    @Test
+    fun oneOnOne_ctaLabel_explainsTheGate() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        assertEquals("Add the other person", vm.state.value.createCtaLabel)
+        vm.setInviteeInput("aa".repeat(32))
+        vm.tappedAddInvitee()
+        assertEquals("Start 1-on-1", vm.state.value.createCtaLabel)
+        vm.tappedInviteByKey()
+        vm.setInviteeInput("bb".repeat(32))
+        vm.tappedAddInvitee()
+        assertEquals("1-on-1 needs exactly one", vm.state.value.createCtaLabel)
+    }
+
+    @Test
+    fun tyranny_canSubmit_evenWithZeroInvitees() = runTest {
+        val vm = makeViewModel()
+        // Default is Tyranny — zero invitees still enables submit
+        // (creator-only group is the canonical Tyranny zero case).
+        assertTrue(vm.state.value.canSubmit)
+    }
+
     // ─── close / reset ────────────────────────────────────────────
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -319,7 +319,7 @@ class CreateGroupViewModelTest {
      *  lambda just throws if reached — the screen flow is still fully
      *  exercised via intent dispatch. */
     private fun makeViewModel(): CreateGroupViewModel = CreateGroupViewModel(
-        createGroup = { _, _, _ ->
+        createGroup = { _, _, _, _ ->
             error("createGroup must not be invoked from VM tests")
         },
     )

--- a/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
@@ -1,0 +1,119 @@
+package chat.onym.android.group
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Wire-format pin for [GroupInvitationPayload]. PR-2 adds the
+ * `invitee_bls_secret_key` field for OneOnOne; everything else stays
+ * round-trippable so older / non-OneOnOne envelopes decode unchanged.
+ */
+class GroupInvitationPayloadTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun roundtrip_tyrannyShape_preservesAllFields_andOmitsOneOnOneKey() {
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0x11 },
+            groupSecret = ByteArray(32) { 0x22 },
+            name = "Friends",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x33 },
+            commitment = ByteArray(32) { 0x44 },
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            adminPubkeyHex = "abc",
+            inviteeBlsSecretKey = null,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+
+        // The serializer emits the new field only when it has a value
+        // (Json by default still emits null when encodeDefaults=true,
+        // so just sanity-check the snake_case key spelling).
+        val obj = json.parseToJsonElement(encoded).jsonObject
+        assertTrue(
+            "invitee_bls_secret_key key must use snake_case if present",
+            obj.containsKey("invitee_bls_secret_key") || obj["invitee_bls_secret_key"] == null,
+        )
+        // tier_raw + group_type_raw stay snake-cased for cross-platform parity.
+        assertEquals(0, obj["tier_raw"]!!.jsonPrimitive.contentOrNull?.toInt())
+        assertEquals("tyranny", obj["group_type_raw"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("abc", obj["admin_pubkey_hex"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundtrip_oneOnOneShape_carriesInviteeBlsSecretAsBase64() {
+        val sk1 = ByteArray(32) { 0x99.toByte() }
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0x55 },
+            groupSecret = ByteArray(32) { 0x66 },
+            name = "1v1",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x77 },
+            commitment = ByteArray(32) { 0x88.toByte() },
+            tierRaw = 0,
+            groupTypeRaw = "oneonone",
+            adminPubkeyHex = null,
+            inviteeBlsSecretKey = sk1,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        val rawB64 = obj["invitee_bls_secret_key"]!!.jsonPrimitive.content
+        assertArrayEquals(sk1, Base64.getDecoder().decode(rawB64))
+
+        // OneOnOne envelopes don't surface an admin pubkey.
+        assertNull(
+            "admin_pubkey_hex must be JSON-null for OneOnOne envelopes",
+            obj["admin_pubkey_hex"]!!.jsonPrimitive.contentOrNull,
+        )
+
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertNotNull(decoded.inviteeBlsSecretKey)
+        assertArrayEquals(sk1, decoded.inviteeBlsSecretKey)
+    }
+
+    @Test
+    fun decode_legacyEnvelopeWithoutInviteeBlsSecretKey_decodesWithNullField() {
+        // Envelopes from a pre-PR-2 sender don't include the new field.
+        // The optional default keeps decoding compatible.
+        val legacyJson = """
+            {
+              "version": 1,
+              "group_id": "${b64(ByteArray(32) { 0x10 })}",
+              "group_secret": "${b64(ByteArray(32) { 0x20 })}",
+              "name": "legacy",
+              "members": [],
+              "epoch": 0,
+              "salt": "${b64(ByteArray(32) { 0x30 })}",
+              "commitment": "${b64(ByteArray(32) { 0x40 })}",
+              "tier_raw": 0,
+              "group_type_raw": "tyranny",
+              "admin_pubkey_hex": "deadbeef"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), legacyJson)
+        assertEquals("legacy", decoded.name)
+        assertNull(decoded.inviteeBlsSecretKey)
+    }
+
+    private fun b64(bytes: ByteArray): String =
+        Base64.getEncoder().encodeToString(bytes)
+}


### PR DESCRIPTION
## Summary

Top of the OneOnOne stack. Stacked on #37 (PR-2), which is stacked on #36 (PR-1). Mirrors onym-ios PR #36 PR-3 follow-up.

User-facing change: the "1-on-1" governance card in Create Group is now selectable instead of showing "Soon". Picking it gates the Step-2 Create CTA on having **exactly one** invitee.

- `OnymUIGovernance.OneOnOne.isAvailable = true` → picker drops the "Soon" pill and the card is clickable.
- `step2Hint` per governance — the Step-2 banner used to read "Tyranny. You'll be the only admin." for every type. Now it's per-type: "1-on-1. Pick exactly one person." etc.
- `CreateGroupState.canSubmit` — Tyranny: always-on (zero invitees = creator-only group). 1-on-1: invitees.size == 1. The Step-2 Create button reads this directly via `enabled = state.canSubmit`.
- `createCtaLabel` per type — 1-on-1 self-explains the gate ("Add the other person" → "Start 1-on-1" → "1-on-1 needs exactly one").
- `submit()` short-circuits with PR-2's `OneOnOneRequiresExactlyOneInvitee` if someone bypasses the gate (defense in depth).
- VM tests cover every CTA-label state, the per-type submit gate, picker selectability, and the always-on Tyranny case.

## Test plan

- [x] Unit: `CreateGroupViewModelTest` — new tests `oneOnOne_isSelectable_andAdvancesToStep2`, `oneOnOne_canSubmitOnly_whenInviteeCountIsExactlyOne`, `oneOnOne_ctaLabel_explainsTheGate`, `tyranny_canSubmit_evenWithZeroInvitees`
- [x] Existing unit suites still green (chain, group, identity)
- [x] AndroidTest compiles
- [x] `:app:assembleDebug` succeeds
- [ ] Manual: open Create Group → tap 1-on-1 card → Next → assert Create CTA reads "Add the other person" and is disabled → paste an inbox key → "Start 1-on-1" enables → tap → real testnet round-trip via PR-1 + PR-2

## Acceptance

User can create a 1-on-1 group on Android end-to-end via the "1-on-1" card on Step-1 → paste invitee key → "Start 1-on-1" → group lands on testnet (no `InvalidCommitmentEncoding` thanks to PR-1's canonical-Fr fix) and the invitee receives a sealed envelope carrying their ephemeral `sk_1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)