### PR TITLE
transport: intro inbox subscription fan-out + multi-listener (PR-3/7)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -320,6 +320,47 @@ class OnymApplication : Application() {
             )
         }
 
+        // Intro inbox fan-out (deeplink-invite PR-3). Sender
+        // subscribes to every per-invite intro pubkey's tag so
+        // joiners' "request to join" envelopes land in the
+        // IntroRequestStore. Filtered to the currently-active
+        // identity — switching identity drops the prior set,
+        // re-subscribes for the new one.
+        val introKeyStore: chat.onym.android.group.IntroKeyStore =
+            chat.onym.android.group.EncryptedPrefsIntroKeyStore(applicationContext)
+        val introRequestStore: chat.onym.android.group.IntroRequestStore =
+            chat.onym.android.group.InMemoryIntroRequestStore()
+        val introInboxPump = chat.onym.android.group.IntroInboxPump(
+            transport = inboxTransport,
+            store = introRequestStore,
+            inboxTagFor = { introPub ->
+                chat.onym.android.transport.TransportInboxId(
+                    chat.onym.android.identity.IdentityRepository.inboxTag(introPub),
+                )
+            },
+        )
+        // Cascade-delete intro keys when an identity is removed so
+        // we don't keep listening on tags whose owner is gone. The
+        // removal-listener slot is multi-listener (PR-3 of the
+        // deeplink stack flipped it from single → list).
+        // GroupRepository's chat-wipe registered first (during its
+        // `init`); this hook appends. Order: chats wipe first, then
+        // intro keys.
+        identityRepository.registerRemovalListener { id ->
+            introKeyStore.deleteForOwner(id)
+        }
+        applicationScope.launch {
+            introInboxPump.runFanout(
+                kotlinx.coroutines.flow.combine(
+                    introKeyStore.entriesFlow,
+                    identityRepository.currentIdentityId,
+                ) { entries, activeId ->
+                    if (activeId == null) emptyList()
+                    else entries.filter { it.ownerIdentityId == activeId }
+                },
+            )
+        }
+
         // App-wide network preference (PR-C follow-up). Defaults to
         // testnet; the Settings → Network → "Use Mainnet" Switch
         // flips it. CreateGroupInteractor reads `current()` per call

--- a/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
@@ -6,6 +6,9 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import chat.onym.android.identity.Base64ByteArraySerializer
 import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.SerializationException
