### PR TITLE
group: branch CreateGroupInteractor on SepGroupType for Anarchy (PR-2/3)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
@@ -436,6 +436,83 @@ class CreateGroupInteractorTest {
         }
     }
 
+    // ─── Anarchy ──────────────────────────────────────────────────
+
+    @Test
+    fun create_anarchy_zeroInvitees_anchorsViaAnarchyPayload() = runBlocking {
+        // Anarchy tolerates any invitee count including zero (creator-
+        // only group is fine — the contract's `member_count` is
+        // informational, not enforced).
+        val contractsAnarchy = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeAnarchy = true)),
+            ),
+        )
+        contractsAnarchy.bootstrap()
+        contractsAnarchy.refresh()
+        val interactor = makeInteractor(contracts = contractsAnarchy)
+
+        val group = interactor.create(
+            name = "Anarchic group",
+            invitees = emptyList(),
+            groupType = chat.onym.android.chain.SepGroupType.ANARCHY,
+        )
+
+        assertEquals(chat.onym.android.chain.SepGroupType.ANARCHY, group.groupType)
+        assertTrue(group.isPublishedOnChain)
+        // Anarchy has no admin role on chain — adminPubkeyHex stays null.
+        assertEquals(null, group.adminPubkeyHex)
+
+        val invocations = contractTransport.invocations()
+        assertEquals(1, invocations.size)
+        assertEquals("create_group", invocations.single().function)
+
+        // No invitees → no inbox sends.
+        assertTrue(inboxTransport.sends().isEmpty())
+    }
+
+    @Test
+    fun create_anarchy_withInvitees_anchorsAndShipsInvitations() = runBlocking {
+        val contractsAnarchy = ContractsRepository(
+            store = InMemoryAnchorSelectionStore(),
+            fetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(makeManifest(includeTyranny = true, includeAnarchy = true)),
+            ),
+        )
+        contractsAnarchy.bootstrap()
+        contractsAnarchy.refresh()
+        val interactor = makeInteractor(contracts = contractsAnarchy)
+
+        val invitee1 = ByteArray(32) { 0x10 }
+        val invitee2 = ByteArray(32) { 0x20 }
+        val group = interactor.create(
+            name = "Open group",
+            invitees = listOf(invitee1, invitee2),
+            groupType = chat.onym.android.chain.SepGroupType.ANARCHY,
+        )
+
+        assertTrue(group.isPublishedOnChain)
+        assertEquals(2, inboxTransport.sends().size)
+    }
+
+    @Test
+    fun create_anarchy_noAnarchyBinding_throwsNoContractBinding() = runBlocking {
+        // Default contracts only has Tyranny — selecting Anarchy must
+        // raise NoContractBinding(Anarchy), not silently fall through.
+        val interactor = makeInteractor()
+        try {
+            interactor.create(
+                name = "Anarchic",
+                invitees = emptyList(),
+                groupType = chat.onym.android.chain.SepGroupType.ANARCHY,
+            )
+            error("expected NoContractBinding(Anarchy)")
+        } catch (e: CreateGroupError.NoContractBinding) {
+            assertEquals(GovernanceType.Anarchy, e.type)
+        }
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private fun makeInteractor(
@@ -458,6 +535,7 @@ class CreateGroupInteractorTest {
     private fun makeManifest(
         includeTyranny: Boolean,
         includeOneOnOne: Boolean = false,
+        includeAnarchy: Boolean = false,
     ): ContractsManifest {
         val entries = buildList<ContractEntry> {
             if (includeTyranny) {
@@ -472,6 +550,13 @@ class CreateGroupInteractorTest {
                     network = ContractNetwork.Testnet,
                     type = GovernanceType.OneOnOne,
                     id = "CONEONONETEST0000000000000000000000000000000000000000000",
+                ))
+            }
+            if (includeAnarchy) {
+                add(ContractEntry(
+                    network = ContractNetwork.Testnet,
+                    type = GovernanceType.Anarchy,
+                    id = "CANARCHYTEST00000000000000000000000000000000000000000000",
                 ))
             }
         }

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.group
 
+import chat.onym.android.chain.AnarchyCreateGroupPayload
 import chat.onym.android.chain.AnchorSelectionKey
 import chat.onym.android.chain.CanonicalFr
 import chat.onym.android.chain.ContractsRepository
@@ -216,6 +217,20 @@ open class CreateGroupInteractor(
                     OneOnOneCreateGroupPayload(
                         groupId = groupId,
                         commitment = proof.commitment,
+                        proof = proof.proof,
+                        publicInputs = proof.publicInputs,
+                    ),
+                )
+                SepGroupType.ANARCHY -> client.createGroupAnarchy(
+                    AnarchyCreateGroupPayload(
+                        groupId = groupId,
+                        commitment = proof.commitment,
+                        tier = tier.rawValue,
+                        // Send the actual roster size so the contract's
+                        // informational `member_count` reflects reality.
+                        // The relayer would default to `0` ("not tracked")
+                        // if absent, but accurate state is cheap to send.
+                        memberCount = members.size,
                         proof = proof.proof,
                         publicInputs = proof.publicInputs,
                     ),


### PR DESCRIPTION
## Summary

PR-2 of the Anarchy stack — wires the interactor's create path through Anarchy on top of PR-1's chain seam (#50). PR-3 will toggle the UI + add the testnet E2E.

- \`CreateGroupInteractor.create()\` POSTs an \`AnarchyCreateGroupPayload\` for the \`ANARCHY\` branch (tier + member_count + 2-element PI, no admin commitment).
- No new invitee-count validation — Anarchy tolerates any count incl. zero (the contract's \`member_count\` is informational, not enforced).
- \`adminPubkeyHex = null\` for Anarchy (existing Tyranny-only \`if\` branch already covers this).
- Missing binding raises \`NoContractBinding(Anarchy)\`.

## Test plan

- [x] Three new \`CreateGroupInteractorTest\` cases (zero invitees, 2 invitees, missing binding)
- [x] \`makeManifest\` helper extended with \`includeAnarchy\` flag
- [x] All existing tests still green
- [x] \`:app:compileDebugAndroidTestKotlin\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)