### PR TITLE
fix: rejection-sample groupId into canonical bls12-381 Fr

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
@@ -97,17 +97,6 @@ import java.util.UUID
  * Mirrors `CreateGroupTyrannyE2ETests.swift` from onym-ios PR #32.
  */
 @RunWith(AndroidJUnit4::class)
-@org.junit.Ignore(
-    "Disabled pending the cross-repo BLS Fr canonical-encoding fix between " +
-        "OnymSDK + the deployed Tyranny contract. Run #25262987336 hit " +
-        "`Error(Contract, #15) InvalidCommitmentEncoding` — the contract's " +
-        "`is_canonical_fr` (sep-tyranny/src/lib.rs:284-300) rejects either the " +
-        "`commitment`, `admin_pubkey_commitment`, or `group_id_fr` arg because " +
-        "the SDK emits Fr scalars in a byte order Soroban's `Fr::from_bytes` " +
-        "treats as non-canonical. The fix lives in onym-sdk or at the contract's " +
-        "Fr encoding boundary — not in this test's wiring. Re-enable + " +
-        "re-dispatch a release once a contracts release pins the byte order.",
-)
 class CreateGroupTyrannyE2ETest {
 
     private val args by lazy { InstrumentationRegistry.getArguments() }

--- a/app/src/main/kotlin/chat/onym/android/chain/CanonicalFr.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/CanonicalFr.kt
@@ -1,0 +1,76 @@
+package chat.onym.android.chain
+
+import java.security.SecureRandom
+
+/**
+ * BLS12-381 scalar-field (`Fr`) canonical-encoding helpers.
+ *
+ * The `sep-tyranny` Soroban contract (`onym-contracts/plonk/sep-tyranny/
+ * src/lib.rs:299`) rejects any `group_id` whose 32-byte BE encoding is
+ * `>= r` with `Error::InvalidCommitmentEncoding` (#15). The check
+ * exists by design — it closes a `group_id_A` vs `group_id_A + p
+ * (mod 2^256)` collision in `group_id_fr` (see the contract comment
+ * at lines 290–298). With `groupID = randomBytes(32)` the failure
+ * rate is `(2^256 - r) / 2^256 ≈ 0.547`; this helper rejection-
+ * samples until the draw is canonical, accept rate ≈ 0.453, so the
+ * loop terminates in ~2.2 iterations on average.
+ *
+ * Mirrors `CreateGroupInteractor.randomCanonicalFr()` /
+ * `isCanonicalFr(_:)` from onym-ios PR #36.
+ *
+ * `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
+ */
+internal object CanonicalFr {
+
+    /** BLS12-381 Fr modulus, big-endian. 32 bytes. */
+    private val MODULUS_BE: ByteArray = byteArrayOf(
+        0x73.toByte(), 0xed.toByte(), 0xa7.toByte(), 0x53.toByte(),
+        0x29.toByte(), 0x9d.toByte(), 0x7d.toByte(), 0x48.toByte(),
+        0x33.toByte(), 0x39.toByte(), 0xd8.toByte(), 0x08.toByte(),
+        0x09.toByte(), 0xa1.toByte(), 0xd8.toByte(), 0x05.toByte(),
+        0x53.toByte(), 0xbd.toByte(), 0xa4.toByte(), 0x02.toByte(),
+        0xff.toByte(), 0xfe.toByte(), 0x5b.toByte(), 0xfe.toByte(),
+        0xff.toByte(), 0xff.toByte(), 0xff.toByte(), 0xff.toByte(),
+        0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x01.toByte(),
+    )
+
+    /**
+     * `true` iff [bytes] is exactly 32 bytes long and, interpreted as
+     * a big-endian integer, is strictly less than the BLS12-381 Fr
+     * modulus. Mirrors the contract's `is_canonical_fr` predicate
+     * (sep-tyranny/src/lib.rs:688).
+     */
+    fun isCanonical(bytes: ByteArray): Boolean {
+        if (bytes.size != 32) return false
+        for (i in 0 until 32) {
+            val a = bytes[i].toInt() and 0xFF
+            val b = MODULUS_BE[i].toInt() and 0xFF
+            if (a < b) return true
+            if (a > b) return false
+        }
+        // bytes == MODULUS → not strictly less → not canonical.
+        return false
+    }
+
+    /**
+     * Uniformly-random 32-byte BE value strictly less than the
+     * BLS12-381 scalar field order `r`. Rejection-samples until a
+     * canonical value falls out (accept rate ≈ 0.453, so ~2.2
+     * iterations on average).
+     *
+     * Why we can't just take `randomBytes(32) mod r`: the contract
+     * rejects any non-canonical encoding outright, and the SDK's
+     * silent mod-r reduction would diverge from the contract's check
+     * on ~25% of inputs. Generating canonically at the source removes
+     * the reduction question entirely.
+     *
+     * @param random Injectable for tests. Production callers can omit.
+     */
+    fun randomCanonicalFr32(random: SecureRandom = SecureRandom()): ByteArray {
+        val buf = ByteArray(32)
+        while (true) {
+            random.nextBytes(buf)
+            if (isCanonical(buf)) return buf.copyOf()
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.group
 
 import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.CanonicalFr
 import chat.onym.android.chain.ContractsRepository
 import chat.onym.android.chain.GovernanceType
 import chat.onym.android.chain.GroupCreateProof
@@ -109,8 +110,15 @@ open class CreateGroupInteractor(
         val binding = contracts.snapshots.value.binding(key)
             ?: throw CreateGroupError.NoContractBinding(GovernanceType.Tyranny)
 
-        // 3. Group params
-        val groupId = randomBytes(32)
+        // 3. Group params.
+        // `groupId` MUST be a canonical bls12-381 Fr (BE value < r) —
+        // sep-tyranny's `is_canonical_fr(&group_id)` rejects anything
+        // else with `Error::InvalidCommitmentEncoding` (#15). The check
+        // exists to close a same-`group_id_fr` collision via
+        // `group_id + p (mod 2^256)` — see the contract comment at
+        // sep-tyranny/src/lib.rs:290–298. Run #25262987336 hit exactly
+        // that with an `ea…` first byte from raw `SecureRandom.nextBytes`.
+        val groupId = CanonicalFr.randomCanonicalFr32()
         val groupSecret = randomBytes(32)
         val salt = GroupCommitmentBuilder.generateSalt()
         val tier = SepTier.SMALL

--- a/app/src/test/kotlin/chat/onym/android/chain/CanonicalFrTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/CanonicalFrTest.kt
@@ -1,0 +1,160 @@
+package chat.onym.android.chain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.SecureRandom
+
+/**
+ * Regression coverage for the bls12-381 canonical-Fr predicate +
+ * rejection sampler that [chat.onym.android.group.CreateGroupInteractor]
+ * uses to mint `groupId`. The contract (`sep-tyranny/src/lib.rs:299`)
+ * rejects non-canonical `group_id` with
+ * `Error::InvalidCommitmentEncoding` (#15); these tests pin the
+ * client-side guarantee that we never hand the contract a value `>= r`.
+ *
+ * Mirrors `CanonicalFrTests.swift` from onym-ios PR #36.
+ *
+ * `r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
+ */
+class CanonicalFrTest {
+
+    // ─── isCanonical boundary cases ───────────────────────────────
+
+    @Test
+    fun isCanonical_zero_isCanonical() {
+        assertTrue(CanonicalFr.isCanonical(ByteArray(32)))
+    }
+
+    @Test
+    fun isCanonical_one_isCanonical() {
+        val bytes = ByteArray(32)
+        bytes[31] = 1
+        assertTrue(CanonicalFr.isCanonical(bytes))
+    }
+
+    @Test
+    fun isCanonical_rMinusOne_isCanonical() {
+        val rMinusOne = byteArrayOf(
+            0x73.toByte(), 0xed.toByte(), 0xa7.toByte(), 0x53.toByte(),
+            0x29.toByte(), 0x9d.toByte(), 0x7d.toByte(), 0x48.toByte(),
+            0x33.toByte(), 0x39.toByte(), 0xd8.toByte(), 0x08.toByte(),
+            0x09.toByte(), 0xa1.toByte(), 0xd8.toByte(), 0x05.toByte(),
+            0x53.toByte(), 0xbd.toByte(), 0xa4.toByte(), 0x02.toByte(),
+            0xff.toByte(), 0xfe.toByte(), 0x5b.toByte(), 0xfe.toByte(),
+            0xff.toByte(), 0xff.toByte(), 0xff.toByte(), 0xff.toByte(),
+            0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x00.toByte(),
+        )
+        assertTrue(CanonicalFr.isCanonical(rMinusOne))
+    }
+
+    @Test
+    fun isCanonical_r_isNotCanonical() {
+        val r = byteArrayOf(
+            0x73.toByte(), 0xed.toByte(), 0xa7.toByte(), 0x53.toByte(),
+            0x29.toByte(), 0x9d.toByte(), 0x7d.toByte(), 0x48.toByte(),
+            0x33.toByte(), 0x39.toByte(), 0xd8.toByte(), 0x08.toByte(),
+            0x09.toByte(), 0xa1.toByte(), 0xd8.toByte(), 0x05.toByte(),
+            0x53.toByte(), 0xbd.toByte(), 0xa4.toByte(), 0x02.toByte(),
+            0xff.toByte(), 0xfe.toByte(), 0x5b.toByte(), 0xfe.toByte(),
+            0xff.toByte(), 0xff.toByte(), 0xff.toByte(), 0xff.toByte(),
+            0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x01.toByte(),
+        )
+        assertFalse(
+            "the field order itself is NOT a canonical Fr",
+            CanonicalFr.isCanonical(r),
+        )
+    }
+
+    @Test
+    fun isCanonical_rPlusOne_isNotCanonical() {
+        val rPlusOne = byteArrayOf(
+            0x73.toByte(), 0xed.toByte(), 0xa7.toByte(), 0x53.toByte(),
+            0x29.toByte(), 0x9d.toByte(), 0x7d.toByte(), 0x48.toByte(),
+            0x33.toByte(), 0x39.toByte(), 0xd8.toByte(), 0x08.toByte(),
+            0x09.toByte(), 0xa1.toByte(), 0xd8.toByte(), 0x05.toByte(),
+            0x53.toByte(), 0xbd.toByte(), 0xa4.toByte(), 0x02.toByte(),
+            0xff.toByte(), 0xfe.toByte(), 0x5b.toByte(), 0xfe.toByte(),
+            0xff.toByte(), 0xff.toByte(), 0xff.toByte(), 0xff.toByte(),
+            0x00.toByte(), 0x00.toByte(), 0x00.toByte(), 0x02.toByte(),
+        )
+        assertFalse(CanonicalFr.isCanonical(rPlusOne))
+    }
+
+    @Test
+    fun isCanonical_allOnes_isNotCanonical() {
+        // High byte 0xFF >> 0x73 — same shape as the testnet failure.
+        assertFalse(CanonicalFr.isCanonical(ByteArray(32) { 0xFF.toByte() }))
+    }
+
+    @Test
+    fun isCanonical_observedFailingValue_isNotCanonical() {
+        // The literal bytes from the diagnostic event in the failing
+        // testnet run (mirrored from onym-ios PR #36) — kept as a
+        // regression anchor.
+        val observed = byteArrayOf(
+            0xfd.toByte(), 0xfb.toByte(), 0xc9.toByte(), 0x7d.toByte(),
+            0x06.toByte(), 0x85.toByte(), 0xf2.toByte(), 0xb9.toByte(),
+            0xf3.toByte(), 0xad.toByte(), 0x24.toByte(), 0xf7.toByte(),
+            0xa4.toByte(), 0xc7.toByte(), 0x57.toByte(), 0x41.toByte(),
+            0x6b.toByte(), 0xd5.toByte(), 0x3a.toByte(), 0x87.toByte(),
+            0x11.toByte(), 0x47.toByte(), 0x7c.toByte(), 0xe2.toByte(),
+            0xc3.toByte(), 0x59.toByte(), 0x77.toByte(), 0x80.toByte(),
+            0x24.toByte(), 0xdb.toByte(), 0xfb.toByte(), 0x0d.toByte(),
+        )
+        assertFalse(
+            "exact value that tripped Error #15 on the v0.0.5 tyranny contract",
+            CanonicalFr.isCanonical(observed),
+        )
+    }
+
+    @Test
+    fun isCanonical_justBelowR_highByte0x73_isCanonical() {
+        // High byte == 0x73 but second byte < r's second byte (0xed).
+        val bytes = ByteArray(32)
+        bytes[0] = 0x73
+        bytes[1] = 0xec.toByte()
+        assertTrue(CanonicalFr.isCanonical(bytes))
+    }
+
+    @Test
+    fun isCanonical_wrongLength_returnsFalse() {
+        assertFalse(CanonicalFr.isCanonical(ByteArray(31)))
+        assertFalse(CanonicalFr.isCanonical(ByteArray(33)))
+    }
+
+    // ─── randomCanonicalFr32 sampling ─────────────────────────────
+
+    @Test
+    fun randomCanonicalFr32_alwaysCanonical_over10kSamples() {
+        // Statistically, the sampler's accept rate is `r / 2^256 ≈ 0.453`.
+        // 10k samples give a generous floor on rejected-path coverage
+        // (~5.5k rejections), and the assertion is unconditional.
+        val rng = SecureRandom()
+        repeat(10_000) {
+            val draw = CanonicalFr.randomCanonicalFr32(rng)
+            assertEquals(32, draw.size)
+            assertTrue(
+                "sampler returned non-canonical bytes: ${draw.joinToString("") { "%02x".format(it.toInt() and 0xFF) }}",
+                CanonicalFr.isCanonical(draw),
+            )
+        }
+    }
+
+    @Test
+    fun randomCanonicalFr32_isNonZeroAndDistinct() {
+        // Sanity: the sampler isn't returning a constant. 100 draws
+        // should yield 100 distinct values with overwhelming probability.
+        val rng = SecureRandom()
+        val seen = HashSet<List<Byte>>(100)
+        repeat(100) {
+            seen.add(CanonicalFr.randomCanonicalFr32(rng).toList())
+        }
+        assertEquals("sampler should not collide over 100 draws", 100, seen.size)
+        assertFalse(
+            "all-zero would be a giveaway of a broken RNG",
+            seen.contains(List(32) { 0.toByte() }),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Mirror of [onym-ios PR #36](https://github.com/onymchat/onym-ios/pull/36). Same root cause + same fix on the Android side.

`CreateGroupInteractor` was minting `groupId = randomBytes(32)` — a uniformly-random 32-byte draw. With probability `(2^256 - r) / 2^256 ≈ 0.547` the value lands `>= r` (bls12-381 scalar order, high byte `0x73`). `sep-tyranny/src/lib.rs:299` rejects any non-canonical `group_id` with `Error::InvalidCommitmentEncoding` (#15). The check exists by design — see contract comment lines 290–298 — to close a `group_id_A` vs `group_id_A + p (mod 2^256)` collision in `group_id_fr`.

Run [#25262987336](https://github.com/onymchat/onym-android/actions/runs/25262987336) hit exactly that with an `ea…` first byte from raw `SecureRandom.nextBytes`.

## Changes

- **`chain/CanonicalFr` utility** — `isCanonical(bytes)` mirrors the contract predicate as a constant-r byte-by-byte compare; `randomCanonicalFr32()` rejection-samples until canonical (accept rate ≈ 0.453, so ~2.2 iterations on average).
- **`CreateGroupInteractor.groupId`** now goes through `CanonicalFr.randomCanonicalFr32()`. `groupSecret` / `salt` unchanged — neither is treated as canonical Fr by any contract.
- **`CanonicalFrTest`** (11 cases): boundary cases (0, 1, r-1 canonical; r, r+1, 0xFF…FF non-canonical; wrong length → false); the literal failing testnet value `0xfdfb…fb0d` pinned (mirrored from the iOS PR's regression anchor); 10k-sample sweep + 100-draw distinctness sanity.
- **Drop `@Ignore`** on `CreateGroupTyrannyE2ETest` — the canonical-Fr fix unblocks it.

## Test plan

- [x] `:app:testDebugUnitTest --tests CanonicalFrTest` — 11/11 green
- [x] `:app:compileDebugAndroidTestKotlin` — green
- [ ] CI: re-dispatch a Release; expect `CreateGroupTyrannyE2ETest` to land green on testnet (no more Error #15)

## Notes

- The OneOnOne stack PR #36 (`chain/oneonone-payload-fr-canonical`) bundled this same fix with the OneOnOne wire format. After this lands I'll rebase that stack to drop the now-duplicate canonical-Fr changes.
- OneOnOne contract doesn't gate `group_id` canonicality (no proof binding), so unaffected — but using canonical `groupId` everywhere is the right default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)