@@ -30,6 +33,18 @@ class EncryptedPrefsIntroKeyStore(
 ) : IntroKeyStore {
 
     private val mutex = Mutex()
+
+    private val _entriesFlow = MutableStateFlow<List<IntroKeyEntry>>(emptyList())
+    override val entriesFlow: StateFlow<List<IntroKeyEntry>> = _entriesFlow.asStateFlow()
+
+    init {
+        // Seed the flow at construction time so the first subscriber
+        // sees the on-disk state without needing an explicit reload.
+        // EncryptedSharedPreferences read is lazy via the `prefs`
+        // delegate, so this only does work if a previous session
+        // wrote something.
+        _entriesFlow.value = loadAllUnlocked().map { it.toEntry() }
+    }
 
     private val prefs: SharedPreferences by lazy {
         val masterKey = MasterKey.Builder(context)
@@ -118,6 +133,10 @@ class EncryptedPrefsIntroKeyStore(
         // once IntroIntroducer wraps them) and we want
         // write-confirmation before returning.
         prefs.edit().putString(KEY_BLOB, raw).commit()
+        // Keep the reactive surface in lockstep with the on-disk
+        // state. Inside the mutex on every mutation path, so no
+        // emission interleaves with a partial in-flight write.
+        _entriesFlow.value = entries.map { it.toEntry() }
     }
 
     private fun StoredIntroKey.toEntry(): IntroKeyEntry = IntroKeyEntry(

--- a/app/src/main/kotlin/chat/onym/android/group/IntroInboxPump.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroInboxPump.kt
@@ -1,0 +1,87 @@
+package chat.onym.android.group
+
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Sender-side pump for intro inbox subscriptions. Mirrors
+ * [chat.onym.android.inbox.IncomingInvitationsInteractor.runFanout]
+ * but drops inbounds into [IntroRequestStore] instead of the
+ * identity-inbox sink.
+ *
+ * **Why a parallel interactor instead of one shared seam**:
+ * deliberately mirroring code rather than abstracting because the
+ * two flows are likely to diverge — intro requests are interactive
+ * (sender taps Approve), invitations are autonomic (joiner sees
+ * the chat appear). Shared abstraction would leak through either
+ * a generic-type parameter or a sink interface that adds
+ * indirection without saving meaningful code.
+ *
+ * Subscription set is rebuilt wholesale on every emission via
+ * `collectLatest`. Adding/revoking an intro key flips the active
+ * subscription set within one emission window.
+ *
+ * **Each launched subscription captures its [IntroKeyEntry]**, so
+ * inbounds can be tagged with the matching introPub directly —
+ * no `tag → pub` reverse-lookup map needed. The pump holds the
+ * mapping in scope for the duration of each subscription.
+ */
+class IntroInboxPump(
+    private val transport: InboxTransport,
+    private val store: IntroRequestStore,
+    /** Maps an intro pubkey → its Nostr inbox tag. Production wires
+     *  to `IdentityRepository.inboxTag(introPub)` (the same
+     *  `SHA-256("sep-inbox-v1" || pub)[..8]` derivation identity
+     *  inbox tags use); tests pass an identity-equality stub. */
+    private val inboxTagFor: (introPublicKey: ByteArray) -> TransportInboxId,
+) {
+
+    /**
+     * Run the fan-out for the lifetime of the calling scope. Each
+     * [entries] emission cancels the prior subscription set
+     * wholesale and re-subscribes.
+     *
+     * Production wires:
+     * `introKeyStore.entriesFlow.map { it.filter { it.ownerIdentityId == active } }`
+     * — switching identities or revoking an entry drops its
+     * subscription within one emission window.
+     */
+    suspend fun runFanout(entries: Flow<List<IntroKeyEntry>>) {
+        entries
+            .map { list -> list.distinctBy { it.introPublicKey.toList() } }
+            .distinctUntilChanged { old, new ->
+                old.size == new.size &&
+                    old.zip(new).all { (a, b) -> a.introPublicKey.contentEquals(b.introPublicKey) }
+            }
+            .collectLatest { current ->
+                coroutineScope {
+                    for (entry in current) {
+                        launch { run(entry) }
+                    }
+                }
+            }
+    }
+
+    /** Subscribe to one entry's inbox tag and pump every inbound
+     *  into the store, tagged with the entry's introPubkey so
+     *  PR-4's approval interactor can find the matching privkey. */
+    private suspend fun run(entry: IntroKeyEntry) {
+        val tag = inboxTagFor(entry.introPublicKey)
+        transport.subscribe(tag).collect { inbound ->
+            store.record(
+                IntroRequest(
+                    id = inbound.messageId,
+                    targetIntroPublicKey = entry.introPublicKey,
+                    payload = inbound.payload,
+                    receivedAt = inbound.receivedAt,
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
@@ -1,6 +1,7 @@
 package chat.onym.android.group
 
 import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Persistence seam for per-invite ephemeral X25519 keypairs.
@@ -24,6 +25,16 @@ import chat.onym.android.identity.IdentityId
  * we don't leak intro privkeys past the identity that minted them.
  */
 interface IntroKeyStore {
+    /** Hot stream of every entry across every owner. Emits the
+     *  current snapshot on subscribe, then a fresh value after
+     *  every [save] / [revoke] / [deleteForOwner].
+     *
+     *  Drives the inbox fan-out (PR-3): the wiring layer maps
+     *  this → list of intro inbox tags → feeds into the request
+     *  pump. New entry → new subscription within the next
+     *  emission window. */
+    val entriesFlow: StateFlow<List<IntroKeyEntry>>
+
     /** Persist a freshly-minted intro entry. Idempotent on
      *  [IntroKeyEntry.introPublicKey] — re-mint with the same pub
      *  is a no-op (shouldn't happen in practice; X25519 keypairs

--- a/app/src/main/kotlin/chat/onym/android/group/IntroRequest.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroRequest.kt
@@ -1,0 +1,44 @@
+package chat.onym.android.group
+
+import java.time.Instant
+
+/**
+ * One inbound "request to join" envelope received over an intro
+ * inbox tag. Opaque bytes here — decryption + parsing of the inner
+ * payload (which carries the joiner's identity pubkey + group
+ * acknowledgement) happens in PR-4's `IntroRequestInteractor`.
+ *
+ * Mirrors the [chat.onym.android.persistence.IncomingInvitationRecord]
+ * shape; the two stores are deliberately parallel (identity inbox
+ * vs intro inbox) because the consumer flows differ.
+ */
+data class IntroRequest(
+    /** Nostr event id; dedupe key. */
+    val id: String,
+    /** The inviter's intro pubkey this request was addressed to.
+     *  Also doubles as the lookup key into [IntroKeyStore] —
+     *  `store.find(targetIntroPub)` returns the privkey that
+     *  decrypts [payload]. */
+    val targetIntroPublicKey: ByteArray,
+    /** Sealed envelope bytes — the inner JSON is encrypted to
+     *  [targetIntroPublicKey] via X25519+AES-GCM. */
+    val payload: ByteArray,
+    val receivedAt: Instant,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IntroRequest) return false
+        return id == other.id &&
+            targetIntroPublicKey.contentEquals(other.targetIntroPublicKey) &&
+            payload.contentEquals(other.payload) &&
+            receivedAt == other.receivedAt
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + targetIntroPublicKey.contentHashCode()
+        h = 31 * h + payload.contentHashCode()
+        h = 31 * h + receivedAt.hashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/IntroRequestStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroRequestStore.kt
@@ -1,0 +1,53 @@
+package chat.onym.android.group
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory sink for inbound intro requests. Process-lifetime —
+ * the request approval flow (PR-4) is interactive; if the user
+ * doesn't act before the process dies, the joiner re-shares.
+ *
+ * Mirrors the [chat.onym.android.persistence.InMemoryInvitationStore]
+ * shape — identical posture for the V1 receive-side (interactive
+ * UI consumes the StateFlow; persistence lands in a follow-up if
+ * we need durability across restarts).
+ */
+interface IntroRequestStore {
+    /** Hot stream of pending requests. Sorted newest-first by
+     *  [IntroRequest.receivedAt]. UI subscribes here. */
+    val requests: StateFlow<List<IntroRequest>>
+
+    /** Append a fresh request. Dedup on [IntroRequest.id]; returns
+     *  `true` on insert, `false` if the id was already present. */
+    suspend fun record(request: IntroRequest): Boolean
+
+    /** Drop a request after the user has acted on it (Approve or
+     *  Decline) so it stops cluttering the surface. */
+    suspend fun consume(id: String)
+}
+
+class InMemoryIntroRequestStore : IntroRequestStore {
+
+    private val mutex = Mutex()
+    private val pending = mutableListOf<IntroRequest>()
+
+    private val _requests = MutableStateFlow<List<IntroRequest>>(emptyList())
+    override val requests: StateFlow<List<IntroRequest>> = _requests.asStateFlow()
+
+    override suspend fun record(request: IntroRequest): Boolean = mutex.withLock {
+        if (pending.any { it.id == request.id }) return@withLock false
+        pending += request
+        _requests.value = pending.sortedByDescending { it.receivedAt }
+        true
+    }
+
+    override suspend fun consume(id: String) = mutex.withLock {
+        if (pending.removeAll { it.id == id }) {
+            _requests.value = pending.sortedByDescending { it.receivedAt }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -69,9 +69,15 @@ class IdentityRepository(
     private val _currentIdentityId = MutableStateFlow<IdentityId?>(null)
     /** Listeners notified when an identity is removed; they get the
      *  removed id BEFORE the storage wipe completes (so they can
-     *  cascade-delete owned data). Set by [setRemovalListener] —
-     *  PR-3's `GroupRepository` registers itself. */
-    private var removalListener: (suspend (IdentityId) -> Unit)? = null
+     *  cascade-delete owned data). Multi-slot — `GroupRepository`
+     *  registers a chat-wipe listener; the deeplink-invite layer
+     *  registers an intro-key-wipe listener. Invoked in registration
+     *  order; later registrants run after earlier ones.
+     *
+     *  Snapshot-replace on register so iterators inside `remove()`
+     *  don't crash on concurrent mutations. */
+    @Volatile
+    private var removalListeners: List<suspend (IdentityId) -> Unit> = emptyList()
 
     /** Hot stream of the **currently-selected** identity's snapshot.
      *  New collectors get the current value immediately, then one new
@@ -93,15 +99,20 @@ class IdentityRepository(
     fun currentIdentity(): Identity? = _snapshots.value
 
     /** Register a listener invoked just before a [remove] wipes its
-     *  storage. Single-listener — `GroupRepository` hooks in here.
-     *  Pass `null` to clear. */
+     *  storage. Multi-slot — appends. Passing `null` clears every
+     *  registered listener (used by tests for setup hygiene; never
+     *  by production callers).
+     *
+     *  Listeners are invoked in registration order. A listener that
+     *  throws aborts the chain — subsequent listeners + the wipe
+     *  itself don't run, so wire ordering matters: register
+     *  listeners that MUST run before the wipe (e.g.
+     *  GroupRepository's chat-delete) FIRST. */
     override fun registerRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {
-        removalListener = listener
+        removalListeners = if (listener == null) emptyList() else removalListeners + listener
     }
 
-    /** Back-compat alias for [registerRemovalListener]. PR-2 named the
-     *  hook `setRemovalListener`; PR-3 renamed it to match the
-     *  [ActiveIdentityProvider] interface. */
+    /** Back-compat alias. */
     @Deprecated("Use registerRemovalListener", ReplaceWith("registerRemovalListener(listener)"))
     fun setRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {
         registerRemovalListener(listener)
@@ -183,7 +194,7 @@ class IdentityRepository(
             val newId = IdentityId.new()
             val snapshot = snapshotFromEntropy(entropy, name = "")
             if (previousId != null) {
-                removalListener?.invoke(previousId)
+                removalListeners.forEach { it.invoke(previousId) }
                 store.wipe(previousId)
             }
             store.save(newId, snapshot)
@@ -204,7 +215,7 @@ class IdentityRepository(
     suspend fun wipe() = mutex.withLock {
         withContext(ioDispatcher) {
             store.loadCurrent()?.let { id ->
-                removalListener?.invoke(id)
+                removalListeners.forEach { it.invoke(id) }
                 store.wipe(id)
             }
             _snapshots.value = null
@@ -264,7 +275,7 @@ class IdentityRepository(
     suspend fun remove(id: IdentityId) = mutex.withLock {
         withContext(ioDispatcher) {
             if (id !in store.listIds()) return@withContext
-            removalListener?.invoke(id)
+            removalListeners.forEach { it.invoke(id) }
             val wasActive = store.loadCurrent() == id
             store.wipe(id)
             if (wasActive) {
@@ -531,7 +542,7 @@ class IdentityRepository(
         }
         val snapshot = snapshotFromEntropy(entropy, name = resolved)
         if (previousId != null) {
-            removalListener?.invoke(previousId)
+            removalListeners.forEach { it.invoke(previousId) }
             store.wipe(previousId)
         }
         store.save(newId, snapshot)

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
@@ -3,6 +3,9 @@ package chat.onym.android.support
 import chat.onym.android.group.IntroKeyEntry
 import chat.onym.android.group.IntroKeyStore
 import chat.onym.android.identity.IdentityId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -18,9 +21,13 @@ class InMemoryIntroKeyStore : IntroKeyStore {
     private val mutex = Mutex()
     private val entries = mutableListOf<IntroKeyEntry>()
 
+    private val _entriesFlow = MutableStateFlow<List<IntroKeyEntry>>(emptyList())
+    override val entriesFlow: StateFlow<List<IntroKeyEntry>> = _entriesFlow.asStateFlow()
+
     override suspend fun save(entry: IntroKeyEntry) = mutex.withLock {
         entries.removeAll { it.introPublicKey.contentEquals(entry.introPublicKey) }
         entries += entry
+        _entriesFlow.value = entries.toList()
     }
 
     override suspend fun find(introPublicKey: ByteArray): IntroKeyEntry? = mutex.withLock {
@@ -35,13 +42,16 @@ class InMemoryIntroKeyStore : IntroKeyStore {
 
     override suspend fun revoke(introPublicKey: ByteArray) {
         mutex.withLock {
-            entries.removeAll { it.introPublicKey.contentEquals(introPublicKey) }
+            val changed = entries.removeAll { it.introPublicKey.contentEquals(introPublicKey) }
+            if (changed) _entriesFlow.value = entries.toList()
         }
     }
 
     override suspend fun deleteForOwner(ownerIdentityId: IdentityId): Int = mutex.withLock {
         val before = entries.size
         entries.removeAll { it.ownerIdentityId == ownerIdentityId }
-        before - entries.size
+        val removed = before - entries.size
+        if (removed > 0) _entriesFlow.value = entries.toList()
+        removed
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/group/IntroInboxPumpTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/IntroInboxPumpTest.kt
@@ -1,0 +1,145 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.support.FakeInboxTransport
+import chat.onym.android.transport.InboundInbox
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class IntroInboxPumpTest {
+
+    private val now = Instant.parse("2026-05-03T12:00:00Z")
+    private val alice = IdentityId("alice-uuid")
+    private val groupId = ByteArray(32) { 0x42 }
+
+    private fun entry(seed: Byte) = IntroKeyEntry(
+        introPublicKey = ByteArray(32) { seed },
+        introPrivateKey = ByteArray(32) { (seed + 1).toByte() },
+        ownerIdentityId = alice,
+        groupId = groupId,
+        createdAtMillis = 1_700_000_000L,
+    )
+
+    /** Fake tag derivation — each pubkey gets the hex of its first
+     *  4 bytes as its tag. Doesn't have to match
+     *  IdentityRepository.inboxTag's actual SHA-256 derivation;
+     *  the pump only needs the mapping to be deterministic + the
+     *  inverse uniquely recoverable. */
+    private fun fakeTag(pub: ByteArray): TransportInboxId =
+        TransportInboxId(pub.take(4).joinToString("") { "%02x".format(it) })
+
+    @Test
+    fun runFanout_subscribesToEveryIntroPubInTheList() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryIntroRequestStore()
+        val pump = IntroInboxPump(transport, store, ::fakeTag)
+
+        val entries = MutableStateFlow(listOf(entry(0x10), entry(0x20)))
+
+        coroutineScope {
+            val job = async { pump.runFanout(entries) }
+            yield()
+            assertEquals(
+                "two entries → two subscriptions",
+                setOf(fakeTag(entry(0x10).introPublicKey), fakeTag(entry(0x20).introPublicKey)),
+                transport.subscribedInboxes,
+            )
+            job.cancel()
+            job.join()
+        }
+    }
+
+    @Test
+    fun runFanout_inboundOnTaggedInbox_recordedWithMatchingIntroPub() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryIntroRequestStore()
+        val pump = IntroInboxPump(transport, store, ::fakeTag)
+
+        val e = entry(0x10)
+        val entries = MutableStateFlow(listOf(e))
+
+        coroutineScope {
+            val job = async { pump.runFanout(entries) }
+            yield()
+            transport.emit(
+                InboundInbox(
+                    inbox = fakeTag(e.introPublicKey),
+                    payload = "request-bytes".toByteArray(),
+                    receivedAt = now,
+                    messageId = "ev-1",
+                )
+            )
+            yield()
+            val recorded = store.requests.first()
+            assertEquals(1, recorded.size)
+            // Every inbound is stamped with the introPub of the
+            // entry whose tag it landed on. PR-4's approval
+            // interactor looks up the privkey by this field.
+            assertArrayEquals(e.introPublicKey, recorded.first().targetIntroPublicKey)
+            job.cancel()
+            job.join()
+        }
+    }
+
+    @Test
+    fun runFanout_swappingTheListCancelsOldSubsAndStartsNewOnes() = runTest(UnconfinedTestDispatcher()) {
+        // Re-subscribing the SAME tag after cancellation hits a fake-
+        // transport limitation (consumeAsFlow cancels the channel),
+        // mirrored in IncomingInvitationsInteractorTest. Swap the list
+        // to entirely different entries so the assertion exercises the
+        // wholesale-resubscribe semantics without that trap.
+        val transport = FakeInboxTransport()
+        val store = InMemoryIntroRequestStore()
+        val pump = IntroInboxPump(transport, store, ::fakeTag)
+
+        val a = entry(0x10)
+        val c = entry(0x30)
+        val entries = MutableStateFlow(listOf(a))
+
+        coroutineScope {
+            val job = async { pump.runFanout(entries) }
+            yield()
+            assertEquals(setOf(fakeTag(a.introPublicKey)), transport.subscribedInboxes)
+
+            entries.value = listOf(c)
+            yield()
+            assertEquals(setOf(fakeTag(c.introPublicKey)), transport.subscribedInboxes)
+            assertTrue(
+                "a's subscription was cancelled when it dropped off the list",
+                transport.unsubscribedInboxes.contains(fakeTag(a.introPublicKey)),
+            )
+            job.cancel()
+            job.join()
+        }
+    }
+
+    @Test
+    fun runFanout_emptyList_subscribesToNothing() = runTest(UnconfinedTestDispatcher()) {
+        val transport = FakeInboxTransport()
+        val store = InMemoryIntroRequestStore()
+        val pump = IntroInboxPump(transport, store, ::fakeTag)
+
+        val entries = MutableStateFlow<List<IntroKeyEntry>>(emptyList())
+
+        coroutineScope {
+            val job = async { pump.runFanout(entries) }
+            yield()
+            assertTrue(transport.subscribedInboxes.isEmpty())
+            job.cancel()
+            job.join()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR-3 of the Level-2 deeplink stack. Stacked on #61. Sender's app subscribes to every per-invite intro pubkey's Nostr inbox tag so joiners' "request to join" envelopes land in \`IntroRequestStore\`.

- \`IntroKeyStore.entriesFlow\` — reactive surface (both impls).
- \`IntroRequest\` + \`IntroRequestStore\` (in-memory).
- \`IntroInboxPump\` — sender-side fan-out, mirrors \`IncomingInvitationsInteractor.runFanout\`. Each subscription captures its \`IntroKeyEntry\` so inbounds are stamped with the matching \`introPub\`.
- **\`IdentityRepository.registerRemovalListener\` flipped single → multi-listener** (additive append). Lets GroupRepository's chat-wipe AND the intro-key-wipe both run on identity removal, instead of the second registration overwriting the first.
- \`OnymApplication\`: wires the keystore + pump, registers the cascade listener, launches \`runFanout\` filtered to current identity.

## Test plan

- [x] 4 unit tests on \`IntroInboxPumpTest\` (happy fan-out, inbound→stamped-introPub, list-swap, empty list)
- [x] All other unit tests still green
- [x] \`:app:compileDebugAndroidTestKotlin\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)