### PR TITLE
fix: release-issue template — markers in textarea so they ship to body

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Submitting this issue triggers the [Release workflow](../actions/workflows/release.yml).
 
-        - The "UI tests" section auto-populates within ~30 s of opening, then ticks each box as the corresponding test class passes on the emulator.
+        - The "UI tests" section auto-populates within ~30 s of submitting, then ticks each box as the corresponding test class passes on the emulator.
         - The "Manual QA" section is yours — never overwritten by automation.
         - On test failure, the workflow posts a comment with stack-trace excerpts and a link to the run.
         - The signed APK build is gated on a green emulator run; failures block the artifact.
@@ -29,18 +29,22 @@ body:
       description: Free-form. The Release workflow generates a commit-log changelog automatically; this field is for anything additional you want surfaced.
       placeholder: Highlight the OneOnOne flow + the LFS checkout fix.
 
-  - type: markdown
+  - type: textarea
+    id: checklist
     attributes:
+      label: Checklist
+      description: |
+        ⚠ Submit as-is. The `<!-- UI_TESTS_START / END -->` and `<!-- MANUAL_QA_START / END -->` markers are load-bearing —
+        the workflow finds the auto-managed UI tests section by looking for them. Deleting markers will break the
+        check-tick automation. Manual QA items are yours to tick by hand once the APK uploads.
       value: |
         ## UI tests
 
         <!-- UI_TESTS_START -->
-        _Auto-populating… (the `release-from-issue` workflow will fill this in within ~30 s of opening)_
+        _Auto-populating… (the `release-from-issue` workflow fills this in within ~30 s of opening)_
         <!-- UI_TESTS_END -->
 
         ## Manual QA
-
-        Tick by hand on a real device once the APK uploads to the GitHub Release.
 
         <!-- MANUAL_QA_START -->
         ### Install + onboarding


### PR DESCRIPTION
## Summary

Issue #44 surfaced two bugs in PR #43's v1 release-issue automation:

**1. Missing \`release\` label in the repo.** The template's \`labels: ["release"]\` silently no-ops when the label doesn't exist in the repo. Since the orchestrator listens on \`issues.labeled\` filtered to \`release\`, the workflow never fired. Fixed out-of-band by creating the label.

**2. Markers were in a \`type: markdown\` block.** GitHub issue forms render \`markdown\` body elements to the form-fill UI but **do not submit them with the issue**. So \`<!-- UI_TESTS_START / END -->\` and \`<!-- MANUAL_QA_START / END -->\` never made it into the issue body, and \`release_issue.py hydrate\` would have failed with "issue body missing required markers".

## Fix

Move the markers + Manual QA checklist into a \`textarea\` field's \`value:\`. Textarea defaults are submitted as part of the body. The description warns "Submit as-is — markers are load-bearing".

## Tradeoff

User can edit / delete markers in the form before submitting. Acceptable for v1; v2 can move to a workflow-side bootstrap (read from a separate \`.github/release-issue-body.md\`) if marker corruption becomes a real problem.

## Test plan

- [x] YAML valid (\`yaml.safe_load\`)
- [ ] After merge: open a "Release: v0.0.X" issue, confirm body contains the markers + Manual QA, confirm orchestrator hydrates UI tests within ~30 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)