### PR TITLE
group: IntroCapability — Level-2 deeplink invite payload (PR-1/7)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/IntroCapability.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroCapability.kt
@@ -1,0 +1,178 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.util.Base64
+
+/**
+ * The deeplink-shareable capability for the Level-2 sender-approval
+ * invite flow. Intentionally minimal — carries **no `groupSecret`**,
+ * **no member roster**. A bearer of this capability can only do one
+ * thing: send a "request to join" to the inviter's intro inbox.
+ * The actual `GroupInvitationPayload` (with `groupSecret` + members)
+ * is sealed by the inviter only after they tap Approve in their app.
+ *
+ * ## Wire shape
+ *
+ * Encoded as `Base64(JSON)` and ferried via either:
+ *
+ *  - `https://onym.chat/join?c=<base64>` — the App Link (autoVerify=true).
+ *    Universal channel; works from any messenger / browser.
+ *  - `onym://join?c=<base64>` — custom-scheme fallback when App Link
+ *    auto-verification fails (e.g., on devices that haven't fetched
+ *    the assetlinks.json yet).
+ *
+ * The query parameter is `c` (capability), kept short to keep the
+ * URL pasteable through SMS-character-counted channels.
+ *
+ * ## Per-invite ephemeral key
+ *
+ * [introPublicKey] is a **fresh X25519 pubkey minted per invite** —
+ * never the inviter's identity inbox key. The matching private key
+ * stays on the inviter's device (persisted in PR-2). This gives the
+ * inviter per-link revocation: stop listening on a given intro tag
+ * → that invite link goes silent. It also means link interception
+ * doesn't leak the inviter's long-term inbox key.
+ *
+ * ## What's safe to ship in [groupName]
+ *
+ * Optional, plaintext, **public**. The link transits cleartext
+ * channels (Telegram, SMS, etc.) — anyone observing the link can
+ * read this string. Useful for the joiner's "join this group?"
+ * preview before they tap Approve. Inviter chooses whether to
+ * include it; for groups with sensitive names, leave null and let
+ * the inviter convey context out-of-band ("hey, join my chat:
+ * <link>").
+ */
+@Serializable
+data class IntroCapability(
+    /** X25519 32-byte pubkey, freshly minted per invite. Encrypts
+     *  the joiner's request envelope; the inviter's app holds the
+     *  matching private key (PR-2 persistence). */
+    @SerialName("intro_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val introPublicKey: ByteArray,
+
+    /** 32-byte canonical bls12-381 Fr (BE). The on-chain `group_id`
+     *  the joiner is asking to join. Lets the joiner verify the
+     *  group exists on chain (`get_commitment`) before sending a
+     *  request — protects against a forged link pointing at a
+     *  non-existent group. */
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+
+    /** Optional display name. Public — see class doc. */
+    @SerialName("group_name")
+    val groupName: String? = null,
+) {
+    init {
+        require(introPublicKey.size == 32) {
+            "introPublicKey: expected 32 bytes, got ${introPublicKey.size}"
+        }
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    /** Encode to the base64-of-JSON payload that lands in the URL
+     *  query string. URL-safe Base64 (no `=` padding, no `+`/`/`)
+     *  so the result drops straight into a URL query without
+     *  percent-encoding. */
+    fun encode(): String {
+        val raw = jsonFormat.encodeToString(serializer(), this)
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(raw.toByteArray(Charsets.UTF_8))
+    }
+
+    /** Build the canonical App Link form. Drop into
+     *  [android.content.Intent.EXTRA_TEXT] for an
+     *  [android.content.Intent.ACTION_SEND] share intent. */
+    fun toAppLink(): String = "$APP_LINK_BASE${encode()}"
+
+    /** Build the custom-scheme fallback. Same payload, different
+     *  scheme — for testing in environments where the App Link
+     *  auto-verification hasn't completed yet. */
+    fun toCustomSchemeLink(): String = "$CUSTOM_SCHEME_BASE${encode()}"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IntroCapability) return false
+        return introPublicKey.contentEquals(other.introPublicKey) &&
+            groupId.contentEquals(other.groupId) &&
+            groupName == other.groupName
+    }
+
+    override fun hashCode(): Int {
+        var h = introPublicKey.contentHashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + (groupName?.hashCode() ?: 0)
+        return h
+    }
+
+    companion object {
+        const val APP_LINK_BASE = "https://onym.chat/join?c="
+        const val CUSTOM_SCHEME_BASE = "onym://join?c="
+
+        private val jsonFormat = Json {
+            encodeDefaults = false  // omit groupName=null from the wire
+            ignoreUnknownKeys = true
+        }
+
+        /** Inverse of [encode]. Throws [InvalidIntroCapability] on any
+         *  malformed input (bad base64, bad JSON, wrong key sizes). */
+        fun decode(payload: String): IntroCapability {
+            val raw = try {
+                Base64.getUrlDecoder().decode(payload)
+            } catch (e: IllegalArgumentException) {
+                throw InvalidIntroCapability("base64 decode failed: ${e.message}", e)
+            }
+            return try {
+                jsonFormat.decodeFromString(serializer(), raw.toString(Charsets.UTF_8))
+            } catch (e: SerializationException) {
+                throw InvalidIntroCapability("JSON decode failed: ${e.message}", e)
+            } catch (e: IllegalArgumentException) {
+                // size requires() on the constructor
+                throw InvalidIntroCapability(e.message ?: "shape check failed", e)
+            }
+        }
+
+        /** Pull the `c=…` query parameter out of any link form
+         *  ([APP_LINK_BASE] or [CUSTOM_SCHEME_BASE]) + decode it.
+         *  Returns null if the URL doesn't carry a capability —
+         *  caller decides whether that's an error. */
+        fun fromLink(link: String): IntroCapability? {
+            val uri = try { URI(link) } catch (_: Throwable) { return null }
+            val query = uri.rawQuery ?: return null
+            for (part in query.split('&')) {
+                val eq = part.indexOf('=')
+                if (eq < 0) continue
+                val key = part.substring(0, eq)
+                if (key != "c") continue
+                val value = part.substring(eq + 1)
+                return decode(value)
+            }
+            return null
+        }
+
+        /** Build a `mailto:`-style share-text payload bundling the
+         *  link with a human-readable nudge. Inviter pastes this
+         *  into their share-sheet target. */
+        fun shareText(link: String, groupName: String?): String =
+            if (groupName.isNullOrBlank()) {
+                "Join my chat on Onym: $link"
+            } else {
+                "Join \"$groupName\" on Onym: $link"
+            }
+    }
+}
+
+/** Decode-side failures from [IntroCapability.decode] /
+ *  [IntroCapability.fromLink]. Caller maps to user-facing copy. */
+class InvalidIntroCapability(message: String, cause: Throwable? = null) :
+    Exception(message, cause)

