### PR TITLE
identity: per-invite intro keypair persistence + minting (PR-2/7)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
@@ -1,0 +1,149 @@
+package chat.onym.android.group
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import chat.onym.android.identity.Base64ByteArraySerializer
+import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Production [IntroKeyStore] backed by EncryptedSharedPreferences.
+ * Whole-blob persistence — every mutation rewrites a single
+ * preference key. Intro privkeys are tiny (32B each) and the
+ * realistic count is dozens, not thousands, so the rewrite cost
+ * is negligible and we get atomicity for free.
+ *
+ * The master key is the same `AES256_GCM` Android Keystore key
+ * `IdentitySecretStore` uses. Backup-extraction yields ciphertext
+ * the restoring device can't decrypt — see the backup_rules /
+ * data_extraction_rules XML.
+ */
+class EncryptedPrefsIntroKeyStore(
+    private val context: Context,
+    private val prefsFileName: String = DEFAULT_PREFS_FILE_NAME,
+) : IntroKeyStore {
+
+    private val mutex = Mutex()
+
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            prefsFileName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override suspend fun save(entry: IntroKeyEntry) = mutex.withLock {
+        val current = loadAllUnlocked().toMutableList()
+        val existingIdx = current.indexOfFirst {
+            it.introPub.contentEquals(entry.introPublicKey)
+        }
+        val stored = StoredIntroKey(
+            introPub = entry.introPublicKey,
+            introPriv = entry.introPrivateKey,
+            ownerIdentityId = entry.ownerIdentityId.value,
+            groupId = entry.groupId,
+            createdAtMillis = entry.createdAtMillis,
+        )
+        if (existingIdx >= 0) current[existingIdx] = stored
+        else current += stored
+        saveAllUnlocked(current)
+    }
+
+    override suspend fun find(introPublicKey: ByteArray): IntroKeyEntry? = mutex.withLock {
+        loadAllUnlocked()
+            .firstOrNull { it.introPub.contentEquals(introPublicKey) }
+            ?.toEntry()
+    }
+
+    override suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry> = mutex.withLock {
+        loadAllUnlocked()
+            .filter { it.ownerIdentityId == ownerIdentityId.value }
+            .sortedByDescending { it.createdAtMillis }
+            .map { it.toEntry() }
+    }
+
+    override suspend fun revoke(introPublicKey: ByteArray) = mutex.withLock {
+        val current = loadAllUnlocked()
+        val filtered = current.filterNot { it.introPub.contentEquals(introPublicKey) }
+        if (filtered.size != current.size) saveAllUnlocked(filtered)
+    }
+
+    override suspend fun deleteForOwner(ownerIdentityId: IdentityId): Int = mutex.withLock {
+        val current = loadAllUnlocked()
+        val filtered = current.filterNot { it.ownerIdentityId == ownerIdentityId.value }
+        val removed = current.size - filtered.size
+        if (removed > 0) saveAllUnlocked(filtered)
+        removed
+    }
+
+    // ─── private ──────────────────────────────────────────────────
+
+    private fun loadAllUnlocked(): List<StoredIntroKey> {
+        val raw = prefs.getString(KEY_BLOB, null) ?: return emptyList()
+        return try {
+            json.decodeFromString(StoredIntroKeysBlob.serializer(), raw).entries
+        } catch (_: SerializationException) {
+            // Corrupted blob → discard rather than crash. Acceptable
+            // because this store holds ephemeral per-invite keys; if
+            // we lose them, the worst that happens is in-flight
+            // invites fail to deliver and the inviter re-shares.
+            emptyList()
+        }
+    }
+
+    private fun saveAllUnlocked(entries: List<StoredIntroKey>) {
+        val raw = json.encodeToString(
+            StoredIntroKeysBlob.serializer(),
+            StoredIntroKeysBlob(entries),
+        )
+        // Use commit() rather than apply() — the call sites are
+        // already inside `withContext(ioDispatcher)` (well, will be
+        // once IntroIntroducer wraps them) and we want
+        // write-confirmation before returning.
+        prefs.edit().putString(KEY_BLOB, raw).commit()
+    }
+
+    private fun StoredIntroKey.toEntry(): IntroKeyEntry = IntroKeyEntry(
+        introPublicKey = introPub,
+        introPrivateKey = introPriv,
+        ownerIdentityId = IdentityId(ownerIdentityId),
+        groupId = groupId,
+        createdAtMillis = createdAtMillis,
+    )
+
+    companion object {
+        const val DEFAULT_PREFS_FILE_NAME = "chat.onym.android.intro_keys"
+        private const val KEY_BLOB = "blob"
+    }
+}
+
+/** On-disk envelope. Wraps the list so future fields (sort order,
+ *  schema version, etc.) can be added without re-shaping the JSON. */
+@Serializable
+internal data class StoredIntroKeysBlob(val entries: List<StoredIntroKey>)
+
+@Serializable
+internal data class StoredIntroKey(
+    @Serializable(with = Base64ByteArraySerializer::class) val introPub: ByteArray,
+    @Serializable(with = Base64ByteArraySerializer::class) val introPriv: ByteArray,
+    val ownerIdentityId: String,
+    @Serializable(with = Base64ByteArraySerializer::class) val groupId: ByteArray,
+    val createdAtMillis: Long,
+)

