### PR TITLE
ux: Settings → Identities + multi-identity management UI (PR-5/5)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
@@ -1,0 +1,172 @@
+package chat.onym.android.uitests
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import chat.onym.android.MainActivity
+import chat.onym.android.UITestRegistry
+import chat.onym.android.identity.IdentitySecretStore
+import chat.onym.android.support.FakeContractsManifestFetcher
+import chat.onym.android.support.FakeKnownRelayersFetcher
+import chat.onym.android.support.InMemoryAnchorSelectionStore
+import chat.onym.android.support.InMemoryRelayerSelectionStore
+import chat.onym.android.uitests.screens.SettingsScreenObject
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import java.security.Security
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * End-to-end coverage of Settings → Identities (PR-5). Backed by
+ * an isolated [IdentitySecretStore] (per-test EncryptedSharedPreferences
+ * file) injected via [UITestRegistry] so each test starts cold and
+ * doesn't collide with parallel runs.
+ *
+ * The Application's eager bootstrap auto-creates the first identity,
+ * so every test starts with one identity already on disk + selected.
+ *
+ * What's exercised:
+ *
+ *  - Settings → "Manage identities" navigation lands on the screen
+ *    and shows the bootstrapped identity.
+ *  - "+ Add identity" FAB appends a second row.
+ *  - Trash → name-confirm dialog → confirm removes the row + cascades
+ *    via the `IdentityRepository.registerRemovalListener` hook
+ *    (PR-3 wiring; the listener is registered in `init` on
+ *    `GroupRepository`).
+ */
+@RunWith(AndroidJUnit4::class)
+class IdentitiesUITest {
+
+    private lateinit var identityStore: IdentitySecretStore
+
+    @get:Rule(order = 0)
+    val registrySetup = object : TestWatcher() {
+        override fun starting(description: Description) {
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.insertProviderAt(BouncyCastleProvider(), 2)
+            }
+            val ctx = ApplicationProvider.getApplicationContext<chat.onym.android.OnymApplication>()
+            identityStore = IdentitySecretStore(
+                ctx,
+                prefsFileName = "chat.onym.android.identity.uitests.${UUID.randomUUID()}",
+            )
+            // Seed every other store IdentitiesUITest doesn't directly
+            // assert on, so MainActivity's Application.onCreate doesn't
+            // trip on a missing relayer/contracts wiring.
+            UITestRegistry.identitySecretStore = identityStore
+            UITestRegistry.relayerStore = InMemoryRelayerSelectionStore().apply {
+                kotlinx.coroutines.runBlocking {
+                    saveConfiguration(
+                        chat.onym.android.chain.RelayerConfiguration(
+                            endpoints = listOf(
+                                chat.onym.android.chain.RelayerEndpoint(
+                                    "test", "https://relayer.test.invalid", listOf("testnet"),
+                                ),
+                            ),
+                            hasUserInteracted = true,
+                        )
+                    )
+                }
+            }
+            UITestRegistry.relayerFetcher = FakeKnownRelayersFetcher(
+                FakeKnownRelayersFetcher.Mode.Succeeds(emptyList())
+            )
+            UITestRegistry.contractsStore = InMemoryAnchorSelectionStore()
+            UITestRegistry.contractsFetcher = FakeContractsManifestFetcher(
+                FakeContractsManifestFetcher.Mode.Succeeds(
+                    chat.onym.android.chain.ContractsManifest(
+                        version = 1,
+                        releases = emptyList(),
+                    ),
+                )
+            )
+            UITestRegistry.enabled = true
+            ctx.rebuildDependenciesForTest()
+        }
+
+        override fun finished(description: Description) {
+            try { identityStore.wipeAll() } catch (_: Throwable) { /* best-effort */ }
+            UITestRegistry.reset()
+        }
+    }
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    private val settings get() = SettingsScreenObject(composeRule)
+
+    @Test
+    fun bootstrap_landsOnIdentitiesScreen_withOneRow() {
+        settings.tapIdentitiesRow()
+
+        // Wait for the bootstrap-from-zero path to populate the
+        // identities flow (eager bootstrap kicks off when the
+        // Application's deps are built; the screen's StateFlow
+        // collector picks it up shortly after).
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            composeRule.onAllNodesWithTag("identities.add").fetchSemanticsNodes().isNotEmpty() &&
+                identityStore.listIds().isNotEmpty()
+        }
+        // Exactly one identity row is visible.
+        val rowCount = composeRule.onAllNodesWithTag(
+            identityStore.listIds().first().testTagPrefix() + ".remove",
+        ).fetchSemanticsNodes().size
+        assert(rowCount == 1) { "expected 1 identity row, saw $rowCount" }
+    }
+
+    @Test
+    fun addIdentity_appendsRow() {
+        settings.tapIdentitiesRow()
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            identityStore.listIds().size == 1
+        }
+        composeRule.onNodeWithTag("identities.add").performClick()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            identityStore.listIds().size == 2
+        }
+    }
+
+    @Test
+    fun removeIdentity_typedConfirm_deletesFromStore() {
+        settings.tapIdentitiesRow()
+        composeRule.waitUntil(timeoutMillis = 10.seconds.inWholeMilliseconds) {
+            identityStore.listIds().size == 1
+        }
+        // Add a second identity so we can remove the second one
+        // (removing the only one is allowed but the post-remove state
+        // is "no identity" — the bootstrap path would re-add one on
+        // the next dependency rebuild, complicating the assertion).
+        composeRule.onNodeWithTag("identities.add").performClick()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            identityStore.listIds().size == 2
+        }
+
+        // The newly-added identity gets the auto-fill name "Identity 2".
+        val secondId = identityStore.listIds()[1]
+        composeRule.onNodeWithTag("identities.row.${secondId.value}.remove").performClick()
+
+        // Type the expected name; tap Remove.
+        composeRule.onNodeWithTag("identities.remove.confirm.input").performTextInput("Identity 2")
+        composeRule.onNodeWithTag("identities.remove.confirm").performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            identityStore.listIds().size == 1
+        }
+    }
+
+    /** `identities.row.<id>` is the row's tag prefix; `.remove`
+     *  appends the trash-icon's selector. Pulled into a helper so
+     *  the row-tag scheme stays in one place. */
+    private fun chat.onym.android.identity.IdentityId.testTagPrefix(): String =
+        "identities.row.$value"
+}

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/SettingsScreenObject.kt
@@ -1,32 +1,44 @@
 package chat.onym.android.uitests.screens
 
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 
 /**
- * Page object for the root Settings screen. Just the two rows we
- * navigate into from instrumented tests.
+ * Page object for the root Settings screen. Page-object navigation
+ * helpers for the rows the rest of the suite cares about.
  *
- * Post-PR-30 the start destination is the Chats tab, not Settings —
- * so every method here first taps the Settings bottom-bar tab to
- * make sure the rows we want are in the visible window. Without
- * that hop the rows still exist in the NavHost (Chats is also
- * mounted) but their compose bounds aren't on-screen, so
- * `performClick` fails with `Failed to inject touch input`
- * (run #25263258259 surfaced this on every AnchorsUITest /
- * RelayerSettingsUITest case).
+ * Two reasons every method opens the Settings tab first AND scrolls
+ * the target row into view before tapping it:
+ *
+ *  1. **Tab discipline**: post-PR-30 the start destination is the
+ *     Chats tab, not Settings. Without `openSettingsTab` the rows
+ *     still resolve in the NavHost (Chats is mounted concurrently)
+ *     but their compose bounds aren't on the visible window, so
+ *     `performClick` fails with `Failed to inject touch input`
+ *     (run #25263258259 surfaced this on every AnchorsUITest /
+ *     RelayerSettingsUITest case).
+ *  2. **Scroll discipline**: post-multi-identity (PR-5) Settings
+ *     gained an "Identities" row between Security and Network.
+ *     On smaller test windows the Network rows (Relayer / Anchors /
+ *     Use Mainnet toggle) can sit below the fold. `scrollAndClick`
+ *     uses `performScrollToNode` against the LazyColumn's
+ *     `settings.list` tag so the target row is guaranteed visible
+ *     before the touch.
  */
 class SettingsScreenObject(private val rule: ComposeContentTestRule) {
 
-    fun tapRelayerRow() {
-        openSettingsTab()
-        rule.onNodeWithTag("settings.relayer_row").performClick()
-    }
+    fun tapRelayerRow() = scrollAndClick("settings.relayer_row")
+    fun tapAnchorsRow() = scrollAndClick("settings.anchors_row")
+    fun tapIdentitiesRow() = scrollAndClick("settings.identities_row")
 
-    fun tapAnchorsRow() {
+    private fun scrollAndClick(tag: String) {
         openSettingsTab()
-        rule.onNodeWithTag("settings.anchors_row").performClick()
+        rule.onNodeWithTag("settings.list")
+            .performScrollToNode(hasTestTag(tag))
+        rule.onNodeWithTag(tag).performClick()
     }
 
     /** Tap the Settings tab in the bottom NavigationBar. Idempotent

--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -45,4 +45,6 @@ class AppDependencies(
     /** Chats tab — read-only view over [chat.onym.android.group.GroupRepository.snapshots].
      *  Mirrors `makeChatsFlow` from onym-ios PR #30. */
     val makeChatsViewModel: () -> ChatsViewModel,
+    /** Settings → Identities — multi-identity management (PR-5). */
+    val makeIdentitiesViewModel: () -> chat.onym.android.identity.IdentitiesViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -157,8 +157,17 @@ class OnymApplication : Application() {
     }
 
     private fun buildDependencies(): AppDependencies {
+        // Honour the test-injected per-prefs-file store when set
+        // (UI tests get a fresh EncryptedSharedPreferences file per
+        // test); fall back to the production default-name store
+        // otherwise.
+        val identityStore = if (UITestRegistry.enabled) {
+            UITestRegistry.identitySecretStore ?: IdentitySecretStore(applicationContext)
+        } else {
+            IdentitySecretStore(applicationContext)
+        }
         val identityRepository = IdentityRepository(
-            store = IdentitySecretStore(applicationContext),
+            store = identityStore,
         )
         // Eager bootstrap (PR-28 follow-up). Without this, the first
         // Create Group attempt on a fresh install fails with

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -374,6 +374,9 @@ class OnymApplication : Application() {
             makeChatsViewModel = {
                 chat.onym.android.chats.ChatsViewModel(repository = groupRepository)
             },
+            makeIdentitiesViewModel = {
+                chat.onym.android.identity.IdentitiesViewModel(identity = identityRepository)
+            },
         )
     }
 

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -36,10 +36,12 @@ import chat.onym.android.group.creategroup.CreateGroupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.search.SearchScreen
+import chat.onym.android.identity.IdentitiesViewModel
 import chat.onym.android.settings.AnchorsNetworkScreen
 import chat.onym.android.settings.AnchorsPickerViewModel
 import chat.onym.android.settings.AnchorsRootScreen
 import chat.onym.android.settings.AnchorsVersionScreen
+import chat.onym.android.settings.IdentitiesScreen
 import chat.onym.android.settings.RelayerSettingsScreen
 import chat.onym.android.settings.RelayerSettingsViewModel
 import chat.onym.android.settings.SettingsScreen
@@ -138,6 +140,7 @@ fun RootScreen(dependencies: AppDependencies) {
                     onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
                     onRelayerClick = { navController.navigate(ROUTE_RELAYER_SETTINGS) },
                     onAnchorsClick = { navController.navigate(ROUTE_ANCHORS_ROOT) },
+                    onIdentitiesClick = { navController.navigate(ROUTE_IDENTITIES) },
                     useMainnet = networkPref == chat.onym.android.chain.AppNetwork.Mainnet,
                     onToggleMainnet = { on ->
                         coroutineScope.launch {
@@ -167,6 +170,17 @@ fun RootScreen(dependencies: AppDependencies) {
             }
             composable(Tab.Search.route) {
                 SearchScreen()
+            }
+            composable(ROUTE_IDENTITIES) {
+                val vm: IdentitiesViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeIdentitiesViewModel() }
+                    },
+                )
+                IdentitiesScreen(
+                    viewModel = vm,
+                    onBack = { navController.popBackStack() },
+                )
             }
             composable(ROUTE_RELAYER_SETTINGS) {
                 val vm: RelayerSettingsViewModel = viewModel(
@@ -266,6 +280,7 @@ private enum class Tab(val route: String, val labelRes: Int) {
 }
 
 private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
+private const val ROUTE_IDENTITIES = "identities"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"

--- a/app/src/main/kotlin/chat/onym/android/UITestSupport.kt
+++ b/app/src/main/kotlin/chat/onym/android/UITestSupport.kt
@@ -4,6 +4,7 @@ import chat.onym.android.chain.AnchorSelectionStore
 import chat.onym.android.chain.ContractsManifestFetcher
 import chat.onym.android.chain.KnownRelayersFetcher
 import chat.onym.android.chain.RelayerSelectionStore
+import chat.onym.android.identity.IdentitySecretStore
 
 /**
  * Indirection point that lets instrumented UI tests inject in-memory
@@ -53,6 +54,14 @@ object UITestRegistry {
      *  [chat.onym.android.chain.GitHubReleasesContractsManifestFetcher]. */
     var contractsFetcher: ContractsManifestFetcher? = null
 
+    /** Per-test isolated [IdentitySecretStore]. When non-null,
+     *  [OnymApplication] uses it instead of the production
+     *  default-prefs-file store — so each instrumented test that
+     *  exercises identity flows can wipe + bootstrap into a fresh
+     *  EncryptedSharedPreferences file without colliding with
+     *  parallel runs. */
+    var identitySecretStore: IdentitySecretStore? = null
+
     /** Reset between tests. Called from `@Before`. */
     fun reset() {
         enabled = false
@@ -60,5 +69,6 @@ object UITestRegistry {
         relayerFetcher = null
         contractsStore = null
         contractsFetcher = null
+        identitySecretStore = null
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
@@ -1,0 +1,83 @@
+package chat.onym.android.identity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for Settings → Identities.
+ *
+ * Reads the multi-identity surface off [IdentityRepository] and
+ * exposes a flat [items] list the screen renders directly. Drives
+ * the three intents:
+ *
+ *  - [select] — flip the active identity.
+ *  - [add] — append a fresh BIP39-backed identity (V1 bootstrap
+ *    only; restore-from-mnemonic UI lives in the recovery flow and
+ *    isn't reachable from here).
+ *  - [remove] — gated by a typed-name confirm. The repository's
+ *    removal listener (registered by `GroupRepository`) cascades a
+ *    delete-by-owner over the identity's chats.
+ *
+ * Errors raised by the repository surface on [errorMessage]; UI
+ * shows them as a Snackbar / inline banner and clears via
+ * [clearError].
+ */
+class IdentitiesViewModel(
+    private val identity: IdentityRepository,
+) : ViewModel() {
+
+    /** Each row the screen renders: identity summary + whether it's
+     *  the currently-selected one. */
+    data class Row(val summary: IdentitySummary, val isActive: Boolean)
+
+    val items: StateFlow<List<Row>> = combine(
+        identity.identities,
+        identity.currentIdentityId,
+    ) { list, activeId ->
+        list.map { Row(summary = it, isActive = it.id == activeId) }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    fun select(id: IdentityId) {
+        viewModelScope.launch {
+            try {
+                identity.select(id)
+            } catch (e: Throwable) {
+                _errorMessage.value = "Couldn't switch identity: ${e.message ?: e.javaClass.simpleName}"
+            }
+        }
+    }
+
+    fun add(name: String = "") {
+        viewModelScope.launch {
+            try {
+                identity.add(name = name)
+            } catch (e: Throwable) {
+                _errorMessage.value = "Couldn't add identity: ${e.message ?: e.javaClass.simpleName}"
+            }
+        }
+    }
+
+    fun remove(id: IdentityId) {
+        viewModelScope.launch {
+            try {
+                identity.remove(id)
+            } catch (e: Throwable) {
+                _errorMessage.value = "Couldn't remove identity: ${e.message ?: e.javaClass.simpleName}"
+            }
+        }
+    }
+
+    fun clearError() {
+        _errorMessage.value = null
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
@@ -1,0 +1,253 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.identity.IdentitiesViewModel
+import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Identities. Lists every identity on the device, marks
+ * the active one, lets the user add a fresh identity ("Add" FAB) or
+ * remove an existing one (per-row trash → name-confirm dialog).
+ *
+ * Removing an identity cascades a delete of its local chats via
+ * `IdentityRepository.registerRemovalListener` (PR-3 wiring) — the
+ * confirm dialog spells that out.
+ */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+fun IdentitiesScreen(
+    viewModel: IdentitiesViewModel,
+    onBack: () -> Unit,
+) {
+    val items by viewModel.items.collectAsStateWithLifecycle()
+    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    var pendingRemoval by remember { mutableStateOf<IdentitiesViewModel.Row?>(null) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Identities") },
+                navigationIcon = {
+                    Box(
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .clickable(onClick = onBack)
+                            .testTag("identities.back"),
+                    ) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                text = { Text("Add identity") },
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                onClick = { viewModel.add() },
+                elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp),
+                modifier = Modifier.testTag("identities.add"),
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            items(items, key = { it.summary.id.value }) { row ->
+                IdentityRow(
+                    row = row,
+                    onTap = { if (!row.isActive) viewModel.select(row.summary.id) },
+                    onRemove = { pendingRemoval = row },
+                )
+            }
+        }
+    }
+
+    pendingRemoval?.let { row ->
+        RemoveIdentityDialog(
+            row = row,
+            onDismiss = { pendingRemoval = null },
+            onConfirm = {
+                viewModel.remove(row.summary.id)
+                pendingRemoval = null
+            },
+        )
+    }
+}
+
+@Composable
+private fun IdentityRow(
+    row: IdentitiesViewModel.Row,
+    onTap: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onTap)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("identities.row.${row.summary.id.value}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Active checkmark or empty slot.
+        Box(modifier = Modifier.size(24.dp), contentAlignment = Alignment.Center) {
+            if (row.isActive) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = "Active",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = row.summary.name.ifBlank { "Unnamed identity" },
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (row.isActive) FontWeight.SemiBold else FontWeight.Normal,
+            )
+            Text(
+                text = "BLS ${row.summary.blsPublicKey.toHexShort()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clickable(onClick = onRemove)
+                .testTag("identities.row.${row.summary.id.value}.remove"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.Delete,
+                contentDescription = "Remove",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RemoveIdentityDialog(
+    row: IdentitiesViewModel.Row,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val expectedName = row.summary.name.ifBlank { "Unnamed identity" }
+    var typed by remember { mutableStateOf("") }
+    val canConfirm = typed.trim() == expectedName
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Remove ${row.summary.name.ifBlank { "this identity" }}?") },
+        text = {
+            Column {
+                Text(
+                    "Removing this identity wipes its local chats and messages permanently. " +
+                        "Anchored groups stay on chain but you'll lose your local copy.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.size(12.dp))
+                Text(
+                    "Type \"$expectedName\" to confirm:",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.size(4.dp))
+                OutlinedTextField(
+                    value = typed,
+                    onValueChange = { typed = it },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("identities.remove.confirm.input"),
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = canConfirm,
+                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                ),
+                modifier = Modifier.testTag("identities.remove.confirm"),
+            ) {
+                Text("Remove")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+private fun ByteArray.toHexShort(): String {
+    if (isEmpty()) return ""
+    val sb = StringBuilder()
+    for (i in 0 until minOf(4, size)) sb.append("%02x".format(this[i].toInt() and 0xFF))
+    if (size > 4) sb.append("…")
+    return sb.toString()
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.Icon
@@ -63,6 +64,7 @@ fun SettingsScreen(
     onBackupClick: () -> Unit,
     onRelayerClick: () -> Unit,
     onAnchorsClick: () -> Unit,
+    onIdentitiesClick: () -> Unit,
     /** App-wide network preference. Bound to the Settings → Network
      *  → "Use Mainnet" Switch. */
     useMainnet: Boolean,
@@ -120,6 +122,35 @@ fun SettingsScreen(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                )
+            }
+
+            // Identities — multi-identity management (PR-5).
+            item { SectionHeader("Identities") }
+            item {
+                ListItem(
+                    headlineContent = { Text("Manage identities") },
+                    leadingContent = {
+                        SettingsIconBox(
+                            icon = Icons.Filled.Person,
+                            background = Color(0xFFAF52DE),
+                        )
+                    },
+                    trailingContent = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    },
+                    colors = ListItemDefaults.colors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(onClick = onIdentitiesClick)
+                        .testTag("settings.identities_row"),
                 )
             }
 

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -83,7 +83,10 @@ fun SettingsScreen(
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
-        LazyColumn(contentPadding = padding) {
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier.testTag("settings.list"),
+        ) {
             // Groups section moved to the Chats tab (PR-30) — Settings
             // now opens straight to the Security section.
             item {


### PR DESCRIPTION
## Summary

Top of the 5-PR multi-identity stack. Stacked on #56. After this lands, the user can add / select / remove identities from Settings; chats filter to the active identity automatically (PR-3).

User-facing:
- Settings → "Manage identities" row (testTag \`settings.identities_row\`)
- **Identities screen**: lists every identity with a ✓ on the active one. Tap to switch. Trash icon → name-confirm dialog → remove.
- "Add identity" FAB at the bottom: bootstraps a fresh BIP39 identity, auto-named "Identity N".

Wiring:
- \`IdentitiesViewModel\` (in identity/) — wraps \`identities\` + \`currentIdentityId\` into a flat \`items: StateFlow<List<Row>>\`. Three intents: \`select\`, \`add\`, \`remove\`. Errors surface on \`errorMessage\` → Snackbar.
- \`IdentitiesScreen\` Compose with FAB + dialog. Test tags on every interactive element.
- \`AppDependencies.makeIdentitiesViewModel\` factory.
- \`RootScreen\` \`ROUTE_IDENTITIES\` + Settings push.

Removal cascades through PR-3's \`GroupRepository\` listener — the identity's chats vanish from disk before its secrets do. Dialog spells that out before asking for the typed-name confirm.

## Acceptance

1. Settings → "Manage identities" → see 1 identity ✓ active
2. Tap "+ Add identity" → bootstraps "Identity 2", auto-selected
3. Tap first identity row → ✓ moves
4. Trash icon → confirm dialog → type name → Remove
5. Selected identity flips to whichever remains
6. Chats screen reflects the active identity's groups only

## Test plan

- [x] Compose compiles, \`assembleDebug\` clean
- [x] Existing unit tests still green
- [ ] VM tests deferred (keychain FFI dependency on IdentityRepository); thin delegate
- [ ] UI / acceptance test in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)