### PR TITLE
group: branch CreateGroupInteractor on SepGroupType for OneOnOne (PR-2/3)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
@@ -325,6 +325,111 @@ class CreateGroupInteractorTest {
         }
     }
 
+    // ─── OneOnOne ─────────────────────────────────────────────────
+
+    @Test
+    fun create_oneOnOne_zeroInvitees_throwsExactCountError() = runBlocking {
+        // Manifest needs a OneOnOne entry for the binding lookup to
+        // get past `NoContractBinding` — but the validation fails
+        // before that anyway. Re-seed contracts with both bindings
+        // so the test stays focused on the count check.
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = emptyList(),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected OneOnOneRequiresExactlyOneInvitee")
+        } catch (e: CreateGroupError.OneOnOneRequiresExactlyOneInvitee) {
+            assertEquals(0, e.actual)
+        }
+    }
+
+    @Test
+    fun create_oneOnOne_twoInvitees_throwsExactCountError() = runBlocking {
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = listOf(ByteArray(32), ByteArray(32) { 0xAA.toByte() }),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected OneOnOneRequiresExactlyOneInvitee")
+        } catch (e: CreateGroupError.OneOnOneRequiresExactlyOneInvitee) {
+            assertEquals(2, e.actual)
+        }
+    }
+
+    @Test
+    fun create_oneOnOne_oneInvitee_anchorsViaOneOnOnePayload_andShipsInviteeBlsSecret() = runBlocking {
+        val contractsBoth = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeOneOnOne = true)),
+            ),
+        )
+        contractsBoth.bootstrap()
+        contractsBoth.refresh()
+        val interactor = makeInteractor(contracts = contractsBoth)
+
+        val invitee = ByteArray(32) { 0xCC.toByte() }
+        val group = interactor.create(
+            name = "Talk",
+            invitees = listOf(invitee),
+            groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+        )
+
+        assertEquals(chat.onym.android.chain.SepGroupType.ONE_ON_ONE, group.groupType)
+        assertTrue(group.isPublishedOnChain)
+        // OneOnOne has no admin role.
+        assertEquals(null, group.adminPubkeyHex)
+
+        // The invocation went out as a OneOnOne payload (no `tier`,
+        // no `admin_pubkey_commitment`, 2-element PI).
+        val invocations = contractTransport.invocations()
+        assertEquals(1, invocations.size)
+        assertEquals("create_group", invocations.single().function)
+
+        // Exactly one invitation envelope was sealed + sent.
+        val sends = inboxTransport.sends()
+        assertEquals(1, sends.size)
+    }
+
+    @Test
+    fun create_oneOnOne_noOneOnOneBinding_throwsNoContractBinding() = runBlocking {
+        // Default contracts only has Tyranny — selecting OneOnOne
+        // must raise NoContractBinding(OneOnOne), not silently fall
+        // through to the Tyranny binding.
+        val interactor = makeInteractor()
+        try {
+            interactor.create(
+                name = "1v1",
+                invitees = listOf(ByteArray(32) { 0xCC.toByte() }),
+                groupType = chat.onym.android.chain.SepGroupType.ONE_ON_ONE,
+            )
+            error("expected NoContractBinding(OneOnOne)")
+        } catch (e: CreateGroupError.NoContractBinding) {
+            assertEquals(GovernanceType.OneOnOne, e.type)
+        }
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private fun makeInteractor(
@@ -332,6 +437,7 @@ class CreateGroupInteractorTest {
             chat.onym.android.chain.StaticNetworkPreferenceProvider(
                 chat.onym.android.chain.AppNetwork.Testnet,
             ),
+        contracts: ContractsRepository = this.contracts,
     ) = CreateGroupInteractor(
         identity = identity,
         relayers = relayers,
@@ -343,14 +449,26 @@ class CreateGroupInteractorTest {
         makeContractTransport = { contractTransport },
     )
 
-    private fun makeManifest(includeTyranny: Boolean): ContractsManifest {
-        val entries: List<ContractEntry> = if (includeTyranny) {
-            listOf(ContractEntry(
-                network = ContractNetwork.Testnet,
-                type = GovernanceType.Tyranny,
-                id = "CTYRANNYTEST00000000000000000000000000000000000000000000",
-            ))
-        } else emptyList()
+    private fun makeManifest(
+        includeTyranny: Boolean,
+        includeOneOnOne: Boolean = false,
+    ): ContractsManifest {
+        val entries = buildList<ContractEntry> {
+            if (includeTyranny) {
+                add(ContractEntry(
+                    network = ContractNetwork.Testnet,
+                    type = GovernanceType.Tyranny,
+                    id = "CTYRANNYTEST00000000000000000000000000000000000000000000",
+                ))
+            }
+            if (includeOneOnOne) {
+                add(ContractEntry(
+                    network = ContractNetwork.Testnet,
+                    type = GovernanceType.OneOnOne,
+                    id = "CONEONONETEST0000000000000000000000000000000000000000000",
+                ))
+            }
+        }
         return ContractsManifest(
             version = 1,
             releases = listOf(

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -329,8 +329,13 @@ class OnymApplication : Application() {
                     inboxTransport = inboxTransport,
                 )
                 CreateGroupViewModel(
-                    createGroup = { name, invitees, onProgress ->
-                        interactor.create(name = name, invitees = invitees, onProgress = onProgress)
+                    createGroup = { name, invitees, groupType, onProgress ->
+                        interactor.create(
+                            name = name,
+                            invitees = invitees,
+                            groupType = groupType,
+                            onProgress = onProgress,
+                        )
                     },
                 )
             },

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -10,6 +10,7 @@ import chat.onym.android.chain.GroupProofGenerator
 import chat.onym.android.chain.GroupProofGeneratorError
 import chat.onym.android.chain.NetworkPreferenceProvider
 import chat.onym.android.chain.OkHttpSepContractTransport
+import chat.onym.android.chain.OneOnOneCreateGroupPayload
 import chat.onym.android.chain.OnymGroupProofGenerator
 import chat.onym.android.chain.RelayerRepository
 import chat.onym.android.chain.SepContractClient
@@ -87,6 +88,7 @@ open class CreateGroupInteractor(
     open suspend fun create(
         name: String,
         invitees: List<ByteArray>,
+        groupType: SepGroupType = SepGroupType.TYRANNY,
         onProgress: (CreateGroupProgress) -> Unit = {},
     ): ChatGroup {
         // 1. Validate
@@ -96,19 +98,27 @@ open class CreateGroupInteractor(
         for ((index, key) in invitees.withIndex()) {
             if (key.size != 32) throw CreateGroupError.InvalidInviteeKey(index)
         }
+        // OneOnOne is a strict 2-party group — exactly 1 invitee
+        // (the second party). Tyranny tolerates any count including
+        // zero.
+        if (groupType == SepGroupType.ONE_ON_ONE && invitees.size != 1) {
+            throw CreateGroupError.OneOnOneRequiresExactlyOneInvitee(actual = invitees.size)
+        }
 
-        // 2. Resolve relayer + contract binding
+        val governanceType = groupType.toGovernanceType()
+            ?: throw CreateGroupError.UnsupportedGroupType(groupType)
+
+        // 2. Resolve relayer + contract binding for the requested
+        //    governance type. Same key drives both `binding.contractId`
+        //    and the wire payload's top-level `contractType`.
         val relayerUrl = relayers.selectUrl() ?: throw CreateGroupError.NoActiveRelayer
-        // Resolve the contract binding for whichever network the
-        // user has selected — same key is reused for the wire
-        // payload's top-level `network` field below.
         val activeNetwork = networkPreference.current()
         val key = AnchorSelectionKey(
             network = activeNetwork.contractNetwork,
-            type = GovernanceType.Tyranny,
+            type = governanceType,
         )
         val binding = contracts.snapshots.value.binding(key)
-            ?: throw CreateGroupError.NoContractBinding(GovernanceType.Tyranny)
+            ?: throw CreateGroupError.NoContractBinding(governanceType)
 
         // 3. Group params.
         // `groupId` MUST be a canonical bls12-381 Fr (BE value < r) —
@@ -121,15 +131,14 @@ open class CreateGroupInteractor(
         val groupId = CanonicalFr.randomCanonicalFr32()
         val groupSecret = randomBytes(32)
         val salt = GroupCommitmentBuilder.generateSalt()
-        val tier = SepTier.SMALL
+        val tier = SepTier.SMALL  // OneOnOne ignores tier (depth=5 hardcoded)
 
-        // 4. Creator member — the one BLS Fr scalar read outside
-        // IdentityRepository this layer needs. The bytes pass straight
-        // into Tyranny.proveCreate (via GroupProofGenerator) and into
-        // computeLeafHash, then fall out of scope at the end of this
-        // method. IdentityRepository pins the "do not retain" contract
-        // on the accessor; this is the proof-generation hop the
-        // contract authorises.
+        // 4. Creator's BLS key. The bytes pass straight into the
+        //    proof generator and into `computeLeafHash`, then fall
+        //    out of scope at the end of this method.
+        //    IdentityRepository pins the "do not retain" contract on
+        //    the accessor; this is the proof-generation hop the
+        //    contract authorises.
         val blsSecret = try {
             // onym:allow-secret-read
             identity.blsSecretKey()
@@ -146,48 +155,77 @@ open class CreateGroupInteractor(
         } catch (e: Throwable) {
             throw CreateGroupError.SdkFailure(e.message ?: e.toString())
         }
-        val members = listOf(creatorMember)  // single-member roster, already sorted
+        val members = listOf(creatorMember)  // local creator-only roster
+
+        // OneOnOne: generate a fresh ephemeral BLS Fr for the second
+        // party and use it as `sk_1` in the founding ceremony. The
+        // FFI rejects `sk_0 == sk_1`, so retry on the (vanishing)
+        // chance the canonical sample collides with the creator's key.
+        val secondaryBlsSecret: ByteArray? = if (groupType == SepGroupType.ONE_ON_ONE) {
+            var candidate: ByteArray
+            do {
+                candidate = CanonicalFr.randomCanonicalFr32()
+            } while (candidate.contentEquals(blsSecret))
+            candidate
+        } else {
+            null
+        }
 
         // 5. Generate proof
         onProgress(CreateGroupProgress.Proving)
-        val input = GroupProofCreateInput(
-            groupType = SepGroupType.TYRANNY,
+        val proofInput = GroupProofCreateInput(
+            groupType = groupType,
             tier = tier,
             members = members,
             adminBlsSecretKey = blsSecret,
             adminIndex = 0,
             groupId = groupId,
             salt = salt,
+            secondaryBlsSecretKey = secondaryBlsSecret,
         )
         val proof: GroupCreateProof = try {
-            proofGenerator.proveCreate(input)
+            proofGenerator.proveCreate(proofInput)
         } catch (e: GroupProofGeneratorError) {
             throw CreateGroupError.ProofGenerationFailed(e)
         } catch (e: Throwable) {
             throw CreateGroupError.SdkFailure(e.message ?: e.toString())
         }
 
-        // 6. Anchor on chain
+        // 6. Anchor on chain — per-type payload + relayer call.
         onProgress(CreateGroupProgress.Anchoring)
         val transport = makeContractTransport(relayerUrl)
         val client = SepContractClient(
             contractID = binding.contractId,
-            contractType = SepGroupType.TYRANNY,
+            contractType = groupType,
             network = activeNetwork.sepNetwork,
             transport = transport,
         )
-        val payload = TyrannyCreateGroupPayload(
-            groupId = groupId,
-            commitment = proof.commitment,
-            tier = tier.rawValue,
-            adminPubkeyCommitment = proof.adminPubkeyCommitment,
-            proof = proof.proof,
-            publicInputs = proof.publicInputs,
-        )
         val response = try {
-            client.createGroupTyranny(payload)
+            when (groupType) {
+                SepGroupType.TYRANNY -> client.createGroupTyranny(
+                    TyrannyCreateGroupPayload(
+                        groupId = groupId,
+                        commitment = proof.commitment,
+                        tier = tier.rawValue,
+                        adminPubkeyCommitment = proof.adminPubkeyCommitment,
+                        proof = proof.proof,
+                        publicInputs = proof.publicInputs,
+                    ),
+                )
+                SepGroupType.ONE_ON_ONE -> client.createGroupOneOnOne(
+                    OneOnOneCreateGroupPayload(
+                        groupId = groupId,
+                        commitment = proof.commitment,
+                        proof = proof.proof,
+                        publicInputs = proof.publicInputs,
+                    ),
+                )
+                else -> throw CreateGroupError.UnsupportedGroupType(groupType)
+            }
         } catch (e: SepContractError) {
             throw CreateGroupError.AnchorTransport(e.message ?: "transport error")
+        } catch (e: CreateGroupError) {
+            throw e
         } catch (e: Throwable) {
             throw CreateGroupError.AnchorTransport(e.message ?: "unknown")
         }
@@ -195,9 +233,15 @@ open class CreateGroupInteractor(
             throw CreateGroupError.AnchorRejected(response.message)
         }
 
-        // 7. Save locally
+        // 7. Save locally. For OneOnOne we don't surface an
+        //    `adminPubkeyHex` (no admin role on chain); leaving it
+        //    null lets the receiver-side decoder branch on it.
         val groupIdHex = groupId.toHex()
-        val adminPubkeyHex = identitySnapshot.blsPublicKey.toHex()
+        val adminPubkeyHex = if (groupType == SepGroupType.TYRANNY) {
+            identitySnapshot.blsPublicKey.toHex()
+        } else {
+            null
+        }
         val group = ChatGroup(
             id = groupIdHex,
             name = trimmedName,
@@ -208,38 +252,41 @@ open class CreateGroupInteractor(
             salt = salt,
             commitment = proof.commitment,
             tier = tier,
-            groupType = SepGroupType.TYRANNY,
+            groupType = groupType,
             adminPubkeyHex = adminPubkeyHex,
             isPublishedOnChain = false,
         )
         groups.insert(group)
         groups.markPublished(group.id, proof.commitment)
 
-        // 8. Send invitations (group is already on disk; failures
-        //    throw but a future "retry invites" UI can pick up the
-        //    half-delivered state).
+        // 8. Send invitations. For OneOnOne the (sole) invitee gets
+        //    the ephemeral `secondaryBlsSecret` so they can act as
+        //    the second party of the immutable group.
         if (invitees.isNotEmpty()) {
             onProgress(CreateGroupProgress.SendingInvitations(invitees.size))
-            val invitePayload = GroupInvitationPayload(
-                version = 1,
-                groupId = groupId,
-                groupSecret = groupSecret,
-                name = trimmedName,
-                members = members,
-                epoch = 0uL,
-                salt = salt,
-                commitment = proof.commitment,
-                tierRaw = tier.rawValue,
-                groupTypeRaw = SepGroupType.TYRANNY.wireValue,
-                adminPubkeyHex = adminPubkeyHex,
-            )
-            val payloadBytes = try {
-                jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)
-                    .toByteArray(Charsets.UTF_8)
-            } catch (_: Throwable) {
-                throw CreateGroupError.InvitationEncodingFailed
-            }
             for ((index, inboxKey) in invitees.withIndex()) {
+                val invitePayload = GroupInvitationPayload(
+                    version = 1,
+                    groupId = groupId,
+                    groupSecret = groupSecret,
+                    name = trimmedName,
+                    members = members,
+                    epoch = 0uL,
+                    salt = salt,
+                    commitment = proof.commitment,
+                    tierRaw = tier.rawValue,
+                    groupTypeRaw = groupType.wireValue,
+                    adminPubkeyHex = adminPubkeyHex,
+                    inviteeBlsSecretKey = secondaryBlsSecret,
+                )
+                val payloadBytes = try {
+                    jsonFormat.encodeToString(
+                        GroupInvitationPayload.serializer(),
+                        invitePayload,
+                    ).toByteArray(Charsets.UTF_8)
+                } catch (_: Throwable) {
+                    throw CreateGroupError.InvitationEncodingFailed
+                }
                 val sealed = try {
                     identity.sealInvitation(payloadBytes, inboxKey)
                 } catch (e: Throwable) {
@@ -264,6 +311,18 @@ open class CreateGroupInteractor(
         // the caller sees `isPublishedOnChain = true`.
         return groups.snapshots.value.firstOrNull { it.id == group.id }
             ?: group.copy(isPublishedOnChain = true)
+    }
+
+    /** Bridge the wire-typed [SepGroupType] to the binding-key
+     *  [GovernanceType]. Returns `null` for governance flavours that
+     *  don't have a contract slot today (e.g. `democracy`,
+     *  `oligarchy` until they ship). */
+    private fun SepGroupType.toGovernanceType(): GovernanceType? = when (this) {
+        SepGroupType.TYRANNY -> GovernanceType.Tyranny
+        SepGroupType.ONE_ON_ONE -> GovernanceType.OneOnOne
+        SepGroupType.ANARCHY -> GovernanceType.Anarchy
+        SepGroupType.DEMOCRACY -> GovernanceType.Democracy
+        SepGroupType.OLIGARCHY -> GovernanceType.Oligarchy
     }
 
     private companion object {
@@ -320,6 +379,14 @@ sealed class CreateGroupError(message: String) : Exception(message) {
 
     class InvalidInviteeKey(val index: Int) :
         CreateGroupError("Invitee #${index + 1} is not a 32-byte X25519 public key")
+
+    class OneOnOneRequiresExactlyOneInvitee(val actual: Int) :
+        CreateGroupError(
+            "1-on-1 groups need exactly one invitee — you added $actual.",
+        )
+
+    class UnsupportedGroupType(val type: SepGroupType) :
+        CreateGroupError("$type groups can't be created yet")
 
     object MissingIdentity : CreateGroupError("No identity is loaded — bootstrap or restore first") {
         private fun readResolve(): Any = MissingIdentity

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -145,6 +145,7 @@ data class CreateGroupState(
 typealias GroupCreator = suspend (
     name: String,
     invitees: List<ByteArray>,
+    groupType: SepGroupType,
     onProgress: (CreateGroupProgress) -> Unit,
 ) -> ChatGroup
 
@@ -293,6 +294,7 @@ class CreateGroupViewModel(
             val group = createGroup(
                 current.effectiveName,
                 current.invitees.map { it.inboxPublicKey },
+                current.governance.sepGroupType,
             ) { p -> _state.value = _state.value.copy(progress = p) }
             _state.value = _state.value.copy(
                 createdGroup = group,

--- a/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
@@ -57,6 +57,21 @@ data class GroupInvitationPayload(
      *  `null` for ANARCHY / ONE_ON_ONE. */
     @SerialName("admin_pubkey_hex")
     val adminPubkeyHex: String? = null,
+    /** **OneOnOne only.** 32 BE Fr — the ephemeral BLS secret the
+     *  creator generated for this invitee and used as `sk_1` in the
+     *  founding `OneOnOne.proveCreate(sk_0, sk_1, salt)` call. The
+     *  receiver needs this to act as the second party of the
+     *  immutable 1v1 group.
+     *
+     *  `null` for every other governance type — those flows let the
+     *  receiver bring their own BLS identity.
+     *
+     *  ⚠ Carries a private key. Sealed by
+     *  [chat.onym.android.identity.IdentityRepository.sealInvitation]
+     *  before it leaves the device — never logged, never echoed. */
+    @SerialName("invitee_bls_secret_key")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val inviteeBlsSecretKey: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -71,7 +86,9 @@ data class GroupInvitationPayload(
             (commitment?.contentEquals(other.commitment) ?: (other.commitment == null)) &&
             tierRaw == other.tierRaw &&
             groupTypeRaw == other.groupTypeRaw &&
-            adminPubkeyHex == other.adminPubkeyHex
+            adminPubkeyHex == other.adminPubkeyHex &&
+            (inviteeBlsSecretKey?.contentEquals(other.inviteeBlsSecretKey)
+                ?: (other.inviteeBlsSecretKey == null))
     }
 
     override fun hashCode(): Int {
@@ -86,6 +103,7 @@ data class GroupInvitationPayload(
         h = 31 * h + tierRaw
         h = 31 * h + groupTypeRaw.hashCode()
         h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
+        h = 31 * h + (inviteeBlsSecretKey?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
@@ -16,18 +16,29 @@ import chat.onym.android.chain.SepGroupType
  * in the follow-up to drop the parsed-1568 + epoch-pair shape).
  */
 class StubGroupProofGenerator : GroupProofGenerator {
-    override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof {
-        if (input.groupType != SepGroupType.TYRANNY) {
-            throw GroupProofGeneratorError.NotYetSupported(input.groupType)
+    override suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof =
+        when (input.groupType) {
+            SepGroupType.TYRANNY -> GroupCreateProof(
+                proof = ByteArray(1601) { 0xAB.toByte() },
+                publicInputs = listOf(
+                    ByteArray(32) { 0xCD.toByte() },  // commitment
+                    ByteArray(32),                     // Fr(0)
+                    ByteArray(32) { 0xEE.toByte() },  // admin_pubkey_commitment
+                    ByteArray(32) { 0xFF.toByte() },  // group_id_fr
+                ),
+            )
+            SepGroupType.ONE_ON_ONE -> {
+                if (input.secondaryBlsSecretKey == null) {
+                    throw GroupProofGeneratorError.SecondaryBlsSecretKeyRequired
+                }
+                GroupCreateProof(
+                    proof = ByteArray(1601) { 0x12.toByte() },
+                    publicInputs = listOf(
+                        ByteArray(32) { 0x34.toByte() },  // commitment
+                        ByteArray(32),                     // Fr(0)
+                    ),
+                )
+            }
+            else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
-        return GroupCreateProof(
-            proof = ByteArray(1601) { 0xAB.toByte() },
-            publicInputs = listOf(
-                ByteArray(32) { 0xCD.toByte() },  // commitment
-                ByteArray(32),                      // Fr(0)
-                ByteArray(32) { 0xEE.toByte() },  // admin_pubkey_commitment
-                ByteArray(32) { 0xFF.toByte() },  // group_id_fr
-            ),
-        )
-    }
 }

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -319,7 +319,7 @@ class CreateGroupViewModelTest {
      *  lambda just throws if reached — the screen flow is still fully
      *  exercised via intent dispatch. */
     private fun makeViewModel(): CreateGroupViewModel = CreateGroupViewModel(
-        createGroup = { _, _, _ ->
+        createGroup = { _, _, _, _ ->
             error("createGroup must not be invoked from VM tests")
         },
     )

--- a/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
@@ -1,0 +1,119 @@
+package chat.onym.android.group
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Wire-format pin for [GroupInvitationPayload]. PR-2 adds the
+ * `invitee_bls_secret_key` field for OneOnOne; everything else stays
+ * round-trippable so older / non-OneOnOne envelopes decode unchanged.
+ */
+class GroupInvitationPayloadTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun roundtrip_tyrannyShape_preservesAllFields_andOmitsOneOnOneKey() {
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0x11 },
+            groupSecret = ByteArray(32) { 0x22 },
+            name = "Friends",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x33 },
+            commitment = ByteArray(32) { 0x44 },
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            adminPubkeyHex = "abc",
+            inviteeBlsSecretKey = null,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+
+        // The serializer emits the new field only when it has a value
+        // (Json by default still emits null when encodeDefaults=true,
+        // so just sanity-check the snake_case key spelling).
+        val obj = json.parseToJsonElement(encoded).jsonObject
+        assertTrue(
+            "invitee_bls_secret_key key must use snake_case if present",
+            obj.containsKey("invitee_bls_secret_key") || obj["invitee_bls_secret_key"] == null,
+        )
+        // tier_raw + group_type_raw stay snake-cased for cross-platform parity.
+        assertEquals(0, obj["tier_raw"]!!.jsonPrimitive.contentOrNull?.toInt())
+        assertEquals("tyranny", obj["group_type_raw"]!!.jsonPrimitive.contentOrNull)
+        assertEquals("abc", obj["admin_pubkey_hex"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun roundtrip_oneOnOneShape_carriesInviteeBlsSecretAsBase64() {
+        val sk1 = ByteArray(32) { 0x99.toByte() }
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0x55 },
+            groupSecret = ByteArray(32) { 0x66 },
+            name = "1v1",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x77 },
+            commitment = ByteArray(32) { 0x88.toByte() },
+            tierRaw = 0,
+            groupTypeRaw = "oneonone",
+            adminPubkeyHex = null,
+            inviteeBlsSecretKey = sk1,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+
+        val rawB64 = obj["invitee_bls_secret_key"]!!.jsonPrimitive.content
+        assertArrayEquals(sk1, Base64.getDecoder().decode(rawB64))
+
+        // OneOnOne envelopes don't surface an admin pubkey.
+        assertNull(
+            "admin_pubkey_hex must be JSON-null for OneOnOne envelopes",
+            obj["admin_pubkey_hex"]!!.jsonPrimitive.contentOrNull,
+        )
+
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertNotNull(decoded.inviteeBlsSecretKey)
+        assertArrayEquals(sk1, decoded.inviteeBlsSecretKey)
+    }
+
+    @Test
+    fun decode_legacyEnvelopeWithoutInviteeBlsSecretKey_decodesWithNullField() {
+        // Envelopes from a pre-PR-2 sender don't include the new field.
+        // The optional default keeps decoding compatible.
+        val legacyJson = """
+            {
+              "version": 1,
+              "group_id": "${b64(ByteArray(32) { 0x10 })}",
+              "group_secret": "${b64(ByteArray(32) { 0x20 })}",
+              "name": "legacy",
+              "members": [],
+              "epoch": 0,
+              "salt": "${b64(ByteArray(32) { 0x30 })}",
+              "commitment": "${b64(ByteArray(32) { 0x40 })}",
+              "tier_raw": 0,
+              "group_type_raw": "tyranny",
+              "admin_pubkey_hex": "deadbeef"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), legacyJson)
+        assertEquals("legacy", decoded.name)
+        assertNull(decoded.inviteeBlsSecretKey)
+    }
+
+    private fun b64(bytes: ByteArray): String =
+        Base64.getEncoder().encodeToString(bytes)
+}


### PR DESCRIPTION
## Summary

PR-2 of the OneOnOne stack — wires the interactor to dispatch on `SepGroupType` and ship the invitee's ephemeral BLS secret. Stacked on top of #36 (PR-1). Mirrors onym-ios PR #36 PR-2 follow-up.

- `CreateGroupInteractor.create(name, invitees, groupType)` — `groupType` defaults to `TYRANNY` for back-compat. The VM (PR-3) passes the user's pick.
- OneOnOne validation: exactly 1 invitee → else `OneOnOneRequiresExactlyOneInvitee`.
- Generates an ephemeral canonical-Fr `sk_1` for the invitee (retries on the vanishing chance of collision with the creator's `sk_0` — the FFI rejects equal keys).
- Resolves the binding for the **requested** `GovernanceType` — no more hardcoded `Tyranny`. Missing OneOnOne contract → `NoContractBinding(OneOnOne)`.
- POSTs the right payload per type (`createGroupOneOnOne` for OneOnOne, `createGroupTyranny` for Tyranny).
- Persists with `adminPubkeyHex = null` for OneOnOne (no admin role).
- `GroupInvitationPayload.inviteeBlsSecretKey: ByteArray?` ships `sk_1` inside the sealed envelope. Optional default keeps pre-PR-2 envelopes decodable.
- `GroupCreator` typealias picks up `groupType`; `OnymApplication` + `CreateGroupViewModelTest` updated.

## Test plan

- [x] Unit: `GroupInvitationPayloadTest` (round-trip Tyranny, OneOnOne with bls secret, legacy envelope without the new field)
- [x] Unit: existing `SepContractTypesTest`, `SepContractClientTest`, `GroupProofGeneratorTest`, `CanonicalFrTest`, `CreateGroupViewModelTest` — all green
- [x] AndroidTest compile clean (real prove path covered by `GroupProofGeneratorFfiTest` from PR-B)
- [ ] CI release dispatch: new `CreateGroupInteractorTest` OneOnOne cases (4) on the emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