--- a/app/src/main/kotlin/chat/onym/android/group/IntroCapability.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroCapability.kt
@@ -1,0 +1,178 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.util.Base64
+
+/**
+ * The deeplink-shareable capability for the Level-2 sender-approval
+ * invite flow. Intentionally minimal — carries **no `groupSecret`**,
+ * **no member roster**. A bearer of this capability can only do one
+ * thing: send a "request to join" to the inviter's intro inbox.
+ * The actual `GroupInvitationPayload` (with `groupSecret` + members)
+ * is sealed by the inviter only after they tap Approve in their app.
+ *
+ * ## Wire shape
+ *
+ * Encoded as `Base64(JSON)` and ferried via either:
+ *
+ *  - `https://onym.chat/join?c=<base64>` — the App Link (autoVerify=true).
+ *    Universal channel; works from any messenger / browser.
+ *  - `onym://join?c=<base64>` — custom-scheme fallback when App Link
+ *    auto-verification fails (e.g., on devices that haven't fetched
+ *    the assetlinks.json yet).
+ *
+ * The query parameter is `c` (capability), kept short to keep the
+ * URL pasteable through SMS-character-counted channels.
+ *
+ * ## Per-invite ephemeral key
+ *
+ * [introPublicKey] is a **fresh X25519 pubkey minted per invite** —
+ * never the inviter's identity inbox key. The matching private key
+ * stays on the inviter's device (persisted in PR-2). This gives the
+ * inviter per-link revocation: stop listening on a given intro tag
+ * → that invite link goes silent. It also means link interception
+ * doesn't leak the inviter's long-term inbox key.
+ *
+ * ## What's safe to ship in [groupName]
+ *
+ * Optional, plaintext, **public**. The link transits cleartext
+ * channels (Telegram, SMS, etc.) — anyone observing the link can
+ * read this string. Useful for the joiner's "join this group?"
+ * preview before they tap Approve. Inviter chooses whether to
+ * include it; for groups with sensitive names, leave null and let
+ * the inviter convey context out-of-band ("hey, join my chat:
+ * <link>").
+ */
+@Serializable
+data class IntroCapability(
+    /** X25519 32-byte pubkey, freshly minted per invite. Encrypts
+     *  the joiner's request envelope; the inviter's app holds the
+     *  matching private key (PR-2 persistence). */
+    @SerialName("intro_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val introPublicKey: ByteArray,
+
+    /** 32-byte canonical bls12-381 Fr (BE). The on-chain `group_id`
+     *  the joiner is asking to join. Lets the joiner verify the
+     *  group exists on chain (`get_commitment`) before sending a
+     *  request — protects against a forged link pointing at a
+     *  non-existent group. */
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+
+    /** Optional display name. Public — see class doc. */
+    @SerialName("group_name")
+    val groupName: String? = null,
+) {
+    init {
+        require(introPublicKey.size == 32) {
+            "introPublicKey: expected 32 bytes, got ${introPublicKey.size}"
+        }
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    /** Encode to the base64-of-JSON payload that lands in the URL
+     *  query string. URL-safe Base64 (no `=` padding, no `+`/`/`)
+     *  so the result drops straight into a URL query without
+     *  percent-encoding. */
+    fun encode(): String {
+        val raw = jsonFormat.encodeToString(serializer(), this)
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(raw.toByteArray(Charsets.UTF_8))
+    }
+
+    /** Build the canonical App Link form. Drop into
+     *  [android.content.Intent.EXTRA_TEXT] for an
+     *  [android.content.Intent.ACTION_SEND] share intent. */
+    fun toAppLink(): String = "$APP_LINK_BASE${encode()}"
+
+    /** Build the custom-scheme fallback. Same payload, different
+     *  scheme — for testing in environments where the App Link
+     *  auto-verification hasn't completed yet. */
+    fun toCustomSchemeLink(): String = "$CUSTOM_SCHEME_BASE${encode()}"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IntroCapability) return false
+        return introPublicKey.contentEquals(other.introPublicKey) &&
+            groupId.contentEquals(other.groupId) &&
+            groupName == other.groupName
+    }
+
+    override fun hashCode(): Int {
+        var h = introPublicKey.contentHashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + (groupName?.hashCode() ?: 0)
+        return h
+    }
+
+    companion object {
+        const val APP_LINK_BASE = "https://onym.chat/join?c="
+        const val CUSTOM_SCHEME_BASE = "onym://join?c="
+
+        private val jsonFormat = Json {
+            encodeDefaults = false  // omit groupName=null from the wire
+            ignoreUnknownKeys = true
+        }
+
+        /** Inverse of [encode]. Throws [InvalidIntroCapability] on any
+         *  malformed input (bad base64, bad JSON, wrong key sizes). */
+        fun decode(payload: String): IntroCapability {
+            val raw = try {
+                Base64.getUrlDecoder().decode(payload)
+            } catch (e: IllegalArgumentException) {
+                throw InvalidIntroCapability("base64 decode failed: ${e.message}", e)
+            }
+            return try {
+                jsonFormat.decodeFromString(serializer(), raw.toString(Charsets.UTF_8))
+            } catch (e: SerializationException) {
+                throw InvalidIntroCapability("JSON decode failed: ${e.message}", e)
+            } catch (e: IllegalArgumentException) {
+                // size requires() on the constructor
+                throw InvalidIntroCapability(e.message ?: "shape check failed", e)
+            }
+        }
+
+        /** Pull the `c=…` query parameter out of any link form
+         *  ([APP_LINK_BASE] or [CUSTOM_SCHEME_BASE]) + decode it.
+         *  Returns null if the URL doesn't carry a capability —
+         *  caller decides whether that's an error. */
+        fun fromLink(link: String): IntroCapability? {
+            val uri = try { URI(link) } catch (_: Throwable) { return null }
+            val query = uri.rawQuery ?: return null
+            for (part in query.split('&')) {
+                val eq = part.indexOf('=')
+                if (eq < 0) continue
+                val key = part.substring(0, eq)
+                if (key != "c") continue
+                val value = part.substring(eq + 1)
+                return decode(value)
+            }
+            return null
+        }
+
+        /** Build a `mailto:`-style share-text payload bundling the
+         *  link with a human-readable nudge. Inviter pastes this
+         *  into their share-sheet target. */
+        fun shareText(link: String, groupName: String?): String =
+            if (groupName.isNullOrBlank()) {
+                "Join my chat on Onym: $link"
+            } else {
+                "Join \"$groupName\" on Onym: $link"
+            }
+    }
+}
+
+/** Decode-side failures from [IntroCapability.decode] /
+ *  [IntroCapability.fromLink]. Caller maps to user-facing copy. */
+class InvalidIntroCapability(message: String, cause: Throwable? = null) :
+    Exception(message, cause)

