### PR TITLE
ui-tests: open Settings tab before tapping Settings rows

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
@@ -7,13 +7,33 @@ import androidx.compose.ui.test.performClick
 /**
  * Page object for the root Settings screen. Just the two rows we
  * navigate into from instrumented tests.
+ *
+ * Post-PR-30 the start destination is the Chats tab, not Settings —
+ * so every method here first taps the Settings bottom-bar tab to
+ * make sure the rows we want are in the visible window. Without
+ * that hop the rows still exist in the NavHost (Chats is also
+ * mounted) but their compose bounds aren't on-screen, so
+ * `performClick` fails with `Failed to inject touch input`
+ * (run #25263258259 surfaced this on every AnchorsUITest /
+ * RelayerSettingsUITest case).
  */
 class SettingsScreenObject(private val rule: ComposeContentTestRule) {
+
     fun tapRelayerRow() {
+        openSettingsTab()
         rule.onNodeWithTag("settings.relayer_row").performClick()
     }
 
     fun tapAnchorsRow() {
+        openSettingsTab()
         rule.onNodeWithTag("settings.anchors_row").performClick()
+    }
+
+    /** Tap the Settings tab in the bottom NavigationBar. Idempotent
+     *  — if the user is already on the Settings tab the tap is a
+     *  no-op (single-top + restoreState in [chat.onym.android.RootScreen]). */
+    private fun openSettingsTab() {
+        rule.onNodeWithTag("nav.tab.settings").performClick()
+        rule.waitForIdle()
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import androidx.compose.ui.platform.LocalContext
@@ -88,6 +89,7 @@ fun RootScreen(dependencies: AppDependencies) {
                             icon = { Icon(tab.icon(), contentDescription = null) },
                             label = { Text(stringResource(tab.labelRes)) },
                             selected = currentRoute == tab.route,
+                            modifier = androidx.compose.ui.Modifier.testTag("nav.tab.${tab.route}"),
                             onClick = {
                                 navController.navigate(tab.route) {
                                     // Keep a single instance of each tab destination


### PR DESCRIPTION
## Summary

Run [#25263258259](https://github.com/onymchat/onym-android/actions/runs/25263258259/job/74073866218) failed 9 UI tests in `AnchorsUITest` (3) + `RelayerSettingsUITest` (6), all with the same error:

```
java.lang.AssertionError: Failed to inject touch input.
```

You called the diagnosis right: PR #30 made **Chats** the start destination of the NavHost, but `SettingsScreenObject.tapAnchorsRow` / `tapRelayerRow` looked up `settings.anchors_row` / `settings.relayer_row` directly. Compose-test can resolve a `testTag` against off-screen compositions, but `performClick` fails to deliver the touch because the row's bounds aren't on the visible window.

## Fix

- `SettingsScreenObject.tapAnchorsRow` / `tapRelayerRow` first tap the Settings bottom-bar tab, then the row. Idempotent (single-top + restoreState in `RootScreen`), so re-taps when already on Settings are safe no-ops.
- Tagged each `NavigationBarItem` in `RootScreen.kt` with `nav.tab.<route>` (`nav.tab.chats`, `nav.tab.settings`, `nav.tab.search`) so the test selector is stable across copy / icon changes.

## Test plan

- [x] `:app:compileDebugKotlin :app:compileDebugAndroidTestKotlin` — green
- [ ] CI: re-dispatch a Release; expect AnchorsUITest + RelayerSettingsUITest (9 cases) to land green

🤖 Generated with [Claude Code](https://claude.com/claude-code)