### PR TITLE
ci: release-issue automation — open issue → dispatch + report

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -1,0 +1,76 @@
+name: Release
+description: Cut a release. Auto-dispatches the Release workflow + reports test results back here.
+title: "Release: vX.Y.Z"
+labels: ["release"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Submitting this issue triggers the [Release workflow](../actions/workflows/release.yml).
+
+        - The "UI tests" section auto-populates within ~30 s of opening, then ticks each box as the corresponding test class passes on the emulator.
+        - The "Manual QA" section is yours — never overwritten by automation.
+        - On test failure, the workflow posts a comment with stack-trace excerpts and a link to the run.
+        - The signed APK build is gated on a green emulator run; failures block the artifact.
+
+  - type: input
+    id: tag
+    attributes:
+      label: Release tag
+      description: Must match `vX.Y.Z`. The Release workflow validates this and aborts if the tag already exists.
+      placeholder: v0.0.8
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Release notes (optional)
+      description: Free-form. The Release workflow generates a commit-log changelog automatically; this field is for anything additional you want surfaced.
+      placeholder: Highlight the OneOnOne flow + the LFS checkout fix.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## UI tests
+
+        <!-- UI_TESTS_START -->
+        _Auto-populating… (the `release-from-issue` workflow will fill this in within ~30 s of opening)_
+        <!-- UI_TESTS_END -->
+
+        ## Manual QA
+
+        Tick by hand on a real device once the APK uploads to the GitHub Release.
+
+        <!-- MANUAL_QA_START -->
+        ### Install + onboarding
+        - [ ] Sideload the signed APK on a real device (Android 14+ recommended)
+        - [ ] First-launch onboarding flow renders without crash
+        - [ ] Bootstrap a new identity, then restart the app and confirm it persists
+        - [ ] Restore identity from a 12-word mnemonic, confirm pubkey matches
+
+        ### Create Group — Tyranny
+        - [ ] Create an empty Tyranny group against testnet, confirm it lands on the Stellar contract
+        - [ ] Create a Tyranny group with 1 invitee, confirm invitee receives sealed envelope
+        - [ ] Open Settings → toggle Mainnet, confirm next create resolves the mainnet contract binding
+
+        ### Create Group — 1-on-1
+        - [ ] Pick the 1-on-1 governance card, paste an invitee inbox key, confirm "Start 1-on-1" CTA enables only at exactly 1 invitee
+        - [ ] Create the 1-on-1 group, confirm anchor on testnet
+        - [ ] Confirm invitee receives sealed envelope carrying the ephemeral `sk_1`
+
+        ### Settings + relayer + anchors
+        - [ ] Settings → Relayer Settings → swipe-delete an endpoint, confirm primary marker clears if deleted
+        - [ ] Settings → Anchors → drill into Testnet → Tyranny, pick an older release, confirm persistence
+        - [ ] Add a custom relayer URL, confirm it lands as `custom` network endpoint
+
+        ### Theming + chrome
+        - [ ] Toggle system dark mode, every Create Group screen renders correctly in both themes
+        - [ ] Bottom-tab Chats / Settings / Search switching works without flicker
+        - [ ] Recovery-phrase backup flow (Settings → Backup) walks Intro → Reveal → Verify → Done
+
+        ### Production sanity
+        - [ ] APK installs without "package conflicts with existing" prompt over the prior release
+        - [ ] Network Settings shows the deployed `relayer.onym.chat` endpoint by default after auto-populate
+        - [ ] AltStore source updates with the new IPA URL once notarization mirrors land (separate workflow — leave unchecked if N/A)
+        <!-- MANUAL_QA_END -->

--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -1,0 +1,99 @@
+name: Release from issue
+
+# Triggered when someone opens (or labels) an issue with the `release`
+# label — typically via the "Release" issue template at
+# `.github/ISSUE_TEMPLATE/release.yml`. Discovers the current set of
+# instrumented test classes, hydrates the issue body's UI_TESTS section
+# with `- [ ] <FQN>` checkboxes, validates the tag from the issue body,
+# and dispatches the Release workflow with `tag` + `issue_number` so the
+# Release run can tick boxes / post failure comments back here.
+#
+# Re-running for the same issue is safe: hydrate is idempotent (rewrites
+# the section between `<!-- UI_TESTS_START -->` and `<!-- UI_TESTS_END -->`
+# in full each time).
+
+on:
+  issues:
+    # `labeled` only — NOT `opened` or `edited`. GitHub fires `labeled`
+    # for both template-auto-applied labels (at creation) and labels
+    # added later, so this catches every release-issue path with a
+    # single fire. Listening on `opened` would double-fire when the
+    # template auto-applies `release`. Listening on `edited` would re-
+    # dispatch every time the issue body changes (incl. when this same
+    # workflow hydrates the UI_TESTS section).
+    types: [labeled]
+
+permissions:
+  contents: read    # checkout
+  issues: write     # edit body, post comments
+  actions: write    # dispatch the Release workflow
+
+jobs:
+  hydrate-and-dispatch:
+    name: Hydrate checklist + dispatch Release
+    # Restrict to the specific label that was just added — without this,
+    # any other label change on a release-tagged issue would re-trigger.
+    if: github.event.label.name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        # No `lfs: true` — this job runs python3 over text only.
+
+      - name: Discover instrumented test classes
+        id: discover
+        run: |
+          python3 scripts/release_issue.py discover > /tmp/tests.txt
+          echo "Discovered $(wc -l < /tmp/tests.txt) test classes:"
+          cat /tmp/tests.txt
+
+      - name: Parse + validate release tag
+        id: tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          # Read the issue body fresh — `github.event.issue.body` is the
+          # snapshot at trigger time, which may be stale by a few seconds.
+          BODY=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} --json body --jq .body)
+          TAG=$(printf '%s' "$BODY" | python3 scripts/release_issue.py parse-tag)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - name: Hydrate UI_TESTS section
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          BODY=$(gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} --json body --jq .body)
+          NEW_BODY=$(printf '%s' "$BODY" | python3 scripts/release_issue.py hydrate \
+            --tests /tmp/tests.txt)
+          # Idempotent: if the section is already populated with the
+          # same FQNs, the diff is a no-op. `gh issue edit` skips the
+          # API write when nothing changed.
+          printf '%s' "$NEW_BODY" | gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} --body-file -
+
+      - name: Dispatch Release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run Release \
+            --repo ${{ github.repository }} \
+            -f tag=${{ steps.tag.outputs.tag }} \
+            -f issue_number=${{ github.event.issue.number }}
+          echo "Dispatched Release for tag ${{ steps.tag.outputs.tag }}, issue #${{ github.event.issue.number }}"
+
+      - name: Confirm dispatch on the issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # One-line acknowledgement so the issue author knows the
+          # automation kicked in. Includes a link to the Actions page —
+          # the brand-new run isn't easily linkable until it appears in
+          # the dispatched workflow's run list.
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Dispatched [Release workflow](https://github.com/${{ github.repository }}/actions/workflows/release.yml) for tag \`${{ steps.tag.outputs.tag }}\`. UI test results will land here as the run completes."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,20 @@ on:
         description: 'Release tag (e.g. v0.0.1)'
         required: true
         type: string
+      issue_number:
+        # Set by `release-from-issue.yml` when the workflow is dispatched
+        # from a release-tracking issue. The `report-to-issue` job uses
+        # this to tick UI_TESTS checkboxes + post failure comments back
+        # into the issue. Empty when dispatched manually via
+        # `gh workflow run Release -f tag=...`.
+        description: 'Optional release-issue number to report results into'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write   # tag push + GitHub Release creation + asset upload
+  issues: write     # report-to-issue job edits body + posts comments
 
 jobs:
   # ─── Hard gates ──────────────────────────────────────────────────
@@ -164,8 +175,12 @@ jobs:
           # keep the gradle invocation single-line to dodge the issue.
           script: ./gradlew :app:connectedDebugAndroidTest --no-daemon -Pandroid.testInstrumentationRunnerArguments.ONYM_INTEGRATION=1 -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_URL=https://relayer.onym.chat -Pandroid.testInstrumentationRunnerArguments.ONYM_RELAYER_AUTH_TOKEN="$RELAYER_AUTH_TOKEN"
 
-      - name: Upload androidTest report on failure
-        if: failure()
+      - name: Upload androidTest report
+        # Always upload — the `report-to-issue` job needs to read the
+        # JUnit XMLs even on a fully-green run so it can tick the
+        # UI_TESTS checkboxes in the release-tracking issue. Was
+        # `if: failure()` before the release-issue automation landed.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: connectedAndroidTest-report
@@ -335,3 +350,55 @@ jobs:
         with:
           tag_name: ${{ inputs.tag }}
           files: ${{ steps.apk.outputs.path }}
+
+  # ─── Release-issue reporting ─────────────────────────────────────
+  # Only runs when dispatched from `release-from-issue.yml` (which
+  # passes the issue number). Ticks UI_TESTS checkboxes for passing
+  # test classes; on any failure, posts an aggregated comment with
+  # stack-trace excerpts. `if: always()` so failed runs still report.
+
+  report-to-issue:
+    name: Report test results to release issue
+    needs: [android-test]
+    if: always() && inputs.issue_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        # No `lfs: true` — only need scripts/release_issue.py.
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: connectedAndroidTest-report
+          path: artifact
+
+      - name: Update UI_TESTS checkboxes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          BODY=$(gh issue view ${{ inputs.issue_number }} \
+            --repo ${{ github.repository }} --json body --jq .body)
+          NEW_BODY=$(printf '%s' "$BODY" | python3 scripts/release_issue.py tick \
+            --results artifact/outputs/androidTest-results)
+          # Idempotent: re-runs of the same Release dispatch overwrite
+          # the section in full.
+          printf '%s' "$NEW_BODY" | gh issue edit ${{ inputs.issue_number }} \
+            --repo ${{ github.repository }} --body-file -
+
+      - name: Post failure comment if any tests failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          python3 scripts/release_issue.py comment \
+            --results artifact/outputs/androidTest-results \
+            --run-url "$RUN_URL" > /tmp/comment.md
+          if [ -s /tmp/comment.md ]; then
+            gh issue comment ${{ inputs.issue_number }} \
+              --repo ${{ github.repository }} \
+              --body-file /tmp/comment.md
+          else
+            echo "All test classes green — no failure comment to post."
+          fi

--- a/scripts/release_issue.py
+++ b/scripts/release_issue.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Helpers for the release-from-issue automation.
+
+Subcommands:
+
+    discover                 Emit one FQN per line for each instrumented
+                             test class under app/src/androidTest. Drives
+                             the dynamic checklist in the release issue.
+
+    parse-tag                Read an issue body on stdin, print the
+                             `vX.Y.Z` tag the user typed in the form.
+
+    hydrate    --tests F     Read issue body on stdin; replace the
+                             UI_TESTS section with `- [ ] <FQN>` lines
+                             from F (one FQN per line).
+
+    tick       --results D   Read issue body on stdin; tick UI_TESTS
+                             checkboxes for classes whose JUnit XML in D
+                             has zero failures + zero errors.
+
+    comment    --results D   Print a markdown failure summary suitable
+                             for `gh issue comment`. Empty output (exit 0)
+                             when nothing failed. `--run-url URL` injects
+                             a back-link.
+
+The MANUAL_QA section is opaque to every command — never read or written.
+
+Marker discipline (issue body MUST contain these literally, one per line):
+
+    <!-- UI_TESTS_START -->
+    ...auto-managed content...
+    <!-- UI_TESTS_END -->
+
+Anything outside the markers is preserved byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+ANDROID_TEST_ROOT = REPO_ROOT / "app" / "src" / "androidTest"
+
+UI_TESTS_START = "<!-- UI_TESTS_START -->"
+UI_TESTS_END = "<!-- UI_TESTS_END -->"
+
+# Matches the `@RunWith(AndroidJUnit4::class)` annotation. Class name is
+# captured from the `class X` line that follows. Permits intermediate
+# blank lines or other annotations between them.
+CLASS_DECL = re.compile(r"^\s*(?:open\s+|abstract\s+|sealed\s+|data\s+)?class\s+(\w+)")
+
+
+# ─── discover ─────────────────────────────────────────────────────────
+
+
+def discover() -> list[str]:
+    """Return FQNs of every instrumented test class.
+
+    A "test class" here is any Kotlin file under app/src/androidTest that
+    contains `@RunWith(AndroidJUnit4::class)` somewhere in the file. The
+    package comes from the file's `package` declaration; the class name
+    is the next `class X` token after the annotation.
+    """
+    out: list[str] = []
+    for kt in sorted(ANDROID_TEST_ROOT.rglob("*.kt")):
+        text = kt.read_text(encoding="utf-8")
+        if "@RunWith(AndroidJUnit4::class)" not in text:
+            continue
+        pkg_match = re.search(r"^package\s+([\w.]+)", text, re.MULTILINE)
+        if not pkg_match:
+            continue
+        pkg = pkg_match.group(1)
+        # Find the first class after the annotation. The annotation may
+        # not be immediately on top of the class (e.g. a docstring lives
+        # between), so scan forward from the annotation index.
+        anchor = text.index("@RunWith(AndroidJUnit4::class)")
+        for line in text[anchor:].splitlines():
+            m = CLASS_DECL.match(line)
+            if m:
+                out.append(f"{pkg}.{m.group(1)}")
+                break
+    return out
+
+
+# ─── parse-tag ────────────────────────────────────────────────────────
+
+
+def parse_tag(body: str) -> str:
+    """Extract the `vX.Y.Z` tag from the issue form's "Release tag" field.
+
+    The issue form renders the tag as:
+
+        ### Release tag
+
+        v0.0.8
+
+    We grab the first non-blank line after the `### Release tag` heading,
+    strip whitespace, and validate the shape.
+    """
+    lines = body.splitlines()
+    in_section = False
+    for line in lines:
+        stripped = line.strip()
+        if not in_section:
+            if stripped.lower() in ("### release tag", "### tag"):
+                in_section = True
+            continue
+        if stripped.startswith("###"):
+            break  # next section, no tag found
+        if stripped:
+            if not re.fullmatch(r"v\d+\.\d+\.\d+", stripped):
+                raise SystemExit(
+                    f"tag `{stripped}` does not match vX.Y.Z — fix the issue body and reopen"
+                )
+            return stripped
+    raise SystemExit("no `Release tag` field found in issue body")
+
+
+# ─── body editing ─────────────────────────────────────────────────────
+
+
+def _split_body(body: str) -> tuple[str, str, str]:
+    """Split body into (prefix, ui_tests_section, suffix).
+
+    `ui_tests_section` is the text strictly between the START and END
+    markers, EXCLUDING the marker lines themselves. The markers stay in
+    the prefix and suffix so callers don't have to re-emit them.
+    """
+    if UI_TESTS_START not in body or UI_TESTS_END not in body:
+        raise SystemExit(
+            f"issue body missing required markers `{UI_TESTS_START}` / `{UI_TESTS_END}`"
+        )
+    start_idx = body.index(UI_TESTS_START) + len(UI_TESTS_START)
+    end_idx = body.index(UI_TESTS_END)
+    if end_idx <= start_idx:
+        raise SystemExit("UI_TESTS_END appears before UI_TESTS_START")
+    return body[:start_idx], body[start_idx:end_idx], body[end_idx:]
+
+
+def hydrate(body: str, fqns: list[str]) -> str:
+    """Replace the UI_TESTS section with a fresh `- [ ] FQN` checklist."""
+    prefix, _, suffix = _split_body(body)
+    lines = ["", *(f"- [ ] {fqn}" for fqn in fqns), ""]
+    return prefix + "\n" + "\n".join(lines) + "\n" + suffix
+
+
+def tick(body: str, results: dict[str, bool]) -> str:
+    """Re-render the UI_TESTS checklist with `[x]` for passed classes.
+
+    Lines that don't look like checklist entries (e.g. headings, blank
+    lines, free-form notes someone wedged in there) are dropped — this
+    section is workflow-owned and is fully regenerated on every run.
+
+    A class is considered passed iff `results[fqn]` is True. Classes
+    missing from `results` (e.g. a test class that wasn't run because
+    the suite crashed early) stay unchecked.
+    """
+    prefix, section, suffix = _split_body(body)
+    fqns = []
+    for line in section.splitlines():
+        m = re.match(r"\s*-\s*\[[ xX]\]\s+([\w.]+)", line)
+        if m:
+            fqns.append(m.group(1))
+    rendered = ["", *(_render_line(fqn, results.get(fqn, False)) for fqn in fqns), ""]
+    return prefix + "\n" + "\n".join(rendered) + "\n" + suffix
+
+
+def _render_line(fqn: str, passed: bool) -> str:
+    box = "[x]" if passed else "[ ]"
+    return f"- {box} {fqn}"
+
+
+# ─── JUnit XML parsing ────────────────────────────────────────────────
+
+
+def _parse_results(results_dir: pathlib.Path) -> dict[str, dict]:
+    """Walk the results dir, return {fqn: {passed, failures}}.
+
+    AGP's `connectedDebugAndroidTest` writes ONE TEST-*.xml per device,
+    not one per class. The `<testsuite name="...">` attribute is just the
+    first class encountered — useless for per-class accounting. The real
+    per-class info lives in each `<testcase classname="..." name="...">`.
+    Group by `classname` to get the actual per-class verdict.
+
+    `failures` is a list of `(method, message, trace_excerpt)` tuples.
+    A class is "passed" iff it appeared in the results AND has zero
+    failures and zero errors.
+    """
+    out: dict[str, dict] = {}
+    for xml in sorted(results_dir.rglob("TEST-*.xml")):
+        try:
+            tree = ET.parse(xml)
+        except ET.ParseError as e:
+            print(f"warning: could not parse {xml}: {e}", file=sys.stderr)
+            continue
+        for case in tree.iter("testcase"):
+            fqn = case.attrib.get("classname", "").strip()
+            if not fqn:
+                continue
+            method = case.attrib.get("name", "?")
+            entry = out.setdefault(fqn, {"passed": True, "failures": []})
+            for problem in (*case.findall("failure"), *case.findall("error")):
+                msg = problem.attrib.get("message", "").strip()
+                trace = (problem.text or "").strip()
+                excerpt = "\n".join(trace.splitlines()[:5])
+                entry["failures"].append((method, msg, excerpt))
+                entry["passed"] = False
+    return out
+
+
+# ─── failure comment ──────────────────────────────────────────────────
+
+
+def comment(results_dir: pathlib.Path, run_url: str | None) -> str:
+    """Build a markdown failure summary. Returns empty string if green."""
+    parsed = _parse_results(results_dir)
+    failed = {fqn: info for fqn, info in parsed.items() if not info["passed"]}
+    if not failed:
+        return ""
+    lines: list[str] = []
+    plural = "s" if len(failed) > 1 else ""
+    lines.append(f"## ❌ {len(failed)} test class{plural} failed")
+    lines.append("")
+    if run_url:
+        lines.append(f"Run: {run_url}")
+        lines.append("")
+    for fqn, info in failed.items():
+        lines.append(f"### `{fqn}`")
+        lines.append("")
+        for method, msg, excerpt in info["failures"][:3]:
+            lines.append(f"- **`{method}`** — {msg or '(no message)'}")
+            if excerpt:
+                lines.append("  ```")
+                for trace_line in excerpt.splitlines():
+                    lines.append(f"  {trace_line}")
+                lines.append("  ```")
+        if len(info["failures"]) > 3:
+            lines.append(f"- _(and {len(info['failures']) - 3} more failed)_")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("discover", help="emit instrumented-test FQNs to stdout")
+    sub.add_parser("parse-tag", help="extract `vX.Y.Z` from issue body on stdin")
+
+    p_hydrate = sub.add_parser("hydrate", help="seed UI_TESTS section with discovered FQNs")
+    p_hydrate.add_argument("--tests", required=True, help="file with one FQN per line")
+
+    p_tick = sub.add_parser("tick", help="mark UI_TESTS boxes from JUnit results")
+    p_tick.add_argument("--results", required=True, help="dir with TEST-*.xml under it")
+
+    p_comment = sub.add_parser("comment", help="render failure summary")
+    p_comment.add_argument("--results", required=True, help="dir with TEST-*.xml under it")
+    p_comment.add_argument("--run-url", default=None, help="link back to the workflow run")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "discover":
+        for fqn in discover():
+            print(fqn)
+        return 0
+    if args.cmd == "parse-tag":
+        print(parse_tag(sys.stdin.read()))
+        return 0
+    if args.cmd == "hydrate":
+        body = sys.stdin.read()
+        fqns = [
+            line.strip()
+            for line in pathlib.Path(args.tests).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        sys.stdout.write(hydrate(body, fqns))
+        return 0
+    if args.cmd == "tick":
+        body = sys.stdin.read()
+        parsed = _parse_results(pathlib.Path(args.results))
+        results = {fqn: info["passed"] for fqn, info in parsed.items()}
+        sys.stdout.write(tick(body, results))
+        return 0
+    if args.cmd == "comment":
+        sys.stdout.write(comment(pathlib.Path(args.results), args.run_url))
+        return 0
+    parser.error(f"unknown command: {args.cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds a "Release" issue template that doubles as a release-tracking checklist. Opening the issue auto-dispatches the Release workflow; the workflow ticks UI test checkboxes back into the issue body as classes pass and posts an aggregated comment if any class fails. Manual QA section stays human-owned.

Implements the four design decisions from the planning thread: dynamic checklist / per-repo / per-class granularity / build gated on green tests.

## Pieces

| File | Purpose |
|---|---|
| `.github/ISSUE_TEMPLATE/release.yml` | Issue form. `tag` + optional notes. Auto-applies `release` label. Body has demarcated `<!-- UI_TESTS_START / END -->` (workflow-owned) and `<!-- MANUAL_QA_START / END -->` (human-owned). |
| `.github/workflows/release-from-issue.yml` | Orchestrator. `on: issues: types: [labeled]` filtered to `release`. Discovers test classes, hydrates checklist, validates tag, dispatches `Release`, posts an ack comment. |
| `.github/workflows/release.yml` | New `issue_number` workflow_dispatch input. Artifact upload moved from `if: failure()` → `if: always()`. New `report-to-issue` job ticks `[x]` per passing class + posts a failure comment with stack-trace excerpts. |
| `scripts/release_issue.py` | Five subcommands (`discover`, `parse-tag`, `hydrate`, `tick`, `comment`). Strict marker discipline — only the `UI_TESTS` section is ever touched. |

## Build gating preserved

The `build` job still has `needs: [lint, test, android-test, create-release]` — a single failed instrumented test continues to block APK assembly + upload.

## Trigger semantics

`labeled` only — NOT `opened` or `edited`:

- `opened` would double-fire when the template auto-applies the `release` label (GitHub fires `opened` then `labeled` for pre-applied labels)
- `edited` would re-dispatch on every body edit, including the workflow's own hydrate write
- `labeled` with `if: github.event.label.name == 'release'` catches both creation paths (template-driven and manual-create-then-label) with exactly one fire

## JUnit XML parsing gotcha

AGP's `connectedDebugAndroidTest` writes ONE `TEST-*.xml` per device, not one per class. The `<testsuite name="...">` attribute is just the first class encountered — useless for per-class accounting. The reporter groups by `<testcase classname="...">` instead. Locked down with comment in the parser.

## Smoke-tested locally

Against the artifact from failed run #25271977084 (real CreateGroupTyrannyE2ETest failure):

- `discover` → 12 classes
- `tick` → 11 `[x]`, 1 `[ ]` (CreateGroupTyrannyE2ETest), matches reality
- `comment` → correctly attributes the `MalformedResponse` failure to the right class with the right method + first 5 lines of stack
- All three YAML files parse cleanly

## Test plan

- [x] Unit-equivalent: end-to-end pipeline tested locally against real run artifact
- [ ] After merge: open a "Release" issue with `v0.0.8`, watch the orchestrator hydrate the checklist within ~30 s
- [ ] Verify the dispatched `Release` run ticks boxes / comments on failures
- [ ] Verify `gh workflow run Release -f tag=v0.0.X` (no `issue_number`) still works for manual dispatch

## Followups (V2, deliberately out of V1 scope)

- `/retry` slash command from inside the issue
- Per-method checklist (currently per-class; comment-on-failure carries the method-level detail)
- Org-level template (per-repo for now; iOS adoption tracked at `~/Desktop/ios.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)