--- a/app/src/main/kotlin/chat/onym/android/group/IntroKeyEntry.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroKeyEntry.kt
@@ -1,0 +1,62 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+
+/**
+ * One per-invite ephemeral keypair persisted on the inviter's
+ * device. Maps an invite link's [introPublicKey] (the public half
+ * shipped in the [IntroCapability] inside the link) to its private
+ * counterpart + the metadata needed to dispatch a sealed
+ * [GroupInvitationPayload] when an approved request comes in.
+ *
+ * - [introPrivateKey] is X25519 secret material — used to decrypt
+ *   the joiner's request envelope. Never logged. Per-invite, so
+ *   leaking one doesn't compromise unrelated invites.
+ * - [ownerIdentityId] scopes the entry to the identity that minted
+ *   the link. The cascade-delete on identity removal (PR-3 of the
+ *   multi-identity stack) wipes every entry whose owner gets
+ *   removed.
+ * - [groupId] is the on-chain `group_id` the invite is for —
+ *   needed when the inviter's app surfaces "Bob wants to join
+ *   <group>?" so it can render the group's name.
+ * - [createdAtMillis] drives optional expiration UI (PR-7+ may
+ *   prune invites older than N days).
+ */
+data class IntroKeyEntry(
+    val introPublicKey: ByteArray,
+    val introPrivateKey: ByteArray,
+    val ownerIdentityId: IdentityId,
+    val groupId: ByteArray,
+    val createdAtMillis: Long,
+) {
+    init {
+        require(introPublicKey.size == 32) {
+            "introPublicKey: expected 32 bytes, got ${introPublicKey.size}"
+        }
+        require(introPrivateKey.size == 32) {
+            "introPrivateKey: expected 32 bytes, got ${introPrivateKey.size}"
+        }
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IntroKeyEntry) return false
+        return introPublicKey.contentEquals(other.introPublicKey) &&
+            introPrivateKey.contentEquals(other.introPrivateKey) &&
+            ownerIdentityId == other.ownerIdentityId &&
+            groupId.contentEquals(other.groupId) &&
+            createdAtMillis == other.createdAtMillis
+    }
+
+    override fun hashCode(): Int {
+        var h = introPublicKey.contentHashCode()
+        h = 31 * h + introPrivateKey.contentHashCode()
+        h = 31 * h + ownerIdentityId.hashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + createdAtMillis.hashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
@@ -1,0 +1,54 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+
+/**
+ * Persistence seam for per-invite ephemeral X25519 keypairs.
+ *
+ * Lifecycle of one entry:
+ *
+ *  1. Sender taps "Share invite" → app mints a fresh X25519 keypair
+ *     via [InviteIntroducer.mint], persists via [save].
+ *  2. Joiner taps the deeplink → app sends a request envelope
+ *     encrypted to [IntroKeyEntry.introPublicKey] over Nostr.
+ *  3. Sender's intro-inbox fan-out (PR-3) receives → calls [find]
+ *     with the targeted introPublicKey → uses
+ *     [IntroKeyEntry.introPrivateKey] to decrypt the request
+ *     payload.
+ *  4. On Approve, sender seals the existing
+ *     [GroupInvitationPayload] to the joiner's identity inbox key.
+ *     [revoke] is called to retire the intro slot.
+ *
+ * Owner-scoping: every entry carries an [IdentityId]. Removing an
+ * identity (multi-identity PR-3) cascades a [deleteForOwner] so
+ * we don't leak intro privkeys past the identity that minted them.
+ */
+interface IntroKeyStore {
+    /** Persist a freshly-minted intro entry. Idempotent on
+     *  [IntroKeyEntry.introPublicKey] — re-mint with the same pub
+     *  is a no-op (shouldn't happen in practice; X25519 keypairs
+     *  are uniformly random). */
+    suspend fun save(entry: IntroKeyEntry)
+
+    /** Look up an entry by its public key. Returns null when the
+     *  pubkey is unknown — happens when an old entry was
+     *  [revoke]d, or when a request envelope targets a pubkey
+     *  this device never minted (probably a forged link). */
+    suspend fun find(introPublicKey: ByteArray): IntroKeyEntry?
+
+    /** Every entry minted by [ownerIdentityId]. Sorted newest
+     *  first by [IntroKeyEntry.createdAtMillis]. UI's "Active
+     *  invites" list reads here. */
+    suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry>
+
+    /** Single-entry deletion. Called after a request is accepted
+     *  + sealed → the intro slot is no longer useful. No-op if
+     *  the pubkey isn't present. */
+    suspend fun revoke(introPublicKey: ByteArray)
+
+    /** Cascade for the identity-removal flow. Returns the count
+     *  of entries deleted so the caller can log the cleanup
+     *  size. Hooked into [chat.onym.android.identity.IdentityRepository.registerRemovalListener]
+     *  via the wiring layer. */
+    suspend fun deleteForOwner(ownerIdentityId: IdentityId): Int
+}

--- a/app/src/main/kotlin/chat/onym/android/group/InviteIntroducer.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/InviteIntroducer.kt
@@ -1,0 +1,78 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bouncycastle.crypto.params.X25519PrivateKeyParameters
+import java.security.SecureRandom
+
+/**
+ * Mints fresh per-invite X25519 keypairs and persists them via
+ * [IntroKeyStore]. Returns an [IntroCapability] (the public-facing
+ * deeplink payload) — the caller drops it into a deeplink URL and
+ * shares.
+ *
+ * **Threading**: keypair generation + storage I/O run on
+ * [ioDispatcher] (`Dispatchers.IO` by default). Cheap enough for
+ * the foreground click handler to await directly — X25519 keygen
+ * is microseconds; the EncryptedSharedPreferences `commit()` is
+ * the dominant cost.
+ *
+ * **Why one keypair per invite instead of one per identity**: per-
+ * link revocation. The inviter can stop listening on a specific
+ * intro tag → that link goes silent without affecting other
+ * outstanding invites. A leaked link only burns its own slot.
+ */
+class InviteIntroducer(
+    private val store: IntroKeyStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val random: SecureRandom = SecureRandom(),
+    private val clock: () -> Long = { System.currentTimeMillis() },
+) {
+
+    /**
+     * Mint a fresh intro keypair, persist it, and return the
+     * [IntroCapability] the caller will pack into a deeplink URL.
+     *
+     * @param ownerIdentityId — the identity that's inviting. Used
+     *        for cascade-delete when the identity is removed.
+     * @param groupId — the on-chain `group_id` the invite is for.
+     * @param groupName — optional plaintext name surfaced in the
+     *        deeplink for the joiner's preview. Pass `null` for
+     *        groups whose name is sensitive (deeplink transits
+     *        cleartext channels).
+     */
+    suspend fun mint(
+        ownerIdentityId: IdentityId,
+        groupId: ByteArray,
+        groupName: String? = null,
+    ): IntroCapability = withContext(ioDispatcher) {
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+
+        // BC's X25519PrivateKeyParameters constructor seeded from
+        // SecureRandom does the standard scalar clamping internally.
+        // generatePublicKey() runs the Curve25519 base-point mul.
+        val privateKey = X25519PrivateKeyParameters(random)
+        val publicKey = privateKey.generatePublicKey().encoded
+        val privateKeyBytes = privateKey.encoded
+
+        store.save(
+            IntroKeyEntry(
+                introPublicKey = publicKey,
+                introPrivateKey = privateKeyBytes,
+                ownerIdentityId = ownerIdentityId,
+                groupId = groupId,
+                createdAtMillis = clock(),
+            )
+        )
+
+        IntroCapability(
+            introPublicKey = publicKey,
+            groupId = groupId,
+            groupName = groupName,
+        )
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
@@ -1,0 +1,47 @@
+package chat.onym.android.support
+
+import chat.onym.android.group.IntroKeyEntry
+import chat.onym.android.group.IntroKeyStore
+import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Reusable in-memory [IntroKeyStore]. Same contract as
+ * [chat.onym.android.group.EncryptedPrefsIntroKeyStore] without the
+ * EncryptedSharedPreferences plumbing — fast tests of
+ * `InviteIntroducer` / future request-flow interactors that don't
+ * want to stand up the Keystore.
+ */
+class InMemoryIntroKeyStore : IntroKeyStore {
+
+    private val mutex = Mutex()
+    private val entries = mutableListOf<IntroKeyEntry>()
+
+    override suspend fun save(entry: IntroKeyEntry) = mutex.withLock {
+        entries.removeAll { it.introPublicKey.contentEquals(entry.introPublicKey) }
+        entries += entry
+    }
+
+    override suspend fun find(introPublicKey: ByteArray): IntroKeyEntry? = mutex.withLock {
+        entries.firstOrNull { it.introPublicKey.contentEquals(introPublicKey) }
+    }
+
+    override suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry> = mutex.withLock {
+        entries
+            .filter { it.ownerIdentityId == ownerIdentityId }
+            .sortedByDescending { it.createdAtMillis }
+    }
+
+    override suspend fun revoke(introPublicKey: ByteArray) {
+        mutex.withLock {
+            entries.removeAll { it.introPublicKey.contentEquals(introPublicKey) }
+        }
+    }
+
+    override suspend fun deleteForOwner(ownerIdentityId: IdentityId): Int = mutex.withLock {
+        val before = entries.size
+        entries.removeAll { it.ownerIdentityId == ownerIdentityId }
+        before - entries.size
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/IntroCapabilityTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/IntroCapabilityTest.kt
@@ -1,0 +1,175 @@
+package chat.onym.android.group
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wire-format pin for [IntroCapability]. The shape is the contract
+ * onym-ios will mirror — keep it stable.
+ */
+class IntroCapabilityTest {
+
+    private val sampleIntroPub = ByteArray(32) { 0xAA.toByte() }
+    private val sampleGroupId = ByteArray(32) { 0x42 }
+
+    @Test
+    fun roundtrip_minimalShape_preservesAllFields() {
+        val original = IntroCapability(
+            introPublicKey = sampleIntroPub,
+            groupId = sampleGroupId,
+            groupName = null,
+        )
+        val encoded = original.encode()
+        val decoded = IntroCapability.decode(encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun roundtrip_withGroupName_preservesAllFields() {
+        val original = IntroCapability(
+            introPublicKey = sampleIntroPub,
+            groupId = sampleGroupId,
+            groupName = "Family",
+        )
+        val encoded = original.encode()
+        val decoded = IntroCapability.decode(encoded)
+        assertEquals(original, decoded)
+        assertEquals("Family", decoded.groupName)
+    }
+
+    @Test
+    fun encode_isUrlSafeBase64_noPaddingOrSpecialChars() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "test")
+        val encoded = cap.encode()
+        // URL-safe base64 swaps `+`/`/` for `-`/`_` and drops `=` padding;
+        // the result drops into a query string without percent-encoding.
+        assertFalse("no `+` in URL-safe encoding", encoded.contains('+'))
+        assertFalse("no `/` in URL-safe encoding", encoded.contains('/'))
+        assertFalse("no `=` padding", encoded.contains('='))
+        assertFalse("no whitespace", encoded.any { it.isWhitespace() })
+    }
+
+    @Test
+    fun toAppLink_isOnymChatJoinPath() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val link = cap.toAppLink()
+        assertTrue("expected onym.chat host", link.startsWith("https://onym.chat/join?c="))
+    }
+
+    @Test
+    fun toCustomSchemeLink_isOnymJoinScheme() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val link = cap.toCustomSchemeLink()
+        assertTrue("expected onym:// scheme", link.startsWith("onym://join?c="))
+    }
+
+    @Test
+    fun fromLink_appLinkForm_decodesBackToOriginal() {
+        val original = IntroCapability(sampleIntroPub, sampleGroupId, "Crew")
+        val parsed = IntroCapability.fromLink(original.toAppLink())
+        assertNotNull(parsed)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromLink_customSchemeForm_decodesBackToOriginal() {
+        val original = IntroCapability(sampleIntroPub, sampleGroupId, "Crew")
+        val parsed = IntroCapability.fromLink(original.toCustomSchemeLink())
+        assertNotNull(parsed)
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun fromLink_extraQueryParams_returnsCapability_ignoringExtras() {
+        // Future schemas may grow tracking params (utm_*, etc.) — the
+        // parser must pluck `c=` and ignore the rest.
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "X")
+        val link = "${cap.toAppLink()}&utm_source=share-sheet&ref=foo"
+        val parsed = IntroCapability.fromLink(link)
+        assertNotNull(parsed)
+        assertEquals(cap, parsed)
+    }
+
+    @Test
+    fun fromLink_missingCapabilityParam_returnsNull() {
+        assertNull(IntroCapability.fromLink("https://onym.chat/join"))
+        assertNull(IntroCapability.fromLink("https://onym.chat/join?other=value"))
+    }
+
+    @Test
+    fun fromLink_malformedUri_returnsNull() {
+        assertNull(IntroCapability.fromLink("not a url"))
+        assertNull(IntroCapability.fromLink(""))
+    }
+
+    @Test
+    fun decode_invalidBase64_throwsInvalidIntroCapability() {
+        val thrown = assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode("@@@not-base64@@@")
+        }
+        assertNotNull(thrown.message)
+    }
+
+    @Test
+    fun decode_validBase64_butNotJson_throwsInvalidIntroCapability() {
+        val notJson = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("not json at all".toByteArray())
+        assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode(notJson)
+        }
+    }
+
+    @Test
+    fun decode_validJson_butWrongPubkeySize_throwsInvalidIntroCapability() {
+        val badShape = """{"intro_pub":"AAA=","group_id":"AAA="}"""
+        val encoded = java.util.Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(badShape.toByteArray())
+        assertThrows(InvalidIntroCapability::class.java) {
+            IntroCapability.decode(encoded)
+        }
+    }
+
+    @Test
+    fun constructor_rejectsWrongSizedKeys() {
+        assertThrows(IllegalArgumentException::class.java) {
+            IntroCapability(introPublicKey = ByteArray(31), groupId = sampleGroupId)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            IntroCapability(introPublicKey = sampleIntroPub, groupId = ByteArray(33))
+        }
+    }
+
+    @Test
+    fun shareText_includesGroupName_whenSet() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId, "Friends")
+        val text = IntroCapability.shareText(cap.toAppLink(), cap.groupName)
+        assertTrue(text.contains("\"Friends\""))
+        assertTrue(text.contains("https://onym.chat/join?c="))
+    }
+
+    @Test
+    fun shareText_omitsGroupName_whenBlankOrNull() {
+        val cap = IntroCapability(sampleIntroPub, sampleGroupId)
+        val text = IntroCapability.shareText(cap.toAppLink(), cap.groupName)
+        assertFalse(text.contains("\""))  // no quoted name
+        assertTrue(text.contains("Join my chat"))
+    }
+
+    @Test
+    fun roundtrip_byteForByteIntroPub_isPreserved() {
+        // Random-ish bytes — make sure base64+JSON+base64 doesn't
+        // mutate any byte position.
+        val pub = ByteArray(32) { (it * 7 + 13).toByte() }
+        val gid = ByteArray(32) { (it * 11 + 3).toByte() }
+        val cap = IntroCapability(pub, gid, "X")
+        val decoded = IntroCapability.decode(cap.encode())
+        assertArrayEquals(pub, decoded.introPublicKey)
+        assertArrayEquals(gid, decoded.groupId)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/InviteIntroducerTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/InviteIntroducerTest.kt
@@ -1,0 +1,163 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.support.InMemoryIntroKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import java.security.SecureRandom
+import java.security.Security
+
+/**
+ * Unit tests for [InviteIntroducer] + [IntroKeyStore] contract.
+ * Backed by [InMemoryIntroKeyStore] — the EncryptedSharedPreferences-
+ * backed prod impl gets exercised in androidTest where the Android
+ * Keystore is available.
+ */
+class InviteIntroducerTest {
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpBouncyCastle() {
+            // BC carries Curve25519; the JDK's built-in providers don't
+            // have it on every supported version, so we install BC for
+            // the keypair-mint path.
+            if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                Security.insertProviderAt(BouncyCastleProvider(), 2)
+            }
+        }
+    }
+
+    private val alice = IdentityId("alice-uuid")
+    private val bob = IdentityId("bob-uuid")
+    private val sampleGroupId = ByteArray(32) { 0x42 }
+
+    @Test
+    fun mint_producesDistinctKeypairs_acrossInvocations() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        val cap1 = introducer.mint(alice, sampleGroupId)
+        val cap2 = introducer.mint(alice, sampleGroupId)
+
+        assertEquals(32, cap1.introPublicKey.size)
+        assertEquals(32, cap2.introPublicKey.size)
+        assertNotEquals(
+            "two mints for the same group must produce distinct intro pubkeys",
+            cap1.introPublicKey.toList(),
+            cap2.introPublicKey.toList(),
+        )
+    }
+
+    @Test
+    fun mint_persistsKeypair_recoverableViaFind() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        val cap = introducer.mint(alice, sampleGroupId, groupName = "Family")
+        val entry = store.find(cap.introPublicKey)
+        assertNotNull(entry)
+        assertEquals(alice, entry!!.ownerIdentityId)
+        assertArrayEquals(sampleGroupId, entry.groupId)
+        // Private key must round-trip — that's what decrypts requests
+        // in PR-3+.
+        assertEquals(32, entry.introPrivateKey.size)
+        // PublicKey on the cap must match the persisted entry.
+        assertArrayEquals(cap.introPublicKey, entry.introPublicKey)
+    }
+
+    @Test
+    fun mint_capabilityCarriesGroupName_notTheStore() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        val cap = introducer.mint(alice, sampleGroupId, groupName = "Family")
+        assertEquals("Family", cap.groupName)
+        // The store doesn't persist the name — names live in the
+        // ChatGroup row, not in the per-invite store. Keeps the
+        // intro store tightly scoped to crypto material.
+        val entry = store.find(cap.introPublicKey)!!
+        // (No name field on IntroKeyEntry by design.)
+        assertEquals(32, entry.introPublicKey.size)
+    }
+
+    @Test
+    fun listForOwner_returnsOnlyMatchingIdentitysEntries() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        introducer.mint(alice, sampleGroupId)
+        introducer.mint(alice, ByteArray(32) { 0x55 })
+        introducer.mint(bob, sampleGroupId)
+
+        val aliceList = store.listForOwner(alice)
+        val bobList = store.listForOwner(bob)
+        assertEquals(2, aliceList.size)
+        assertEquals(1, bobList.size)
+        assertTrue(aliceList.all { it.ownerIdentityId == alice })
+    }
+
+    @Test
+    fun revoke_removesEntry() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        val cap = introducer.mint(alice, sampleGroupId)
+        assertNotNull(store.find(cap.introPublicKey))
+        store.revoke(cap.introPublicKey)
+        assertNull(store.find(cap.introPublicKey))
+    }
+
+    @Test
+    fun deleteForOwner_cascadesAllOwnedEntries_returnsCount() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        introducer.mint(alice, sampleGroupId)
+        introducer.mint(alice, ByteArray(32) { 0x55 })
+        introducer.mint(bob, sampleGroupId)
+
+        val removed = store.deleteForOwner(alice)
+        assertEquals(2, removed)
+        assertEquals(0, store.listForOwner(alice).size)
+        assertEquals(1, store.listForOwner(bob).size)
+    }
+
+    @Test
+    fun mint_rejectsWrongSizedGroupId() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val introducer = InviteIntroducer(store, ioDispatcher = Dispatchers.Unconfined)
+
+        try {
+            introducer.mint(alice, ByteArray(31))
+            error("expected IllegalArgumentException")
+        } catch (_: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun mint_clockProvider_stampsCreatedAt() = runTest {
+        val store = InMemoryIntroKeyStore()
+        val frozenNow = 1_700_000_000_000L
+        val introducer = InviteIntroducer(
+            store = store,
+            ioDispatcher = Dispatchers.Unconfined,
+            random = SecureRandom(),
+            clock = { frozenNow },
+        )
+
+        val cap = introducer.mint(alice, sampleGroupId)
+        val entry = store.find(cap.introPublicKey)!!
+        assertEquals(frozenNow, entry.createdAtMillis)
+    }
+}


