### PR TITLE
ci: checkout with lfs:true on jobs that build/test the app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Launcher PNGs live in Git LFS — without this, AAPT2
+          # processes pointer text and the build dies with "file
+          # failed to compile". Same fix as in release.yml.
+          lfs: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Launcher icons (`ic_launcher_foreground.png`,
+          # `ic_launcher_monochrome.png`) live in Git LFS — without
+          # this AAPT2 sees the ~130-byte pointer text and `fail to
+          # compile` blows up the build. Run #25272219941 surfaced it.
+          lfs: true
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           distribution: temurin
@@ -91,6 +97,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # AAPT2 needs the real launcher PNGs (Git LFS), not the
+          # pointer text. Same reason as the JVM-tests job above.
+          lfs: true
 
       - name: Enable KVM group permissions
         run: |
@@ -230,6 +240,12 @@ jobs:
     needs: [lint, test, android-test, create-release]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # `assembleRelease` runs AAPT2 over `app/src/main/res/`,
+          # which includes LFS-tracked launcher PNGs. Without `lfs:
+          # true` the binary content is missing and AAPT2 fails with
+          # "file failed to compile" on the pointer text.
+          lfs: true
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:


### PR DESCRIPTION
## Summary

You called it — yes, the workflow was checking out without LFS. [Run #25272219941](https://github.com/onymchat/onym-android/actions/runs/25272219941/job/74096713120) failed \`:app:assembleRelease\` with:

\`\`\`
ERROR: app/src/main/res/drawable-nodpi/ic_launcher_monochrome.png:
  AAPT: error: file failed to compile.
ERROR: app/src/main/res/drawable-nodpi/ic_launcher_foreground.png:
  AAPT: error: file failed to compile.
\`\`\`

Both PNGs are LFS-tracked (\`git lfs ls-files\` confirms). \`actions/checkout\` defaults to \`lfs: false\`, so the runner gets ~130-byte pointer text and AAPT2 can't decode it.

## Fix

Adds \`with: lfs: true\` to the four checkouts that compile resources or install the APK:

- \`release.yml\`: jvm-unit-tests, emulator instrumented tests, \`assembleRelease\`
- \`ci.yml\`: jvm-unit-tests

Skipped (don't touch the resource pipeline):
- lint jobs (just run \`lint-secrets.py\`)
- \`create-release\` job (only reads commit history)

## Test plan

- [x] grep — every checkout that runs \`gradlew\` now has \`lfs: true\`
- [ ] CI: re-dispatch \`Release v0.0.7\` after merge; \`assembleRelease\` should compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)