### PR TITLE
ux: enable 1-on-1 governance in Create Group (PR-3/3)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -91,9 +91,10 @@ data class CreateGroupState(
      *  screen content. */
     val createdGroup: ChatGroup? = null,
 ) {
-    /** True when the selected governance type is wired (Tyranny only
-     *  in PR-C). The name no longer gates advance — submit falls back
-     *  to [generatedName] when the field is empty. */
+    /** True when the selected governance type is wired to the chain
+     *  layer. Tyranny + 1-on-1 are wired; Anarchy is still TBD. The
+     *  name no longer gates advance — submit falls back to
+     *  [generatedName] when the field is empty. */
     val canAdvanceToStep2: Boolean
         get() = governance.isAvailable
 
@@ -102,12 +103,32 @@ data class CreateGroupState(
     val effectiveName: String
         get() = name.trim().ifEmpty { generatedName }
 
-    /** Label for the primary "Create" CTA on Step2. */
+    /** Label for the primary "Create" CTA on Step2. Per-governance:
+     *  - Tyranny tolerates 0..N invitees ("Create empty group" / "with N").
+     *  - 1-on-1 needs exactly 1 invitee — the CTA spells out the gate
+     *    so the user understands why it's disabled. */
     val createCtaLabel: String
-        get() = when (invitees.size) {
-            0 -> "Create empty group"
-            1 -> "Create with 1 person"
-            else -> "Create with ${invitees.size} people"
+        get() = when (governance) {
+            OnymUIGovernance.OneOnOne -> when (invitees.size) {
+                0 -> "Add the other person"
+                1 -> "Start 1-on-1"
+                else -> "1-on-1 needs exactly one"
+            }
+            else -> when (invitees.size) {
+                0 -> "Create empty group"
+                1 -> "Create with 1 person"
+                else -> "Create with ${invitees.size} people"
+            }
+        }
+
+    /** Whether the Create CTA on Step2 is enabled. Tyranny is always
+     *  enabled (zero invitees = creator-only group); 1-on-1 requires
+     *  exactly one invitee — the chain leg would reject otherwise
+     *  (PR-2's `OneOnOneRequiresExactlyOneInvitee`). */
+    val canSubmit: Boolean
+        get() = when (governance) {
+            OnymUIGovernance.OneOnOne -> invitees.size == 1
+            else -> governance.isAvailable
         }
 
     /** Live char count for the InviteByKey field — matches the
@@ -284,6 +305,18 @@ class CreateGroupViewModel(
             )
             return
         }
+        // 1-on-1 needs exactly one invitee — surface the error here
+        // rather than letting the interactor throw mid-pipeline.
+        if (current.governance == OnymUIGovernance.OneOnOne &&
+            current.invitees.size != 1
+        ) {
+            _state.value = current.copy(
+                error = CreateGroupError.OneOnOneRequiresExactlyOneInvitee(
+                    actual = current.invitees.size,
+                ),
+            )
+            return
+        }
         _state.value = current.copy(
             error = null,
             progress = CreateGroupProgress.Validating,
@@ -409,8 +442,20 @@ enum class OnymUIGovernance(
     ),
     ;
 
-    /** Per-PR-C scope: only Tyranny is wired to the chain layer. */
-    val isAvailable: Boolean get() = this == Tyranny
+    /** Tyranny + 1-on-1 are wired to the chain layer; Anarchy is
+     *  still TBD (no FFI proof generator and no contract slot). */
+    val isAvailable: Boolean get() = this == Tyranny || this == OneOnOne
+
+    /** One-line addendum rendered in the Step-2 banner under the
+     *  governance label. Type-specific because the implications
+     *  differ — Tyranny mentions the admin role, 1-on-1 mentions the
+     *  exact-one-invitee constraint. */
+    val step2Hint: String
+        get() = when (this) {
+            Tyranny -> "You'll be the only admin."
+            OneOnOne -> "Pick exactly one person."
+            Anarchy -> "Everyone shares control."
+        }
 
     val sepGroupType: SepGroupType
         get() = when (this) {

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -356,7 +356,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                 ) {
                     OnymGovIcon(type = state.governance, accent = accent, size = 28.dp)
                     Text(
-                        text = "${state.governance.label}. You'll be the only admin.",
+                        text = "${state.governance.label}. ${state.governance.step2Hint}",
                         color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                         modifier = Modifier.weight(1f),
@@ -508,6 +508,7 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
             OnymPrimaryButton(
                 title = state.createCtaLabel,
                 accent = accent,
+                enabled = state.canSubmit,
                 onClick = viewModel::tappedCreate,
             )
             OnymQuietButton(title = "Back", onClick = viewModel::tappedBackFromStep2)

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -250,6 +250,55 @@ class CreateGroupViewModelTest {
         assertEquals("Create with 2 people", vm.state.value.createCtaLabel)
     }
 
+    // ─── OneOnOne governance ──────────────────────────────────────
+
+    @Test
+    fun oneOnOne_isSelectable_andAdvancesToStep2() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        assertEquals(OnymUIGovernance.OneOnOne, vm.state.value.governance)
+        assertTrue(vm.state.value.canAdvanceToStep2)
+    }
+
+    @Test
+    fun oneOnOne_canSubmitOnly_whenInviteeCountIsExactlyOne() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        // Zero invitees → cannot submit.
+        assertTrue("zero invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
+        // One invitee → enabled.
+        vm.setInviteeInput("aa".repeat(32))
+        vm.tappedAddInvitee()
+        assertTrue("one invitee enables 1-on-1 submit", vm.state.value.canSubmit)
+        // Two invitees → blocked again.
+        vm.tappedInviteByKey()
+        vm.setInviteeInput("bb".repeat(32))
+        vm.tappedAddInvitee()
+        assertTrue("two invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
+    }
+
+    @Test
+    fun oneOnOne_ctaLabel_explainsTheGate() = runTest {
+        val vm = makeViewModel()
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        assertEquals("Add the other person", vm.state.value.createCtaLabel)
+        vm.setInviteeInput("aa".repeat(32))
+        vm.tappedAddInvitee()
+        assertEquals("Start 1-on-1", vm.state.value.createCtaLabel)
+        vm.tappedInviteByKey()
+        vm.setInviteeInput("bb".repeat(32))
+        vm.tappedAddInvitee()
+        assertEquals("1-on-1 needs exactly one", vm.state.value.createCtaLabel)
+    }
+
+    @Test
+    fun tyranny_canSubmit_evenWithZeroInvitees() = runTest {
+        val vm = makeViewModel()
+        // Default is Tyranny — zero invitees still enables submit
+        // (creator-only group is the canonical Tyranny zero case).
+        assertTrue(vm.state.value.canSubmit)
+    }
+
     // ─── close / reset ────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Top of the OneOnOne stack. Stacked on #37 (PR-2), which is stacked on #36 (PR-1). Mirrors onym-ios PR #36 PR-3 follow-up.

User-facing change: the "1-on-1" governance card in Create Group is now selectable instead of showing "Soon". Picking it gates the Step-2 Create CTA on having **exactly one** invitee.

- `OnymUIGovernance.OneOnOne.isAvailable = true` → picker drops the "Soon" pill and the card is clickable.
- `step2Hint` per governance — the Step-2 banner used to read "Tyranny. You'll be the only admin." for every type. Now it's per-type: "1-on-1. Pick exactly one person." etc.
- `CreateGroupState.canSubmit` — Tyranny: always-on (zero invitees = creator-only group). 1-on-1: invitees.size == 1. The Step-2 Create button reads this directly via `enabled = state.canSubmit`.
- `createCtaLabel` per type — 1-on-1 self-explains the gate ("Add the other person" → "Start 1-on-1" → "1-on-1 needs exactly one").
- `submit()` short-circuits with PR-2's `OneOnOneRequiresExactlyOneInvitee` if someone bypasses the gate (defense in depth).
- VM tests cover every CTA-label state, the per-type submit gate, picker selectability, and the always-on Tyranny case.

## Test plan

- [x] Unit: `CreateGroupViewModelTest` — new tests `oneOnOne_isSelectable_andAdvancesToStep2`, `oneOnOne_canSubmitOnly_whenInviteeCountIsExactlyOne`, `oneOnOne_ctaLabel_explainsTheGate`, `tyranny_canSubmit_evenWithZeroInvitees`
- [x] Existing unit suites still green (chain, group, identity)
- [x] AndroidTest compiles
- [x] `:app:assembleDebug` succeeds
- [ ] Manual: open Create Group → tap 1-on-1 card → Next → assert Create CTA reads "Add the other person" and is disabled → paste an inbox key → "Start 1-on-1" enables → tap → real testnet round-trip via PR-1 + PR-2

## Acceptance

User can create a 1-on-1 group on Android end-to-end via the "1-on-1" card on Step-1 → paste invitee key → "Start 1-on-1" → group lands on testnet (no `InvalidCommitmentEncoding` thanks to PR-1's canonical-Fr fix) and the invitee receives a sealed envelope carrying their ephemeral `sk_1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