--- a/app/src/test/kotlin/chat/onym/android/group/IntroCapabilityTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/IntroCapabilityTest.kt
@@ -1,0 +1,175 @@
+package chat.onym.android.group
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wire-format pin for [IntroCapability]. The shape is the contract
+ * onym-ios will mirror — keep it stable.
+ */
+class IntroCapabilityTest {
+
+    private val sampleIntroPub = ByteArray(32) { 0xAA.toByte() }
+    private val sampleGroupId = ByteArray(32) { 0x42 }
+
+    @Test
+    fun roundtrip_minimalShape_preservesAllFields() {
+        val original = IntroCapability(
+            introPublicKey = sampleIntroPub,
+            groupId = sampleGroupId,
+            groupName = null,
+        )
+        val encoded = original.encode()
+        val decoded = IntroCapability.decode(encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun roundtrip_withGroupName_preservesAllFields() {
+        val original = IntroCapability(
+            introPublicKey = sampleIntroPub,
+            groupId = sampleGroupId,
+            groupName = "Family",
+        )
+        val encoded = original.encode()
+        val decoded = IntroCapability.decode(encoded)
+        assertEquals(original, decoded)
+        assertEquals("Family", decoded.groupName)
+    }
+
+    @Test
+    fun encode_isUrlSafeBase64_noPaddingOrSpecialChars() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "test")
+        val encoded = cap.encode()
+        // URL-safe base64 swaps `+`/`/` for `-`/`_` and drops `=` padding;
+        // the result drops into a query string without percent-encoding.
+        assertFalse("no `+` in URL-safe encoding", encoded.contains('+'))
+        assertFalse("no `/` in URL-safe encoding", encoded.contains('/'))
+        assertFalse("no `=` padding", encoded.contains('='))
+        assertFalse("no whitespace", encoded.any { it.isWhitespace() })
+    }
+
+    @Test
+    fun toAppLink_isOnymChatJoinPath() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val link = cap.toAppLink()
+        assertTrue("expected onym.chat host", link.startsWith("https://onym.chat/join?c="))
+    }
+
+    @Test
+    fun toCustomSchemeLink_isOnymJoinScheme() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val link = cap.toCustomSchemeLink()
+        assertTrue("expected onym:// scheme", link.startsWith("onym://join?c="))
+    }
+
+    @Test
+    fun fromLink_appLinkForm_decodesBackToOriginal() {
+        val original = IntroCapability(sampleIntroPub, sampleGroupId, "Crew")
+        val parsed = IntroCapability.fromLink(original.toAppLink())
+        assertNotNull(parsed)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromLink_customSchemeForm_decodesBackToOriginal() {
+        val original = IntroCapability(sampleIntroPub, sampleGroupId, "Crew")
+        val parsed = IntroCapability.fromLink(original.toCustomSchemeLink())
+        assertNotNull(parsed)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromLink_extraQueryParams_returnsCapability_ignoringExtras() {
+        // Future schemas may grow tracking params (utm_*, etc.) — the
+        // parser must pluck `c=` and ignore the rest.
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "X")
+        val link = "${cap.toAppLink()}&utm_source=share-sheet&ref=foo"
+        val parsed = IntroCapability.fromLink(link)
+        assertNotNull(parsed)
+        assertEquals(cap, parsed)
+    }
+
+    @Test
+    fun fromLink_missingCapabilityParam_returnsNull() {
+        assertNull(IntroCapability.fromLink("https://onym.chat/join"))
+        assertNull(IntroCapability.fromLink("https://onym.chat/join?other=value"))
+    }
+
+    @Test
+    fun fromLink_malformedUri_returnsNull() {
+        assertNull(IntroCapability.fromLink("not a url"))
+        assertNull(IntroCapability.fromLink(""))
+    }
+
+    @Test
+    fun decode_invalidBase64_throwsInvalidIntroCapability() {
+        val thrown = assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode("@@@not-base64@@@")
+        }
+        assertNotNull(thrown.message)
+    }
+
+    @Test
+    fun decode_validBase64_butNotJson_throwsInvalidIntroCapability() {
+        val notJson = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("not json at all".toByteArray())
+        assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode(notJson)
+        }
+    }
+
+    @Test
+    fun decode_validJson_butWrongPubkeySize_throwsInvalidIntroCapability() {
+        val badShape = """{"intro_pub":"AAA=","group_id":"AAA="}"""
+        val encoded = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(badShape.toByteArray())
+        assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode(encoded)
+        }
+    }
+
+    @Test
+    fun constructor_rejectsWrongSizedKeys() {
+        assertThrows(IllegalArgumentException::class.java) {
+            IntroCapability(introPublicKey = ByteArray(31), groupId = sampleGroupId)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            IntroCapability(introPublicKey = sampleIntroPub, groupId = ByteArray(33))
+        }
+    }
+
+    @Test
+    fun shareText_includesGroupName_whenSet() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "Friends")
+        val text = IntroCapability.shareText(cap.toAppLink(), cap.groupName)
+        assertTrue(text.contains("\"Friends\""))
+        assertTrue(text.contains("https://onym.chat/join?c="))
+    }
+
+    @Test
+    fun shareText_omitsGroupName_whenBlankOrNull() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val text = IntroCapability.shareText(cap.toAppLink(), cap.groupName)
+        assertFalse(text.contains("\""))  // no quoted name
+        assertTrue(text.contains("Join my chat"))
+    }
+
+    @Test
+    fun roundtrip_byteForByteIntroPub_isPreserved() {
+        // Random-ish bytes — make sure base64+JSON+base64 doesn't
+        // mutate any byte position.
+        val pub = ByteArray(32) { (it * 7 + 13).toByte() }
+        val gid = ByteArray(32) { (it * 11 + 3).toByte() }
+        val cap = IntroCapability(pub, gid, "X")
+        val decoded = IntroCapability.decode(cap.encode())
+        assertArrayEquals(pub, decoded.introPublicKey)
+        assertArrayEquals(gid, decoded.groupId)
+    }
+}


