### PR TITLE
chain: AnarchyCreateGroupPayload + proof generator branch (PR-1/3)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.chain
 
 import chat.onym.android.group.GovernanceMember
+import chat.onym.sdk.Anarchy
 import chat.onym.sdk.OneOnOne
 import chat.onym.sdk.Tyranny
 import kotlinx.coroutines.Dispatchers
@@ -178,11 +179,58 @@ class OnymGroupProofGenerator : GroupProofGenerator {
         when (input.groupType) {
             SepGroupType.TYRANNY -> proveTyrannyCreate(input)
             SepGroupType.ONE_ON_ONE -> proveOneOnOneCreate(input)
-            SepGroupType.ANARCHY,
+            SepGroupType.ANARCHY -> proveAnarchyCreate(input)
             SepGroupType.DEMOCRACY,
             SepGroupType.OLIGARCHY,
                 -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
+
+    private suspend fun proveAnarchyCreate(input: GroupProofCreateInput): GroupCreateProof {
+        // Anarchy reuses the membership proof at create-time — the
+        // contract's `create_group` validates exactly the same
+        // (commitment, epoch=0) PI that a member would later produce
+        // via `verify_membership`. No `proveCreate` exists on the
+        // Anarchy SDK; `proveMembership` IS the create proof.
+        if (input.adminIndex < 0 || input.adminIndex >= input.members.size) {
+            throw GroupProofGeneratorError.AdminIndexOutOfRange(
+                index = input.adminIndex,
+                count = input.members.size,
+            )
+        }
+        val packedLeaves = ByteArray(input.members.size * 32)
+        for ((i, member) in input.members.withIndex()) {
+            require(member.leafHash.size == 32) {
+                "leafHash for member $i has unexpected size ${member.leafHash.size}, expected 32"
+            }
+            System.arraycopy(member.leafHash, 0, packedLeaves, i * 32, 32)
+        }
+
+        // CPU-bound — keep it off Dispatchers.IO and off Dispatchers.Main.
+        // Anarchy is multi-tier (depth ∈ {5, 8, 11}); MVP uses tier 0
+        // (depth 5) so wall-time is comparable to Tyranny SMALL.
+        return withContext(Dispatchers.Default) {
+            val raw = try {
+                Anarchy.proveMembership(
+                    /* depth = */ input.tier.depth,
+                    /* memberLeafHashes = */ packedLeaves,
+                    /* proverSecretKey = */ input.adminBlsSecretKey,
+                    /* proverIndex = */ input.adminIndex,
+                    /* epoch = */ 0L,
+                    /* salt = */ input.salt,
+                )
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            // Anarchy's MembershipProof returns (proof, commitment) as
+            // separate buffers. Synthesize the 2-element PI vector the
+            // contract verifies: [commitment, fr_zero] (epoch=0).
+            // (`MEMBERSHIP_PI_COUNT == 2` in sep-anarchy/src/lib.rs.)
+            GroupCreateProof(
+                proof = raw.proof,
+                publicInputs = listOf(raw.commitment, ByteArray(32)),
+            )
+        }
+    }
 
     private suspend fun proveOneOnOneCreate(input: GroupProofCreateInput): GroupCreateProof {
         val sk1 = input.secondaryBlsSecretKey

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractClient.kt
@@ -50,6 +50,14 @@ class SepContractClient(
             responseSerializer = SepSubmissionResponse.serializer(),
         )
 
+    suspend fun createGroupAnarchy(payload: AnarchyCreateGroupPayload): SepSubmissionResponse =
+        invoke(
+            function = "create_group",
+            payload = payload,
+            payloadSerializer = AnarchyCreateGroupPayload.serializer(),
+            responseSerializer = SepSubmissionResponse.serializer(),
+        )
+
     suspend fun updateCommitmentTyranny(payload: TyrannyUpdateCommitmentPayload): SepSubmissionResponse =
         invoke(
             function = "update_commitment",

--- a/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/SepContractTypes.kt
@@ -221,6 +221,67 @@ data class OneOnOneCreateGroupPayload(
 }
 
 /**
+ * `create_group` payload for the Anarchy (open governance) contract.
+ * Layout mirrors `add_create_group_args` in `onym-relayer/src/handler.rs`,
+ * `ContractType::Anarchy` arm — the relayer extracts `caller` from
+ * its config, `group_id` / `commitment` / `tier` / `member_count` from
+ * this payload's top-level keys, then forwards `--proof` +
+ * `--public-inputs` to the `sep-anarchy` Soroban contract.
+ *
+ * Differs from [TyrannyCreateGroupPayload]: no `admin_pubkey_commitment`
+ * (Anarchy has no admin role). Differs from [OneOnOneCreateGroupPayload]:
+ * has `tier` (Anarchy supports all three depths) AND `member_count`
+ * (informational — supplied at create_group, never updated by the
+ * contract; `0` means "not tracked").
+ *
+ * The PI vector is 2 × 32B chunks: `[commitment, fr_zero]` — same
+ * shape the contract's `MEMBERSHIP_PI_COUNT = 2` checks against
+ * (the second element is the membership-proof `epoch=0` Fr).
+ */
+@Serializable
+data class AnarchyCreateGroupPayload(
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray,
+    val tier: Int,
+    /** Informational only on the contract side. `0` = "not tracked"
+     *  (the v1 sep-xxxx sentinel). The relayer defaults to `0` when
+     *  absent, but we send the real count so future occupancy logic
+     *  has accurate state to read back. */
+    @SerialName("member_count")
+    val memberCount: Int,
+    /** 1601-byte raw PLONK proof. */
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val proof: ByteArray,
+    /** 2 elements × 32 bytes — `[commitment, fr_zero]`. */
+    val publicInputs: List<@Serializable(with = Base64ByteArraySerializer::class) ByteArray>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AnarchyCreateGroupPayload) return false
+        return groupId.contentEquals(other.groupId) &&
+            commitment.contentEquals(other.commitment) &&
+            tier == other.tier &&
+            memberCount == other.memberCount &&
+            proof.contentEquals(other.proof) &&
+            publicInputs.size == other.publicInputs.size &&
+            publicInputs.zip(other.publicInputs).all { (a, b) -> a.contentEquals(b) }
+    }
+
+    override fun hashCode(): Int {
+        var h = groupId.contentHashCode()
+        h = 31 * h + commitment.contentHashCode()
+        h = 31 * h + tier
+        h = 31 * h + memberCount
+        h = 31 * h + proof.contentHashCode()
+        for (p in publicInputs) h = 31 * h + p.contentHashCode()
+        return h
+    }
+}
+
+/**
  * `update_commitment` payload — Tyranny variant. The SDK's
  * `Tyranny.UpdateProof.publicInputs` is 160 bytes = 5 × 32B
  * (`c_old || epoch_old || c_new || admin_pubkey_commitment || group_id_fr`).

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
@@ -39,6 +39,13 @@ class StubGroupProofGenerator : GroupProofGenerator {
                     ),
                 )
             }
+            SepGroupType.ANARCHY -> GroupCreateProof(
+                proof = ByteArray(1601) { 0x56.toByte() },
+                publicInputs = listOf(
+                    ByteArray(32) { 0x78.toByte() },  // commitment
+                    ByteArray(32),                     // Fr(0) — epoch
+                ),
+            )
             else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
 }

--- a/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/GroupProofGeneratorTest.kt
@@ -19,12 +19,30 @@ import org.junit.Test
 class GroupProofGeneratorTest {
 
     @Test
-    fun proveCreate_anarchy_throwsNotYetSupported() = runTest {
-        val input = stubInput(SepGroupType.ANARCHY)
-        val thrown = assertThrows(GroupProofGeneratorError.NotYetSupported::class.java) {
+    fun proveCreate_anarchy_outOfRangeIndex_shortCircuitsBeforeJni() = runTest {
+        // Anarchy is now wired (no longer NotYetSupported), but the
+        // adminIndex bounds check still short-circuits before the JNI
+        // call — same as the Tyranny path. Cheapest test that proves
+        // we entered the Anarchy branch without needing the SDK loaded.
+        val input = GroupProofCreateInput(
+            groupType = SepGroupType.ANARCHY,
+            tier = SepTier.SMALL,
+            members = listOf(
+                GovernanceMember(
+                    publicKeyCompressed = ByteArray(48) { 0xAA.toByte() },
+                    leafHash = ByteArray(32) { 0xBB.toByte() },
+                ),
+            ),
+            adminBlsSecretKey = ByteArray(32) { 0x01 },
+            adminIndex = 5,
+            groupId = ByteArray(32),
+            salt = ByteArray(32),
+        )
+        val thrown = assertThrows(GroupProofGeneratorError.AdminIndexOutOfRange::class.java) {
             kotlinx.coroutines.runBlocking { OnymGroupProofGenerator().proveCreate(input) }
         }
-        assertEquals(SepGroupType.ANARCHY, thrown.type)
+        assertEquals(5, thrown.index)
+        assertEquals(1, thrown.count)
     }
 
     @Test

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractClientTest.kt
@@ -141,6 +141,50 @@ class SepContractClientTest {
     }
 
     @Test
+    fun createGroupAnarchy_sendsCreateGroupFunction_withTierAndMemberCount_butNoAdminCommitment() = runTest {
+        val transport = FakeSepContractTransport(
+            cannedResponseJson = """{"accepted":true,"transactionHash":"an456"}""",
+        )
+        val client = SepContractClient(
+            contractID = testContractId,
+            contractType = SepGroupType.ANARCHY,
+            network = SepNetwork.TESTNET,
+            transport = transport,
+        )
+
+        val payload = AnarchyCreateGroupPayload(
+            groupId = ByteArray(32) { 0x42 },
+            commitment = ByteArray(32) { 0x66 },
+            tier = 0,
+            memberCount = 1,
+            proof = ByteArray(1601) { 0x99.toByte() },
+            publicInputs = listOf(ByteArray(32) { 0x66 }, ByteArray(32)),
+        )
+        val response = client.createGroupAnarchy(payload)
+        assertTrue(response.accepted)
+        assertEquals("an456", response.transactionHash)
+
+        assertEquals("create_group", transport.lastFunction)
+        val invocation = transport.lastInvocationJson!!
+        assertEquals("anarchy", invocation["contractType"]!!.jsonPrimitive.contentOrNull)
+
+        val payloadJson = transport.lastPayloadJson!!
+        assertNotNull("group_id required", payloadJson["group_id"])
+        assertNotNull("commitment required", payloadJson["commitment"])
+        assertEquals(0, payloadJson["tier"]!!.jsonPrimitive.int)
+        assertEquals(1, payloadJson["member_count"]!!.jsonPrimitive.int)
+        assertNotNull("proof required", payloadJson["proof"])
+        // No admin commitment — Anarchy has no admin role.
+        assertEquals(
+            "Anarchy sends no admin_pubkey_commitment",
+            null,
+            payloadJson["admin_pubkey_commitment"],
+        )
+        val pi = payloadJson["publicInputs"] as JsonArray
+        assertEquals(2, pi.size)
+    }
+
+    @Test
     fun updateCommitmentTyranny_routesToUpdateFunction_with5ChunkPI() = runTest {
         val transport = FakeSepContractTransport(
             cannedResponseJson = """{"accepted":true}""",

--- a/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chain/SepContractTypesTest.kt
@@ -216,6 +216,62 @@ class SepContractTypesTest {
         assertEquals(original, decoded)
     }
 
+    // ─── AnarchyCreateGroupPayload ────────────────────────────────
+
+    @Test
+    fun anarchyCreateGroupPayload_emitsExpectedKeys() {
+        val payload = AnarchyCreateGroupPayload(
+            groupId = ByteArray(32) { 0x10 },
+            commitment = ByteArray(32) { 0x20 },
+            tier = 0,
+            memberCount = 1,
+            proof = ByteArray(1601) { 0x30 },
+            publicInputs = listOf(
+                ByteArray(32) { 0x20 },
+                ByteArray(32),
+            ),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(AnarchyCreateGroupPayload.serializer(), payload),
+        ).jsonObject
+
+        assertNotNull("group_id required", obj["group_id"])
+        assertNotNull("commitment required", obj["commitment"])
+        assertEquals(0, obj["tier"]!!.jsonPrimitive.int)
+        // Snake-case `member_count` per the relayer's
+        // `MEMBER_COUNT_KEYS` lookup.
+        assertEquals(1, obj["member_count"]!!.jsonPrimitive.int)
+        assertNotNull("proof required", obj["proof"])
+        // No `admin_pubkey_commitment` — Anarchy has no admin role.
+        assertNull("admin_pubkey_commitment must NOT appear", obj["admin_pubkey_commitment"])
+
+        val pi = obj["publicInputs"] as JsonArray
+        assertEquals("Anarchy PI is 2 × 32B (commitment, fr_zero)", 2, pi.size)
+        for (element in pi) {
+            val raw = Base64.getDecoder().decode(element.jsonPrimitive.content)
+            assertEquals(32, raw.size)
+        }
+
+        val proofBytes = Base64.getDecoder().decode(obj["proof"]!!.jsonPrimitive.content)
+        assertEquals(1601, proofBytes.size)
+        assertArrayEquals(payload.proof, proofBytes)
+    }
+
+    @Test
+    fun anarchyCreateGroupPayload_roundtripPreservesAllFields() {
+        val original = AnarchyCreateGroupPayload(
+            groupId = ByteArray(32) { 0x44 },
+            commitment = ByteArray(32) { 0x55 },
+            tier = 2,
+            memberCount = 0,
+            proof = ByteArray(1601) { 0x66 },
+            publicInputs = listOf(ByteArray(32) { 0x55 }, ByteArray(32)),
+        )
+        val encoded = json.encodeToString(AnarchyCreateGroupPayload.serializer(), original)
+        val decoded = json.decodeFromString(AnarchyCreateGroupPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
     // ─── TyrannyUpdateCommitmentPayload ───────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

PR-1 of the Anarchy stack (PR-2 wires the interactor; PR-3 toggles UI + adds the testnet E2E). Same shape as the OneOnOne stack (#36/#47/#48).

- **\`AnarchyCreateGroupPayload\`** — wire shape: \`group_id\`, \`commitment\`, \`tier\`, \`member_count\`, \`proof\`, 2-element PI \`[commitment, fr_zero]\`. Differs from Tyranny (no \`admin_pubkey_commitment\`) AND from OneOnOne (has both \`tier\` AND \`member_count\`). Matches \`add_create_group_args\` \`ContractType::Anarchy\` arm.
- **\`SepContractClient.createGroupAnarchy(payload)\`** — same envelope as Tyranny / OneOnOne.
- **\`OnymGroupProofGenerator\`** gains an \`ANARCHY\` branch calling \`chat.onym.sdk.Anarchy.proveMembership(depth, packedLeaves, sk, index, epoch=0L, salt)\`. The Anarchy SDK has no \`proveCreate\` — \`proveMembership\` IS the create proof since the contract's \`create_group\` validates exactly the same \`(commitment, epoch=0)\` PI that a member produces later via \`verify_membership\`.

## Test plan

- [x] \`SepContractTypesTest\` — wire-shape + round-trip pins for the new payload (member_count snake-cased, no admin commitment, 2-element PI)
- [x] \`SepContractClientTest\` — \`createGroupAnarchy\` routes to \`create_group\` with \`contractType=anarchy\`
- [x] \`GroupProofGeneratorTest\` — bounds-check on the Anarchy branch short-circuits before JNI
- [x] \`StubGroupProofGenerator\` returns deterministic Anarchy bytes for downstream interactor tests
- [x] \`:app:compileDebugAndroidTestKotlin\` — green
- [ ] CI: PR-2 will exercise the real Anarchy FFI end-to-end via the testnet E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)