### PR TITLE
identity: keyed IdentitySecretStore + IdentityId value type (PR-1/5)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
@@ -114,7 +114,7 @@ class CreateGroupInteractorTest {
 
     @After
     fun tearDown() {
-        try { identityStore.wipe() } catch (_: Throwable) { /* best-effort */ }
+        try { identityStore.wipeAll() } catch (_: Throwable) { /* best-effort */ }
     }
 
     // ─── happy path ───────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
@@ -73,7 +73,7 @@ class IdentityRepositoryInvitationDecryptTest {
 
     @After
     fun tearDown() {
-        try { store.wipe() } catch (_: Throwable) { /* best-effort */ }
+        try { store.wipeAll() } catch (_: Throwable) { /* best-effort */ }
     }
 
     // ─── happy paths ──────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
@@ -76,8 +76,8 @@ class IdentityRepositorySealInvitationTest {
 
     @After
     fun tearDown() {
-        try { senderStore.wipe() } catch (_: Throwable) { /* best-effort */ }
-        try { recipientStore.wipe() } catch (_: Throwable) { /* best-effort */ }
+        try { senderStore.wipeAll() } catch (_: Throwable) { /* best-effort */ }
+        try { recipientStore.wipeAll() } catch (_: Throwable) { /* best-effort */ }
     }
 
     // ─── happy paths ──────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
@@ -51,7 +51,7 @@ class IdentityRepositoryTest {
     @After
     fun tearDown() {
         try {
-            store.wipe()
+            store.wipeAll()
         } catch (_: Throwable) {
             // Best-effort cleanup; the unique prefs file name keeps
             // tests from colliding even if a previous run leaked.
@@ -74,7 +74,9 @@ class IdentityRepositoryTest {
         assertNotNull(identity.recoveryPhrase)
         assertEquals(12, identity.recoveryPhrase!!.split(" ").size)
 
-        val stored = store.load()
+        val activeId = store.loadCurrent()
+        assertNotNull("bootstrap must persist a current-identity selection", activeId)
+        val stored = store.load(activeId!!)
         assertNotNull(stored)
         assertEquals(16, stored!!.entropy?.size)
         assertEquals(32, stored.nostrSecretKey.size)
@@ -186,7 +188,14 @@ class IdentityRepositoryTest {
         repo.bootstrap()
         repo.wipe()
         assertNull(repo.currentIdentity())
-        assertNull(store.load())
+        assertTrue(
+            "wipe clears the active identity from the keyed store",
+            store.listIds().isEmpty(),
+        )
+        assertNull(
+            "wipe also clears the `current` selection",
+            store.loadCurrent(),
+        )
     }
 
     // ─── snapshots ─────────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupTyrannyE2ETest.kt
@@ -134,7 +134,7 @@ class CreateGroupTyrannyE2ETest {
 
     @After
     fun tearDown() {
-        try { identityStore.wipe() } catch (_: Throwable) { /* best-effort */ }
+        try { identityStore.wipeAll() } catch (_: Throwable) { /* best-effort */ }
     }
 
     // ─── Tests ───────────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreenTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreenTest.kt
@@ -97,7 +97,7 @@ class RecoveryPhraseBackupScreenTest {
     @After
     fun tearDown() {
         viewModel.stop()
-        try { store.wipe() } catch (_: Throwable) {}
+        try { store.wipeAll() } catch (_: Throwable) {}
     }
 
     // ─── Intro ─────────────────────────────────────────────────────

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
@@ -90,7 +90,7 @@ class RecoveryPhraseBackupViewModelTest {
     @After
     fun tearDown() {
         viewModel.stop()
-        try { store.wipe() } catch (_: Throwable) {}
+        try { store.wipeAll() } catch (_: Throwable) {}
     }
 
     // ─── Auth ───────────────────────────────────────────────────────

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityId.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityId.kt
@@ -1,0 +1,29 @@
+package chat.onym.android.identity
+
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+/**
+ * Stable per-identity handle. Keys every per-identity record in the
+ * app — secrets in [IdentitySecretStore], owner stamps on
+ * [chat.onym.android.group.ChatGroup], inbox tags in the transport
+ * layer.
+ *
+ * Wraps a UUID — opaque, never user-visible. Display names live on
+ * [IdentitySummary] alongside this id.
+ *
+ * The string form `value` is what lands on disk + on the wire — safe
+ * to use as a SharedPreferences key suffix or Room column.
+ */
+@JvmInline
+@Serializable
+value class IdentityId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "IdentityId must not be blank" }
+    }
+
+    companion object {
+        /** Generate a fresh, never-before-used handle. */
+        fun new(): IdentityId = IdentityId(UUID.randomUUID().toString())
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -87,19 +87,30 @@ class IdentityRepository(
      * Mirrors `IdentityRepository.blsSecretKey` from onym-ios PR #26.
      */
     suspend fun blsSecretKey(): ByteArray = withContext(ioDispatcher) {
-        store.load()?.blsSecretKey ?: throw IdentityError.IdentityNotLoaded
+        val id = store.loadCurrent() ?: throw IdentityError.IdentityNotLoaded
+        store.load(id)?.blsSecretKey ?: throw IdentityError.IdentityNotLoaded
     }
 
     /**
-     * Load the persisted identity, or generate a fresh BIP39-backed
-     * one if none exists. Idempotent: a second call after success
-     * returns the same identity without re-reading the store.
+     * Load the persisted identity (the currently-selected one), or
+     * generate a fresh BIP39-backed identity if no snapshot exists.
+     * Idempotent: a second call after success returns the same
+     * identity without re-reading the store.
+     *
+     * If multiple identities exist on disk, [store]'s `current`
+     * selection (set on every save) determines which one loads.
+     * Multi-identity selection / add APIs land in the next PR.
      */
     suspend fun bootstrap(): Identity = mutex.withLock {
         _snapshots.value?.let { return@withLock it }
         withContext(ioDispatcher) {
-            val stored = store.load()
-            if (stored != null) {
+            val currentId = store.loadCurrent() ?: store.listIds().firstOrNull()
+            val stored = currentId?.let { store.load(it) }
+            if (stored != null && currentId != null) {
+                // Re-pin `current` in case it was missing (defensive — a
+                // partial wipe could clear `current` while leaving the
+                // snapshot intact).
+                if (store.loadCurrent() != currentId) store.saveCurrent(currentId)
                 val identity = identityFromSnapshot(stored)
                 _snapshots.value = identity
                 identity
@@ -110,9 +121,10 @@ class IdentityRepository(
     }
 
     /**
-     * Generate a fresh BIP39-backed identity, replacing any existing
-     * stored identity. The previous identity is unrecoverable after
-     * this call (no in-app backup is taken).
+     * Generate a fresh BIP39-backed identity. Replaces the
+     * currently-selected identity in this PR's API; the multi-
+     * identity API (next PR) will give callers the choice between
+     * "add" and "replace".
      */
     suspend fun generateNew(): Identity = mutex.withLock {
         withContext(ioDispatcher) {
@@ -121,8 +133,10 @@ class IdentityRepository(
     }
 
     /**
-     * Restore an identity from a 12- or 24-word BIP39 mnemonic,
-     * replacing any existing stored identity.
+     * Restore an identity from a 12- or 24-word BIP39 mnemonic.
+     * Replaces the currently-selected identity in this PR's API; the
+     * multi-identity API (next PR) will let callers add a restored
+     * identity alongside existing ones.
      *
      * @throws IdentityError.InvalidMnemonic if the mnemonic is
      *         malformed or has a bad checksum.
@@ -132,17 +146,25 @@ class IdentityRepository(
             val entropy = Bip39.entropyFromMnemonic(mnemonic)
                 ?: throw IdentityError.InvalidMnemonic
             val snapshot = snapshotFromEntropy(entropy)
-            store.save(snapshot)
+            // Replace the active slot — wipe its old snapshot first,
+            // then save under a fresh id so derived caches keyed by id
+            // (when they land in PR-3) get a clean break.
+            val previousId = store.loadCurrent()
+            val newId = IdentityId.new()
+            if (previousId != null) store.wipe(previousId)
+            store.save(newId, snapshot)
+            store.saveCurrent(newId)
             val identity = identityFromSnapshot(snapshot)
             _snapshots.value = identity
             identity
         }
     }
 
-    /** Delete the persisted identity. Subscribers receive a `null` snapshot. */
+    /** Delete the currently-selected identity from storage.
+     *  Subscribers receive a `null` snapshot. */
     suspend fun wipe() = mutex.withLock {
         withContext(ioDispatcher) {
-            store.wipe()
+            store.loadCurrent()?.let { store.wipe(it) }
             _snapshots.value = null
         }
     }
@@ -163,11 +185,14 @@ class IdentityRepository(
      */
     override suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray =
         withContext(ioDispatcher) {
-            // Snapshot read happens off the mutex — `store.load()` is a
+            // Snapshot read happens off the mutex — store I/O is a
             // single atomic SharedPreferences read; concurrent `wipe()`
             // either observes the pre-wipe blob or post-wipe null,
-            // both internally consistent.
-            val snapshot = store.load() ?: throw InvitationDecryptError.IdentityNotLoaded
+            // both internally consistent. Reads against the
+            // currently-selected identity; the multi-identity inbox
+            // fan-out (PR-4) will iterate every id instead.
+            val id = store.loadCurrent() ?: throw InvitationDecryptError.IdentityNotLoaded
+            val snapshot = store.load(id) ?: throw InvitationDecryptError.IdentityNotLoaded
             decryptInvitationLocked(snapshot, envelopeBytes)
         }
 
@@ -269,7 +294,8 @@ class IdentityRepository(
         } catch (e: IllegalArgumentException) {
             throw InvitationSealError.InvalidRecipientPublicKey(e.message ?: "parse failed")
         }
-        val snapshot = store.load() ?: throw InvitationSealError.IdentityNotLoaded
+        val id = store.loadCurrent() ?: throw InvitationSealError.IdentityNotLoaded
+        val snapshot = store.load(id) ?: throw InvitationSealError.IdentityNotLoaded
         sealInvitationLocked(snapshot, payload, recipientPub)
     }
 
@@ -356,7 +382,13 @@ class IdentityRepository(
             // Unreachable: generateMnemonic always emits a valid mnemonic.
             ?: throw IdentityError.InvalidMnemonic
         val snapshot = snapshotFromEntropy(entropy)
-        store.save(snapshot)
+        // Replace-the-active-slot semantics. PR-2's add-identity API
+        // will introduce a non-replacing variant.
+        val previousId = store.loadCurrent()
+        val newId = IdentityId.new()
+        if (previousId != null) store.wipe(previousId)
+        store.save(newId, snapshot)
+        store.saveCurrent(newId)
         val identity = identityFromSnapshot(snapshot)
         _snapshots.value = identity
         return identity

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentitySecretStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentitySecretStore.kt
@@ -8,16 +8,22 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 /**
- * Atomic, single-blob persistence for the on-device identity secrets.
+ * Atomic, per-identity persistence for the on-device identity secrets.
  *
  * One [EncryptedSharedPreferences] file (default name
- * `chat.onym.android.identity`) holds the JSON-encoded [StoredSnapshot]
- * under a single preference key. Every mutation is one
- * `editor.putString(...).commit()` — no intermediate state where one
- * secret has been written and another has not, so partial-failure
- * cleanup is unnecessary.
+ * `chat.onym.android.identity`) holds the JSON-encoded
+ * [StoredSnapshot] for each identity, keyed under
+ * `snapshot.<identityId>`. A separate index key `index` holds the
+ * ordered list of identity ids — the source of truth for "which
+ * identities exist on this device". A `current` key holds the
+ * currently-selected [IdentityId] (or is absent when no identity is
+ * selected).
  *
- * The master key is `AES256_GCM` from the Android Keystore — the JCA
+ * Every mutation is one `editor.put*(...).commit()` per logical edit
+ * — no intermediate state where one secret has been written and
+ * another has not, so partial-failure cleanup is unnecessary.
+ *
+ * The master key is `AES256_GCM` from the Android Keystore; the JCA
  * key handle is non-exportable (hardware-backed on devices with a
  * secure element, software-only on emulators). The encrypted blob is
  * useless to anyone without the matching Keystore handle, so a backup
@@ -25,15 +31,9 @@ import kotlinx.serialization.json.Json
  * the restoring device cannot decrypt — see also
  * `app/src/main/res/xml/{backup_rules,data_extraction_rules}.xml`.
  *
- * The [prefsFileName] is configurable so instrumented tests can isolate
- * each test case in a fresh prefs file (per-test UUID name) and wipe
- * cleanly without colliding with the production identity item.
- *
- * @param context any Android Context (Application context preferred to
- *        avoid leaks).
- * @param prefsFileName name of the EncryptedSharedPreferences file.
- *        DON'T change this in production — changing it orphans the
- *        previous identity. Tests use unique names for isolation.
+ * The [prefsFileName] is configurable so instrumented tests can
+ * isolate each test case in a fresh prefs file (per-test UUID name)
+ * and wipe cleanly without colliding with the production identity item.
  */
 class IdentitySecretStore(
     private val context: Context,
@@ -58,55 +58,141 @@ class IdentitySecretStore(
         )
     }
 
-    /** JSON encoder — strict by default; tolerates unknown keys on
-     *  decode so a future StoredSnapshot field addition won't brick
-     *  existing installs. */
     private val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
     }
 
-    /** Read the persisted snapshot, or `null` if there's no saved identity. */
-    fun load(): StoredSnapshot? {
+    // ─── identity index ────────────────────────────────────────────
+
+    /** Ordered list of identity ids on this device. Order = creation
+     *  order; UI may surface a different sort. Returns an empty list
+     *  when no identities exist. */
+    fun listIds(): List<IdentityId> {
         val raw = try {
-            prefs.getString(KEY_SNAPSHOT, null)
+            prefs.getString(KEY_INDEX, null)
+        } catch (t: Throwable) {
+            throw IdentityError.StorageRead(t)
+        } ?: return emptyList()
+        return try {
+            json.decodeFromString(StoredIndex.serializer(), raw).ids.map(::IdentityId)
+        } catch (e: SerializationException) {
+            throw IdentityError.StoredSnapshotInvalid("index decode failed: ${e.message}")
+        }
+    }
+
+    /** Identity ids that have a snapshot persisted under them. */
+    fun listSnapshots(): List<Pair<IdentityId, StoredSnapshot>> =
+        listIds().mapNotNull { id -> load(id)?.let { id to it } }
+
+    // ─── current selection ────────────────────────────────────────
+
+    /** The currently-selected identity, or `null` if none is selected
+     *  (cold install OR last-active identity was removed). */
+    fun loadCurrent(): IdentityId? {
+        val raw = try {
+            prefs.getString(KEY_CURRENT, null)
+        } catch (t: Throwable) {
+            throw IdentityError.StorageRead(t)
+        } ?: return null
+        return raw.takeIf { it.isNotBlank() }?.let(::IdentityId)
+    }
+
+    /** Persist the active identity selection. `null` clears it. */
+    fun saveCurrent(id: IdentityId?) {
+        val editor = prefs.edit()
+        if (id == null) editor.remove(KEY_CURRENT)
+        else editor.putString(KEY_CURRENT, id.value)
+        if (!commit(editor)) throw IdentityError.StorageWrite(null)
+    }
+
+    // ─── per-identity snapshot ────────────────────────────────────
+
+    /** Read the snapshot for [id], or `null` if the slot is empty. */
+    fun load(id: IdentityId): StoredSnapshot? {
+        val raw = try {
+            prefs.getString(snapshotKey(id), null)
         } catch (t: Throwable) {
             throw IdentityError.StorageRead(t)
         } ?: return null
         return try {
             json.decodeFromString(StoredSnapshot.serializer(), raw)
         } catch (e: SerializationException) {
-            throw IdentityError.StoredSnapshotInvalid("decode failed: ${e.message}")
+            throw IdentityError.StoredSnapshotInvalid("decode failed for $id: ${e.message}")
         }
     }
 
-    /** Persist the snapshot. Overwrites any existing value atomically. */
-    fun save(snapshot: StoredSnapshot) {
+    /** Persist a snapshot for [id]. Atomically updates the index to
+     *  include the id if it wasn't there yet, and writes both keys in
+     *  the same `commit()` so a process crash mid-edit doesn't orphan
+     *  a snapshot or index entry. */
+    fun save(id: IdentityId, snapshot: StoredSnapshot) {
         val raw = try {
             json.encodeToString(StoredSnapshot.serializer(), snapshot)
         } catch (e: SerializationException) {
-            throw IdentityError.StoredSnapshotInvalid("encode failed: ${e.message}")
+            throw IdentityError.StoredSnapshotInvalid("encode failed for $id: ${e.message}")
         }
-        val ok = try {
-            prefs.edit().putString(KEY_SNAPSHOT, raw).commit()
-        } catch (t: Throwable) {
-            throw IdentityError.StorageWrite(t)
-        }
-        if (!ok) throw IdentityError.StorageWrite(null)
+
+        // Add id to the index if absent (preserves insertion order).
+        val ids = listIds()
+        val newIds = if (id in ids) ids else ids + id
+        val indexRaw = json.encodeToString(
+            StoredIndex.serializer(),
+            StoredIndex(newIds.map { it.value }),
+        )
+
+        val editor = prefs.edit()
+            .putString(snapshotKey(id), raw)
+            .putString(KEY_INDEX, indexRaw)
+        if (!commit(editor)) throw IdentityError.StorageWrite(null)
     }
 
-    /** Delete the persisted snapshot. No-op if there's nothing stored. */
-    fun wipe() {
-        val ok = try {
-            prefs.edit().remove(KEY_SNAPSHOT).commit()
-        } catch (t: Throwable) {
-            throw IdentityError.StorageDelete(t)
-        }
-        if (!ok) throw IdentityError.StorageDelete(null)
+    /** Delete a single identity's snapshot + remove it from the index.
+     *  No-op if [id] isn't in the index. If the removed id was the
+     *  currently-selected one, the current selection is also cleared
+     *  (caller is responsible for picking a replacement). */
+    fun wipe(id: IdentityId) {
+        val ids = listIds()
+        if (id !in ids) return
+        val newIds = ids - id
+        val indexRaw = json.encodeToString(
+            StoredIndex.serializer(),
+            StoredIndex(newIds.map { it.value }),
+        )
+        val editor = prefs.edit()
+            .remove(snapshotKey(id))
+            .putString(KEY_INDEX, indexRaw)
+        if (loadCurrent() == id) editor.remove(KEY_CURRENT)
+        if (!commit(editor)) throw IdentityError.StorageDelete(null)
     }
+
+    /** Delete every identity + the index + the current selection.
+     *  Used by tests and the (future) "reset device" flow. */
+    fun wipeAll() {
+        val editor = prefs.edit().clear()
+        if (!commit(editor)) throw IdentityError.StorageDelete(null)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun commit(editor: SharedPreferences.Editor): Boolean = try {
+        editor.commit()
+    } catch (t: Throwable) {
+        throw IdentityError.StorageWrite(t)
+    }
+
+    private fun snapshotKey(id: IdentityId): String = "$KEY_SNAPSHOT_PREFIX${id.value}"
 
     companion object {
         const val DEFAULT_PREFS_FILE_NAME = "chat.onym.android.identity"
-        private const val KEY_SNAPSHOT = "snapshot"
+        private const val KEY_INDEX = "index"
+        private const val KEY_CURRENT = "current"
+        private const val KEY_SNAPSHOT_PREFIX = "snapshot."
     }
 }
+
+/** On-disk envelope for the identity index — wraps the list so
+ *  future fields (sort order, deleted-tombstones, etc.) can be added
+ *  without flattening the JSON shape. */
+@kotlinx.serialization.Serializable
+internal data class StoredIndex(val ids: List<String>)


### PR DESCRIPTION
## Summary

PR-1 of the multi-identity stack. Foundation only — \`IdentityRepository\`'s public API stays single-identity for this PR; PR-2 exposes the multi-identity surface (\`identities\`, \`select\`, \`add\`, \`remove\`).

- New \`IdentityId\` value class (UUID-backed). Opaque handle keying every per-identity record in the app.
- \`IdentitySecretStore\` becomes keyed: \`listIds\` / \`loadCurrent\`/\`saveCurrent\` / \`load(id)\`/\`save(id, snap)\` / \`wipe(id)\` / \`wipeAll\`. Atomic index updates so a process crash mid-edit can't orphan slots.
- \`IdentityRepository\` routes through the keyed store. \`bootstrap()\` reads the active id then loads its snapshot; cold install falls through to \`generateNew\`. \`generateNew\` / \`restore\` mint a fresh id (replace-the-active-slot semantics for now). \`wipe()\` deletes the active slot.
- No backwards-compat path: legacy single-key snapshot blob is gone, not migrated. Pre-1.0, greenfield licence.

## Test plan

- [x] Existing \`IdentityRepositoryTest\` / \`IdentityRepositoryInvitationDecryptTest\` / \`IdentityRepositorySealInvitationTest\` adapted to the keyed shape — all green
- [x] All other affected suites (Recovery / CreateGroup / E2E) compile clean
- [x] All unit tests green

## Stack

PR-1 (this) → chain/keyed store + IdentityId
PR-2 → identity/multi-repo (identities flow + add/select/remove)
PR-3 → group/owner-identity (ChatGroup.ownerIdentityId + filter)
PR-4 → transport/inbox-fanout (subscribe to N tags)
PR-5 → ux/identity-management (Settings → Identities + Chats top-bar picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)