### PR DESCRIPTION
## Summary

PR-1 of the Level-2 sender-approval-required deeplink invite flow. Lays the wire format only; subsequent PRs wire the per-invite keypair, request/approval round-trip, and UI.

## Wire format

\`\`\`kotlin
data class IntroCapability(
    val introPublicKey: ByteArray,  // X25519 32B, ephemeral per invite
    val groupId: ByteArray,          // 32B canonical bls12-381 Fr
    val groupName: String? = null,   // optional plaintext, public
)
\`\`\`

**Crucially: no \`groupSecret\`, no member roster.** Bearers of this capability can only do one thing — send a "request to join" to the inviter's intro inbox. The actual sealed \`GroupInvitationPayload\` ships only after the inviter taps Approve.

## Link shapes

- App Link: \`https://onym.chat/join?c=<url-safe-base64>\` — \`assetlinks.json\` + AASA already served at onym.chat (verified earlier this session).
- Custom scheme: \`onym://join?c=<url-safe-base64>\` — fallback.

## Test plan

- [x] 15 unit tests: round-trip with/without name, URL-safe base64 invariants, both link forms, extra query params, missing/malformed input, wrong-sized keys.
- [x] All other tests still green.

## Stack (planned, 7 PRs total)

PR-1 (this) → IntroCapability wire format
PR-2 → identity/intro-keypair persistence (per-invite X25519 minting)
PR-3 → transport/intro-inbox subscription (sender listens on intro_pub tag)
PR-4 → group/join-request flow (joiner sends request → sender approves)
PR-5 → ux/share-invite-link (post-create ShareInviteScreen)
PR-6 → transport/deeplink-intent-filter (manifest + MainActivity routing)
PR-7 → ux/joinscreen-completion (joiner waits for approval; auto-flips on receipt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)