### PR TITLE
fix: drop Anarchy E2E `assertNull(active)` — relayer ships it

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupAnarchyE2ETest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupAnarchyE2ETest.kt
@@ -159,13 +159,17 @@ class CreateGroupAnarchyE2ETest {
         )
 
         // Round-trip the on-chain state. Anarchy's `CommitmentEntry`
-        // shape (per SepCommitmentEntry's per-governance table) varies
-        // — `commitment` + `epoch` are always present, the rest are
-        // optional. We assert only what the table guarantees.
+        // shape varies — `commitment` + `epoch` are always present;
+        // the rest are decoded if present. We assert only what's
+        // guaranteed across deploys. (Run #25277102111 surfaced that
+        // the testnet anarchy contract DOES ship `active=true`,
+        // contrary to the iOS-imported table that called it
+        // democracy/oligarchy-only — leaving it unasserted here so
+        // the test stays green if a future contract bump flips the
+        // shape.)
         val onChain = env.client.getCommitment(groupId = group.groupIdBytes)
         assertArrayEquals(group.commitment, onChain.commitment)
         assertEquals(0uL, onChain.epoch)
-        assertNull("Anarchy doesn't ship `active`", onChain.active)
     }
 
     /**


### PR DESCRIPTION
## Summary

Run [#25277102111](https://github.com/onymchat/onym-android/actions/runs/25277102111/job/74108605281) failed \`CreateGroupAnarchyE2ETest.create_zeroInvitees_anchorsOnTestnet\` with \`expected null, but was:<true>\` on the post-create read-back. 108/109 instrumented tests passed; only this single assertion was wrong.

## Root cause

The assertion was based on the per-governance table I imported from iOS's \`SEPCommitmentEntry\` docstring, which says \`active\` is democracy/oligarchy-only. The actual deployed v0.0.5 testnet anarchy contract DOES ship \`active=true\`. The table was outdated for anarchy specifically.

## Fix

Drop the assertion. \`active\` is informational, so hard-pinning either way risks breakage on a future contract bump. Keep \`commitment\` + \`epoch\` as the only universally-asserted fields (those are guaranteed across every governance type per the same table).

The sibling \`create_oneInvitee_sendsInvitation_andAnchors\` passed in the same run, confirming the actual chain leg works end-to-end.

## Test plan

- [x] \`:app:compileDebugAndroidTestKotlin\` clean
- [ ] CI: re-dispatch a Release; both Anarchy E2E cases should land green

🤖 Generated with [Claude Code](https://claude.com/claude-code)