### PR TITLE
fix: SepCommitmentEntry — per-governance fields optional

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
@@ -171,10 +171,13 @@ class CreateGroupTyrannyE2ETest {
 
         // Round-trip the on-chain state: read the commitment back via
         // get_commitment and assert it matches what we stored locally.
+        // Tyranny's `CommitmentEntry` ships only `commitment` + `epoch`
+        // + `timestamp` + `tier` — no `active` (that field is
+        // democracy/oligarchy-only). See SepCommitmentEntry's per-type
+        // table.
         val onChain = env.client.getCommitment(groupId = group.groupIdBytes)
         assertArrayEquals(group.commitment, onChain.commitment)
         assertEquals(0uL, onChain.epoch)
-        assertTrue(onChain.active)
     }
 
     /**

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
@@ -223,15 +223,34 @@ data class GetCommitmentPayload(
 
 // ─── responses ────────────────────────────────────────────────────
 
-/** On-chain state returned by `get_commitment`. */
+/**
+ * On-chain state returned by `get_commitment`. The contract-side
+ * `CommitmentEntry` shape varies per governance type — only
+ * [commitment] and [epoch] are present in every variant. The rest
+ * are decoded if present:
+ *
+ * | Field        | anarchy | 1v1 | tyranny | democracy | oligarchy |
+ * |--------------|---------|-----|---------|-----------|-----------|
+ * | `commitment` | ✅      | ✅  | ✅      | ✅        | ✅        |
+ * | `epoch`      | ✅      | ✅  | ✅      | ✅        | ✅        |
+ * | `timestamp`  | varies  | ✅  | ✅      | ✅        | ✅        |
+ * | `tier`       | varies  | —   | ✅      | ✅        | ✅        |
+ * | `active`     | —       | —   | —       | ✅        | ✅        |
+ *
+ * Mirrors `SEPCommitmentEntry` from onym-ios PR #36 — every optional
+ * field is `?` so the relayer can omit it without the client refusing
+ * to decode (which is how release run #25271977084 surfaced this:
+ * `MissingFieldException: Field 'active' is required` against a
+ * tyranny `get_commitment` response that doesn't ship `active`).
+ */
 @Serializable
 data class SepCommitmentEntry(
     @Serializable(with = Base64ByteArraySerializer::class)
     val commitment: ByteArray,
     val epoch: ULong,
-    val timestamp: ULong,
-    val tier: UInt,
-    val active: Boolean,
+    val timestamp: ULong? = null,
+    val tier: UInt? = null,
+    val active: Boolean? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -246,9 +265,9 @@ data class SepCommitmentEntry(
     override fun hashCode(): Int {
         var h = commitment.contentHashCode()
         h = 31 * h + epoch.hashCode()
-        h = 31 * h + timestamp.hashCode()
-        h = 31 * h + tier.hashCode()
-        h = 31 * h + active.hashCode()
+        h = 31 * h + (timestamp?.hashCode() ?: 0)
+        h = 31 * h + (tier?.hashCode() ?: 0)
+        h = 31 * h + (active?.hashCode() ?: 0)
         return h
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
@@ -208,6 +208,40 @@ class SepContractTypesTest {
     }
 
     @Test
+    fun commitmentEntry_decodesTyrannyShape_withoutActive() {
+        // Tyranny `get_commitment` returns commitment + epoch + timestamp
+        // + tier — but NOT `active` (that's democracy/oligarchy only).
+        // Release run #25271977084 surfaced exactly this: the relayer
+        // omitted `active` and the decoder threw `MissingFieldException`.
+        // See SepCommitmentEntry's per-governance table for the full
+        // shape matrix.
+        val tyrannyResponse = """
+            {"commitment":"CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk=",
+             "epoch":0,"timestamp":1700000000,"tier":0}
+        """.trimIndent()
+        val decoded = json.decodeFromString(SepCommitmentEntry.serializer(), tyrannyResponse)
+        assertEquals(0uL, decoded.epoch)
+        assertEquals(0u, decoded.tier)
+        assertEquals(1_700_000_000uL, decoded.timestamp)
+        assertNull("tyranny doesn't ship `active`", decoded.active)
+    }
+
+    @Test
+    fun commitmentEntry_decodesMinimalShape_commitmentEpochOnly() {
+        // The "every variant" floor — anarchy in some configurations
+        // ships only commitment + epoch. Decoder must tolerate it.
+        val minimalResponse = """
+            {"commitment":"CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk=",
+             "epoch":3}
+        """.trimIndent()
+        val decoded = json.decodeFromString(SepCommitmentEntry.serializer(), minimalResponse)
+        assertEquals(3uL, decoded.epoch)
+        assertNull(decoded.timestamp)
+        assertNull(decoded.tier)
+        assertNull(decoded.active)
+    }
+
+    @Test
     fun submissionResponse_keepsCamelCaseTransactionHashKey() {
         val payload = SepSubmissionResponse(
             accepted = true,


### PR DESCRIPTION
## TL;DR — not a missing secret

The bearer token is correct. The chain leg succeeded (sibling test \`create_oneInvitee_sendsInvitation_andAnchors\` **passed** in the same run, 9.28s). The relayer returned a 2xx with a valid \`get_commitment\` body — Android just refused to decode it.

## Root cause

[Release run #25271977084](https://github.com/onymchat/onym-android/actions/runs/25271977084/job/74095819944) failed \`CreateGroupTyrannyE2ETest.create_zeroInvitees_anchorsOnTestnet\` with:

\`\`\`
SepContractError\$MalformedResponse
  Caused by: kotlinx.serialization.MissingFieldException:
    Field 'active' is required for type 'SepCommitmentEntry'
\`\`\`

The relayer's \`get_commitment\` response shape varies per governance type:

| Field        | anarchy | 1v1 | tyranny | democracy | oligarchy |
|--------------|---------|-----|---------|-----------|-----------|
| \`commitment\` | ✅      | ✅  | ✅      | ✅        | ✅        |
| \`epoch\`      | ✅      | ✅  | ✅      | ✅        | ✅        |
| \`timestamp\`  | varies  | ✅  | ✅      | ✅        | ✅        |
| \`tier\`       | varies  | —   | ✅      | ✅        | ✅        |
| \`active\`     | —       | —   | —       | ✅        | ✅        |

Android declared all five required. iOS already has \`active\`, \`tier\`, \`timestamp\` as optional (\`SEPCommitmentEntry\` in onym-ios with the same matrix in the docstring) — that's why iOS PR #36's E2E lands green.

## Fix

- \`SepCommitmentEntry\`: \`timestamp\`, \`tier\`, \`active\` are now \`Type? = null\`. Per-governance matrix copied from iOS into the docstring.
- \`CreateGroupTyrannyE2ETest\`: drop \`assertTrue(onChain.active)\` — tyranny doesn't ship \`active\`, that assertion was never going to pass against a correct response.
- \`SepContractTypesTest\`: pin the tyranny decode (no \`active\`) and the minimal \`commitment + epoch\`-only decode so this regression is locked down.

## Test plan

- [x] \`:app:testDebugUnitTest --tests SepContractTypesTest --tests SepContractClientTest\` — all green
- [x] \`:app:compileDebugAndroidTestKotlin\` — green
- [ ] CI: re-dispatch a Release; \`CreateGroupTyrannyE2ETest\` (both cases) should land green

🤖 Generated with [Claude Code](https://claude.com/claude-code)