### PR TITLE
transport: inbox subscription fan-out across identities (PR-4/5)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -38,6 +38,7 @@ import chat.onym.android.transport.nostr.NostrInboxTransport
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -286,6 +287,29 @@ class OnymApplication : Application() {
         // CreateGroupInteractor.create blocks on `send` (which
         // connects on first use via `NostrInboxTransport`).
         val inboxTransport = NostrInboxTransport(signerProvider = nostrSignerProvider)
+
+        // Multi-identity inbox fan-out (PR-4). Subscribes to every
+        // identity's inbox tag concurrently so messages targeted at
+        // a non-active identity still land on disk. Resubscribes
+        // wholesale when the identities list changes (add / remove).
+        val invitationsRepository = chat.onym.android.inbox.IncomingInvitationsRepository(
+            store = chat.onym.android.persistence.InMemoryInvitationStore(),
+        )
+        val invitationsInteractor = chat.onym.android.inbox.IncomingInvitationsInteractor(
+            inboxTransport = inboxTransport,
+            repository = invitationsRepository,
+        )
+        applicationScope.launch {
+            invitationsInteractor.runFanout(
+                identityRepository.identities.map { summaries ->
+                    summaries.map { summary ->
+                        chat.onym.android.transport.TransportInboxId(
+                            chat.onym.android.identity.IdentityRepository.inboxTag(summary.inboxPublicKey),
+                        )
+                    }
+                },
+            )
+        }
 
         // App-wide network preference (PR-C follow-up). Defaults to
         // testnet; the Settings → Network → "Use Mainnet" Switch

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -665,7 +665,7 @@ class IdentityRepository(
          * `GroupCrypto.hiddenInboxTag` in stellar-mls and
          * `IdentityRepository.inboxTag` in onym-ios.
          */
-        internal fun inboxTag(inboxPublicKey: ByteArray): String {
+        fun inboxTag(inboxPublicKey: ByteArray): String {
             val md = MessageDigest.getInstance("SHA-256")
             md.update("sep-inbox-v1".toByteArray(Charsets.UTF_8))
             md.update(inboxPublicKey)

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
@@ -2,7 +2,11 @@ package chat.onym.android.inbox
 
 import chat.onym.android.transport.InboxTransport
 import chat.onym.android.transport.TransportInboxId
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 
 /**
  * Stateless transport-to-persistence pump. Holds two refs — the
@@ -42,6 +46,40 @@ class IncomingInvitationsInteractor(
                 payload = inbound.payload,
                 receivedAt = inbound.receivedAt,
             )
+        }
+    }
+
+    /**
+     * Multi-identity fan-out. Subscribes to **every** inbox tag in
+     * the latest [tags] emission concurrently — one child coroutine
+     * per tag inside a structured-concurrency scope. When the upstream
+     * flow emits a new list (identity added / removed / selected), the
+     * old subscription set is cancelled wholesale and a fresh set is
+     * launched.
+     *
+     * Fan-out is the right shape for multi-identity: messages sent to
+     * any identity's inbox MUST land on disk regardless of which
+     * identity the user is currently viewing — otherwise switching
+     * identity would silently drop messages received under the others.
+     *
+     * Suspends for the lifetime of the calling scope. Cancelling the
+     * caller cancels every subscription.
+     */
+    suspend fun runFanout(tags: Flow<List<TransportInboxId>>) {
+        tags.distinctUntilChanged().collectLatest { current ->
+            // Inner `coroutineScope` is the structured-concurrency
+            // anchor for THIS emission. `collectLatest` cancels the
+            // outer lambda on the next emission, which propagates
+            // cancellation to the inner scope, which cancels every
+            // child `launch` — the wholesale-resubscribe semantics.
+            // The inner scope never returns under happy operation
+            // (each `run(tag)` collects a never-completing Flow), so
+            // it stays alive until cancelled.
+            coroutineScope {
+                for (tag in current) {
+                    launch { run(tag) }
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/persistence/InMemoryInvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InMemoryInvitationStore.kt
@@ -1,0 +1,43 @@
+package chat.onym.android.persistence
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Process-lifetime in-memory [InvitationStore]. Used as the V1
+ * default sink for the multi-identity inbox fan-out (PR-4) while the
+ * Room-backed receive-and-decrypt flow lands in a follow-up. Swap to
+ * [RoomInvitationStore] (already exists, not yet wired) once the
+ * receive-side decoding lands.
+ *
+ * Process death drops everything; that's intentional for V1 — the
+ * receive side hasn't stabilised yet, and reading garbage off disk
+ * after a schema change would be more confusing than re-fetching
+ * from the relay on next launch.
+ */
+class InMemoryInvitationStore : InvitationStore {
+
+    private val mutex = Mutex()
+    private val rows = LinkedHashMap<String, IncomingInvitationRecord>()
+
+    override suspend fun list(): List<IncomingInvitationRecord> = mutex.withLock {
+        rows.values.sortedByDescending { it.receivedAt }
+    }
+
+    override suspend fun save(record: IncomingInvitationRecord): Boolean = mutex.withLock {
+        val isNew = !rows.containsKey(record.id)
+        rows[record.id] = record
+        isNew
+    }
+
+    override suspend fun updateStatus(id: String, status: IncomingInvitationStatus) {
+        mutex.withLock {
+            val existing = rows[id] ?: return
+            rows[id] = existing.copy(status = status)
+        }
+    }
+
+    override suspend fun delete(id: String) {
+        mutex.withLock { rows.remove(id) }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
@@ -143,6 +143,66 @@ class IncomingInvitationsInteractorTest {
         )
     }
 
+    @Test
+    fun runFanout_subscribesToEveryTagInTheList() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        val alice = TransportInboxId("alice-tag")
+        val bob = TransportInboxId("bob-tag")
+        val tags = kotlinx.coroutines.flow.MutableStateFlow(listOf(alice, bob))
+
+        coroutineScope {
+            val job = async { interactor.runFanout(tags) }
+            yield()
+            // Inbounds on either tag must land in the store.
+            transport.emit(InboundInbox(alice, "alice-msg".toByteArray(), now, "alice-1"))
+            transport.emit(InboundInbox(bob, "bob-msg".toByteArray(), now, "bob-1"))
+            yield()
+            assertEquals(2, store.list().size)
+            // Cancel the fan-out so the test exits.
+            job.cancel()
+            job.join()
+        }
+    }
+
+    @Test
+    fun runFanout_unsubscribesRemovedTags_andSubscribesNewOnes() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryInvitationStore()
+        val repo = IncomingInvitationsRepository(store)
+        val interactor = IncomingInvitationsInteractor(transport, repo)
+
+        val alice = TransportInboxId("alice-tag")
+        val carol = TransportInboxId("carol-tag")
+        val tags = kotlinx.coroutines.flow.MutableStateFlow(listOf(alice))
+
+        coroutineScope {
+            val job = async { interactor.runFanout(tags) }
+            yield()
+            // Initial subscription set is just Alice.
+            assertEquals(setOf(alice), transport.subscribedInboxes)
+
+            // Swap the entire list to [carol]: Alice unsubscribes,
+            // Carol subscribes. The wholesale cancel-and-rebuild
+            // semantics — collectLatest cancels the inner scope which
+            // cancels every child launch, then re-launches with the
+            // new list.
+            tags.value = listOf(carol)
+            yield()
+            assertEquals(setOf(carol), transport.subscribedInboxes)
+            assertTrue(
+                "Alice was unsubscribed when she dropped off the list",
+                transport.unsubscribedInboxes.contains(alice),
+            )
+
+            job.cancel()
+            job.join()
+        }
+    }
+
     private fun inbound(id: String, payload: String, at: Instant = now) = InboundInbox(
         inbox = inbox,
         payload = payload.toByteArray(Charsets.UTF_8),

--- a/app/src/test/kotlin/chat/onym/android/support/FakeInboxTransport.kt
+++ b/app/src/test/kotlin/chat/onym/android/support/FakeInboxTransport.kt
@@ -52,6 +52,14 @@ class FakeInboxTransport : InboxTransport {
     val unsubscribedInboxes: List<TransportInboxId> get() = _unsubscribedInboxes.toList()
     private val _unsubscribedInboxes = mutableListOf<TransportInboxId>()
 
+    /** Currently-active subscriptions. Inserts on `subscribe`, removes
+     *  on `onCompletion` of the returned Flow (= unsubscribe OR
+     *  cancellation). Multi-identity fan-out tests assert on the
+     *  set-equals contract: "the active subscription set tracks the
+     *  identity list across changes". */
+    val subscribedInboxes: Set<TransportInboxId> get() = synchronized(_subscribedInboxes) { _subscribedInboxes.toSet() }
+    private val _subscribedInboxes = mutableSetOf<TransportInboxId>()
+
     override suspend fun connect(endpoints: List<TransportEndpoint>) { /* no-op */ }
 
     override suspend fun disconnect() {
@@ -67,6 +75,7 @@ class FakeInboxTransport : InboxTransport {
 
     override fun subscribe(inbox: TransportInboxId): Flow<InboundInbox> {
         subscribeCallCount += 1
+        synchronized(_subscribedInboxes) { _subscribedInboxes.add(inbox) }
         // Pre-create the channel so a test that calls emit() before
         // the collector starts doesn't hit a missing-key error;
         // unbounded buffer because tests typically know what they
@@ -75,13 +84,17 @@ class FakeInboxTransport : InboxTransport {
             channels.getOrPut(inbox) { Channel(Channel.UNLIMITED) }
         }
         return channel.consumeAsFlow()
-            .onCompletion { _unsubscribedInboxes.add(inbox) }
+            .onCompletion {
+                _unsubscribedInboxes.add(inbox)
+                synchronized(_subscribedInboxes) { _subscribedInboxes.remove(inbox) }
+            }
     }
 
     override suspend fun unsubscribe(inbox: TransportInboxId) {
         mutex.withLock {
             channels.remove(inbox)?.close()
             _unsubscribedInboxes.add(inbox)
+            synchronized(_subscribedInboxes) { _subscribedInboxes.remove(inbox) }
         }
     }
 


### PR DESCRIPTION
## Summary

PR-4 of the multi-identity stack. Stacked on #55. Subscribes to every identity's inbox tag concurrently — messages addressed to a non-active identity still land on disk while the user is viewing a different one.

- \`IncomingInvitationsInteractor.runFanout(tags: Flow<List<TransportInboxId>>)\` — wholesale resubscribe via \`collectLatest\` + a per-emission \`coroutineScope\`. \`distinctUntilChanged\` prevents churn.
- \`IdentityRepository.inboxTag()\` flipped \`internal\` → \`public\` so the wiring layer can derive tags from summaries.
- \`OnymApplication\` launches \`runFanout(identityRepository.identities.map { …tags… })\` into \`applicationScope\`. New \`InMemoryInvitationStore\` (in \`main\`) is the V1 sink — swap to \`RoomInvitationStore\` once the receive/decrypt flow lands.
- \`FakeInboxTransport.subscribedInboxes\` Set added for the fan-out tests.

## Test plan

- [x] \`runFanout_subscribesToEveryTagInTheList\` — concurrent subscriptions; both inbounds land
- [x] \`runFanout_unsubscribesRemovedTags_andSubscribesNewOnes\` — list swap cancels old + starts new
- [x] All other unit tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)