### PR DESCRIPTION
## Summary

PR-2 of the Level-2 deeplink stack. Stacked on #60. Persists per-invite ephemeral X25519 keypairs.

- \`IntroKeyEntry\` value type, owner-scoped to an \`IdentityId\`.
- \`IntroKeyStore\` interface (save / find / listForOwner / revoke / deleteForOwner) — last one is the cascade-delete hook for the identity-removal listener.
- \`EncryptedPrefsIntroKeyStore\` — production impl, same master key as \`IdentitySecretStore\`, whole-blob persistence (entries are tiny, realistic counts are dozens).
- \`InviteIntroducer\` — high-level mint helper that produces an \`IntroCapability\` ready for the deeplink URL.
- \`InMemoryIntroKeyStore\` in \`support/\` for downstream tests.

## Test plan

- [x] 8 unit tests covering distinct-keypairs, persistence round-trip, owner scoping, revoke, cascade delete, size validation, clock-injection
- [x] All other tests still green
- [x] \`:app:compileDebugAndroidTestKotlin\` clean

## Stack

#60 → #(this) → transport/intro-inbox subscription (PR-3) → group/join-request flow (PR-4) → ux/share-invite-link (PR-5) → transport/deeplink-intent-filter (PR-6) → ux/joinscreen-completion (PR-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)