### PR TITLE
group: join-request flow — sender + approver (PR-4/7)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -1,0 +1,254 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityRepository
+import chat.onym.android.identity.InvitationDecryptError
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Sender-side: turn raw [IntroRequest]s into UI-renderable
+ * [PendingRequest]s, and on user approval ship the actual sealed
+ * [GroupInvitationPayload] to the joiner.
+ *
+ * Lifecycle:
+ *  1. [start] subscribes to [IntroRequestStore.requests] and
+ *     decrypts each newly-arrived envelope using the matching
+ *     [IntroKeyEntry.introPrivateKey] from [IntroKeyStore]. Decrypt
+ *     failures are logged via [_decryptFailures] (drives a
+ *     debug-only counter; real users never see them).
+ *  2. UI subscribes to [pending] and renders "X wants to join Y.
+ *     Approve?" prompts.
+ *  3. On Approve → seals the existing [GroupInvitationPayload]
+ *     (built from the local [ChatGroup]) to the joiner's identity
+ *     inbox key, ships via [inboxTransport.send], revokes the
+ *     intro key. The fan-out from PR-3 stops listening on that
+ *     intro tag within one emission window.
+ *  4. On Decline → drop the request, revoke the intro key. No
+ *     NACK to the joiner; their JoinScreen times out gracefully.
+ */
+class JoinRequestApprover(
+    private val identity: IdentityRepository,
+    private val introKeyStore: IntroKeyStore,
+    private val introRequestStore: IntroRequestStore,
+    private val groupRepository: GroupRepository,
+    private val inboxTransport: InboxTransport,
+    private val scope: CoroutineScope,
+) {
+    /** UI-renderable view of one decrypted, awaiting-action request. */
+    data class PendingRequest(
+        /** Stable id == [IntroRequest.id]. Approve / Decline use it
+         *  as the dedupe key. */
+        val id: String,
+        val joinerInboxPublicKey: ByteArray,
+        val joinerDisplayLabel: String,
+        val groupId: ByteArray,
+        /** Looked up from the local [GroupRepository]. Null if the
+         *  joiner is asking about a group we don't know — surface
+         *  a "this invite isn't for any group on this device"
+         *  error in the UI rather than approving. */
+        val groupName: String?,
+    ) {
+        override fun equals(other: Any?): Boolean = this === other ||
+            (other is PendingRequest &&
+                id == other.id &&
+                joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
+                joinerDisplayLabel == other.joinerDisplayLabel &&
+                groupId.contentEquals(other.groupId) &&
+                groupName == other.groupName)
+
+        override fun hashCode(): Int {
+            var h = id.hashCode()
+            h = 31 * h + joinerInboxPublicKey.contentHashCode()
+            h = 31 * h + joinerDisplayLabel.hashCode()
+            h = 31 * h + groupId.contentHashCode()
+            h = 31 * h + (groupName?.hashCode() ?: 0)
+            return h
+        }
+    }
+
+    sealed class ApproveOutcome {
+        object Sent : ApproveOutcome()
+        object UnknownGroup : ApproveOutcome()
+        object UnknownRequest : ApproveOutcome()
+        object NoIdentityLoaded : ApproveOutcome()
+        class TransportFailed(val reason: String) : ApproveOutcome()
+    }
+
+    private val mutex = Mutex()
+    private val _pending = MutableStateFlow<List<PendingRequest>>(emptyList())
+    val pending: StateFlow<List<PendingRequest>> = _pending.asStateFlow()
+
+    /** Internal counter for decrypt failures — drives a future
+     *  diagnostic surface (e.g., Settings → Diagnostics shows
+     *  "N requests failed to decrypt" so users can detect a forged
+     *  link campaign or a corrupted intro key). */
+    private val _decryptFailures = MutableStateFlow(0)
+
+    @Suppress("unused")
+    val decryptFailures: StateFlow<Int> = _decryptFailures.asStateFlow()
+
+    /**
+     * Subscribe to [IntroRequestStore.requests] and keep [pending]
+     * in sync. Idempotent — safe to call once at app start. The
+     * collector lives for [scope]'s lifetime.
+     */
+    fun start() {
+        scope.launch {
+            introRequestStore.requests.collectLatest { raw ->
+                val decoded = raw.mapNotNull { decode(it) }
+                _pending.value = decoded
+            }
+        }
+    }
+
+    /** Test hook: decode + emit synchronously without spawning the
+     *  collector. Lets unit tests assert the decode path without
+     *  fighting collector scheduling. */
+    @androidx.annotation.VisibleForTesting
+    internal suspend fun pumpOnce() {
+        val raw = introRequestStore.requests.value
+        _pending.value = raw.mapNotNull { decode(it) }
+    }
+
+    /**
+     * Approve a pending request: build the [GroupInvitationPayload]
+     * from the local group state, seal to the joiner's inbox key,
+     * ship via Nostr, then revoke the intro slot + drop the
+     * pending entry.
+     */
+    suspend fun approve(requestId: String): ApproveOutcome = mutex.withLock {
+        val req = _pending.value.firstOrNull { it.id == requestId }
+            ?: return@withLock ApproveOutcome.UnknownRequest
+        val activeIdentity = identity.currentIdentity()
+            ?: return@withLock ApproveOutcome.NoIdentityLoaded
+
+        val group = groupRepository.snapshots.value.firstOrNull {
+            it.groupIdBytes.contentEquals(req.groupId)
+        } ?: return@withLock ApproveOutcome.UnknownGroup
+
+        val invitePayload = GroupInvitationPayload(
+            version = 1,
+            groupId = group.groupIdBytes,
+            groupSecret = group.groupSecret,
+            name = group.name,
+            members = group.members,
+            epoch = group.epoch,
+            salt = group.salt,
+            commitment = group.commitment,
+            tierRaw = group.tier.rawValue,
+            groupTypeRaw = group.groupType.wireValue,
+            adminPubkeyHex = group.adminPubkeyHex,
+        )
+        val payloadBytes = try {
+            jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)
+                .toByteArray(Charsets.UTF_8)
+        } catch (e: Throwable) {
+            return@withLock ApproveOutcome.TransportFailed("encode: ${e.message ?: e.javaClass.simpleName}")
+        }
+        val sealed = try {
+            identity.sealInvitation(payloadBytes, req.joinerInboxPublicKey)
+        } catch (e: Throwable) {
+            return@withLock ApproveOutcome.TransportFailed("seal: ${e.message ?: e.javaClass.simpleName}")
+        }
+        val joinerTag = TransportInboxId(IdentityRepository.inboxTag(req.joinerInboxPublicKey))
+        val receipt = try {
+            inboxTransport.send(sealed, joinerTag)
+        } catch (e: Throwable) {
+            return@withLock ApproveOutcome.TransportFailed("send: ${e.message ?: e.javaClass.simpleName}")
+        }
+        if (receipt.acceptedBy < 1) {
+            return@withLock ApproveOutcome.TransportFailed("no relay accepted the invitation")
+        }
+
+        // Best-effort cleanup. Both calls run regardless of failures
+        // because the request is conceptually consumed at this point;
+        // a leaked intro key is benign (sender ignores future
+        // requests on it via UnknownGroup or just not approving).
+        revokeAndConsume(introPub = findIntroPubFor(requestId), requestId = requestId)
+        ApproveOutcome.Sent
+    }
+
+    /** Decline a pending request: drop it + revoke the intro slot.
+     *  No NACK to the joiner — their JoinScreen times out. */
+    suspend fun decline(requestId: String) = mutex.withLock {
+        revokeAndConsume(introPub = findIntroPubFor(requestId), requestId = requestId)
+    }
+
+    // ─── private ──────────────────────────────────────────────────
+
+    private suspend fun decode(raw: IntroRequest): PendingRequest? {
+        // We hold the introPub on the IntroRequest from PR-3's
+        // pump. Look up the privkey via IntroKeyStore. If the
+        // privkey is missing (e.g., the entry was already revoked
+        // before we got here), drop the request silently.
+        val entry = introKeyStore.find(raw.targetIntroPublicKey) ?: return null
+
+        val plaintext = try {
+            IdentityRepository.decryptSealedEnvelopeWithKey(
+                envelopeBytes = raw.payload,
+                recipientX25519PrivateKey = entry.introPrivateKey,
+            )
+        } catch (e: InvitationDecryptError) {
+            _decryptFailures.value += 1
+            return null
+        } catch (e: Throwable) {
+            _decryptFailures.value += 1
+            return null
+        }
+        val payload = try {
+            jsonFormat.decodeFromString(JoinRequestPayload.serializer(), plaintext.toString(Charsets.UTF_8))
+        } catch (_: SerializationException) {
+            _decryptFailures.value += 1
+            return null
+        } catch (_: IllegalArgumentException) {
+            _decryptFailures.value += 1
+            return null
+        }
+        if (!payload.groupId.contentEquals(entry.groupId)) {
+            // Joiner is asking about a different group than the
+            // intro entry was minted for. Forged or stale link —
+            // drop silently.
+            _decryptFailures.value += 1
+            return null
+        }
+
+        val groupName = groupRepository.snapshots.value
+            .firstOrNull { it.groupIdBytes.contentEquals(payload.groupId) }
+            ?.name
+
+        return PendingRequest(
+            id = raw.id,
+            joinerInboxPublicKey = payload.joinerInboxPublicKey,
+            joinerDisplayLabel = payload.joinerDisplayLabel,
+            groupId = payload.groupId,
+            groupName = groupName,
+        )
+    }
+
+    private suspend fun findIntroPubFor(requestId: String): ByteArray? {
+        // PendingRequest doesn't carry the introPub (intentional —
+        // UI should never need it). Resolve via the raw store.
+        val raw = introRequestStore.requests.value.firstOrNull { it.id == requestId }
+            ?: return null
+        return raw.targetIntroPublicKey
+    }
+
+    private suspend fun revokeAndConsume(introPub: ByteArray?, requestId: String) {
+        if (introPub != null) introKeyStore.revoke(introPub)
+        introRequestStore.consume(requestId)
+    }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
@@ -1,0 +1,62 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Inner plaintext of the sealed envelope a joiner sends to an
+ * inviter's intro inbox. Carries everything the inviter's app
+ * needs to ship the actual sealed [GroupInvitationPayload] back:
+ *
+ *  - [joinerInboxPublicKey] — where the sealed invitation will be
+ *    posted (the joiner's identity inbox X25519 key).
+ *  - [joinerDisplayLabel] — UI hint for the inviter's "X wants to
+ *    join Y. Approve?" prompt. Joiner-controlled, **untrusted**;
+ *    the inviter's app should also surface
+ *    [joinerInboxPublicKey]'s hex prefix so the inviter can
+ *    verify out-of-band when the label can't be cross-checked.
+ *  - [groupId] — echoed back so the inviter's approval handler can
+ *    cross-check that the joiner is asking about the right group.
+ *
+ * The OUTER envelope is the standard
+ * [chat.onym.android.identity.SealedEnvelope] (X25519+AES-GCM
+ * sealed to the inviter's intro pubkey + Ed25519-signed by the
+ * joiner's identity key). Reuses the existing seal/decrypt
+ * machinery on `IdentityRepository`.
+ */
+@Serializable
+data class JoinRequestPayload(
+    @SerialName("joiner_inbox_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val joinerInboxPublicKey: ByteArray,
+    @SerialName("joiner_display_label")
+    val joinerDisplayLabel: String,
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+) {
+    init {
+        require(joinerInboxPublicKey.size == 32) {
+            "joinerInboxPublicKey: expected 32 bytes, got ${joinerInboxPublicKey.size}"
+        }
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is JoinRequestPayload) return false
+        return joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
+            joinerDisplayLabel == other.joinerDisplayLabel &&
+            groupId.contentEquals(other.groupId)
+    }
+
+    override fun hashCode(): Int {
+        var h = joinerInboxPublicKey.contentHashCode()
+        h = 31 * h + joinerDisplayLabel.hashCode()
+        h = 31 * h + groupId.contentHashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
@@ -1,0 +1,77 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityRepository
+import chat.onym.android.transport.InboxTransport
+import chat.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+
+/**
+ * Joiner-side: tap-the-deeplink → ship a sealed
+ * [JoinRequestPayload] to the inviter's intro inbox.
+ *
+ * Flow:
+ *  1. Build the payload (joiner's inbox pubkey + display label +
+ *     group id echo).
+ *  2. Seal the payload to [IntroCapability.introPublicKey] using
+ *     the existing [IdentityRepository.sealInvitation] (X25519
+ *     ECDH against intro_pub + AES-GCM + Ed25519 signature with
+ *     the joiner's long-term key).
+ *  3. POST the sealed bytes to the Nostr inbox tag derived from
+ *     intro_pub.
+ *  4. Surface success/failure to the JoinScreen UI (PR-7).
+ */
+class JoinRequestSender(
+    private val identity: IdentityRepository,
+    private val inboxTransport: InboxTransport,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+
+    sealed class Outcome {
+        object Sent : Outcome()
+        class NoIdentityLoaded : Outcome()
+        class TransportFailed(val reason: String) : Outcome()
+    }
+
+    /**
+     * @param capability decoded from the deeplink's `?c=…` payload.
+     * @param joinerDisplayLabel surfaced in the inviter's approval
+     *        prompt. Joiner-controlled untrusted text — keep short
+     *        (Nostr relays typically cap event size at ~64KB and
+     *        we don't want to bloat the request envelope).
+     */
+    suspend fun send(
+        capability: IntroCapability,
+        joinerDisplayLabel: String,
+    ): Outcome = withContext(ioDispatcher) {
+        val activeIdentity = identity.currentIdentity() ?: return@withContext Outcome.NoIdentityLoaded()
+        val payload = JoinRequestPayload(
+            joinerInboxPublicKey = activeIdentity.inboxPublicKey,
+            joinerDisplayLabel = joinerDisplayLabel,
+            groupId = capability.groupId,
+        )
+        val payloadBytes = jsonFormat.encodeToString(JoinRequestPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val sealed = try {
+            identity.sealInvitation(payloadBytes, capability.introPublicKey)
+        } catch (e: Throwable) {
+            return@withContext Outcome.TransportFailed("seal: ${e.message ?: e.javaClass.simpleName}")
+        }
+        val tag = TransportInboxId(IdentityRepository.inboxTag(capability.introPublicKey))
+        val receipt = try {
+            inboxTransport.send(sealed, tag)
+        } catch (e: Throwable) {
+            return@withContext Outcome.TransportFailed("send: ${e.message ?: e.javaClass.simpleName}")
+        }
+        if (receipt.acceptedBy < 1) {
+            return@withContext Outcome.TransportFailed("no relay accepted the request")
+        }
+        Outcome.Sent
+    }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -348,68 +348,10 @@ class IdentityRepository(
     private fun decryptInvitationLocked(
         snapshot: StoredSnapshot,
         envelopeBytes: ByteArray,
-    ): ByteArray {
-        val envelope = try {
-            envelopeJsonFormat.decodeFromString<SealedEnvelope>(envelopeBytes.toString(Charsets.UTF_8))
-        } catch (e: SerializationException) {
-            throw InvitationDecryptError.MalformedEnvelope("invalid JSON: ${e.message}", e)
-        } catch (e: IllegalArgumentException) {
-            // base64 decode failure inside the field serializer
-            throw InvitationDecryptError.MalformedEnvelope("invalid base64: ${e.message}", e)
-        }
-        if (envelope.scheme != INVITATION_SCHEME) {
-            throw InvitationDecryptError.UnsupportedScheme(envelope.scheme)
-        }
-        val ephemeralPub = envelope.ephemeralPublicKey
-            ?: throw InvitationDecryptError.MissingEphemeralKey
-
-        // M-5: verify Ed25519 signature on the ephemeral pubkey if
-        // the envelope provides one. Prevents MITM substitution of
-        // the ephemeral key. Mirrors `GroupCrypto.decryptInvitation`
-        // in stellar-mls.
-        if (envelope.ephemeralKeySignature != null) {
-            val senderPubkey = envelope.senderEd25519PublicKey
-                ?: throw InvitationDecryptError.MalformedEnvelope(
-                    "ephemeral_key_signature present without sender_ed25519_public_key"
-                )
-            val verifier = Ed25519Signer().apply {
-                init(false, Ed25519PublicKeyParameters(senderPubkey, 0))
-            }
-            verifier.update(ephemeralPub, 0, ephemeralPub.size)
-            if (!verifier.verifySignature(envelope.ephemeralKeySignature)) {
-                throw InvitationDecryptError.SignatureFailed
-            }
-        }
-
-        // ECDH against the recipient's X25519 private (recomputed
-        // from nostrSecret per call; not stashed on `this`).
-        val recipientPrivate = inboxKeyAgreementPrivateKey(snapshot.nostrSecretKey)
-        val agreement = X25519Agreement().apply { init(recipientPrivate) }
-        val sharedSecret = ByteArray(agreement.agreementSize)
-        agreement.calculateAgreement(X25519PublicKeyParameters(ephemeralPub, 0), sharedSecret, 0)
-
-        // HKDF salt + info MUST match stellar-mls exactly — interop
-        // with iOS senders + Android stellar-mls senders rides on
-        // these constants.
-        val aesKey = Bip39.hkdfSha256(
-            ikm = sharedSecret,
-            salt = "sep-invitation-v1".toByteArray(Charsets.UTF_8),
-            info = "aes-256-gcm".toByteArray(Charsets.UTF_8),
-            length = 32,
-        )
-
-        val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
-            init(Cipher.DECRYPT_MODE, SecretKeySpec(aesKey, "AES"), GCMParameterSpec(128, envelope.nonce))
-        }
-        return try {
-            // GCM expects ciphertext + tag concatenated.
-            cipher.doFinal(envelope.ciphertext + envelope.authenticationTag)
-        } catch (e: AEADBadTagException) {
-            throw InvitationDecryptError.DecryptionFailed(e)
-        } catch (e: IllegalBlockSizeException) {
-            throw InvitationDecryptError.DecryptionFailed(e)
-        }
-    }
+    ): ByteArray = decryptSealedEnvelopeWithKey(
+        envelopeBytes = envelopeBytes,
+        recipientX25519PrivateKey = inboxKeyAgreementPrivateKey(snapshot.nostrSecretKey).encoded,
+    )
 
     // ─── InvitationEnvelopeSealer ───────────────────────────────────
 
@@ -601,6 +543,93 @@ class IdentityRepository(
     }
 
     companion object {
+
+        /**
+         * Open a [SealedEnvelope] with an arbitrary X25519 private
+         * key. The standard [decryptInvitation] path derives the key
+         * from the active identity's nostr secret; the deeplink-
+         * invite flow (PR-3+) uses a per-invite intro privkey
+         * persisted in [chat.onym.android.group.IntroKeyStore]. Both
+         * paths share this crypto core so the wire format stays in
+         * lockstep.
+         *
+         * Throws [InvitationDecryptError]; never raw `javax.crypto`
+         * / `kotlinx.serialization` exceptions.
+         */
+        fun decryptSealedEnvelopeWithKey(
+            envelopeBytes: ByteArray,
+            recipientX25519PrivateKey: ByteArray,
+        ): ByteArray {
+            require(recipientX25519PrivateKey.size == 32) {
+                "recipient X25519 priv: expected 32 bytes, got ${recipientX25519PrivateKey.size}"
+            }
+            val envelope = try {
+                envelopeJsonFormat.decodeFromString<SealedEnvelope>(
+                    envelopeBytes.toString(Charsets.UTF_8)
+                )
+            } catch (e: SerializationException) {
+                throw InvitationDecryptError.MalformedEnvelope("invalid JSON: ${e.message}", e)
+            } catch (e: IllegalArgumentException) {
+                throw InvitationDecryptError.MalformedEnvelope("invalid base64: ${e.message}", e)
+            }
+            if (envelope.scheme != INVITATION_SCHEME) {
+                throw InvitationDecryptError.UnsupportedScheme(envelope.scheme)
+            }
+            val ephemeralPub = envelope.ephemeralPublicKey
+                ?: throw InvitationDecryptError.MissingEphemeralKey
+
+            // M-5: verify Ed25519 signature on the ephemeral pubkey
+            // if the envelope provides one. Prevents MITM substitution.
+            if (envelope.ephemeralKeySignature != null) {
+                val senderPubkey = envelope.senderEd25519PublicKey
+                    ?: throw InvitationDecryptError.MalformedEnvelope(
+                        "ephemeral_key_signature present without sender_ed25519_public_key"
+                    )
+                val verifier = Ed25519Signer().apply {
+                    init(false, Ed25519PublicKeyParameters(senderPubkey, 0))
+                }
+                verifier.update(ephemeralPub, 0, ephemeralPub.size)
+                if (!verifier.verifySignature(envelope.ephemeralKeySignature)) {
+                    throw InvitationDecryptError.SignatureFailed
+                }
+            }
+
+            // ECDH against the recipient's X25519 private.
+            val recipientPriv = X25519PrivateKeyParameters(recipientX25519PrivateKey, 0)
+            val agreement = X25519Agreement().apply { init(recipientPriv) }
+            val sharedSecret = ByteArray(agreement.agreementSize)
+            agreement.calculateAgreement(
+                X25519PublicKeyParameters(ephemeralPub, 0),
+                sharedSecret,
+                0,
+            )
+
+            // HKDF salt + info MUST match stellar-mls exactly — interop
+            // with iOS senders + Android stellar-mls senders rides on
+            // these constants.
+            val aesKey = Bip39.hkdfSha256(
+                ikm = sharedSecret,
+                salt = "sep-invitation-v1".toByteArray(Charsets.UTF_8),
+                info = "aes-256-gcm".toByteArray(Charsets.UTF_8),
+                length = 32,
+            )
+
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
+                init(
+                    Cipher.DECRYPT_MODE,
+                    SecretKeySpec(aesKey, "AES"),
+                    GCMParameterSpec(128, envelope.nonce),
+                )
+            }
+            return try {
+                cipher.doFinal(envelope.ciphertext + envelope.authenticationTag)
+            } catch (e: AEADBadTagException) {
+                throw InvitationDecryptError.DecryptionFailed(e)
+            } catch (e: IllegalBlockSizeException) {
+                throw InvitationDecryptError.DecryptionFailed(e)
+            }
+        }
+
         /**
          * `HKDF-SHA256(nostrSecret, salt="chat.onym.ios", info="stellar-ed25519-v1", L=32)`
          * → Ed25519 seed → public key (32 bytes raw).

--- a/app/src/test/kotlin/chat/onym/android/group/JoinRequestPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/JoinRequestPayloadTest.kt
@@ -1,0 +1,64 @@
+package chat.onym.android.group
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class JoinRequestPayloadTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun roundtrip_preservesAllFields() {
+        val original = JoinRequestPayload(
+            joinerInboxPublicKey = ByteArray(32) { 0xAA.toByte() },
+            joinerDisplayLabel = "Bob",
+            groupId = ByteArray(32) { 0x42 },
+        )
+        val encoded = json.encodeToString(JoinRequestPayload.serializer(), original)
+        val decoded = json.decodeFromString(JoinRequestPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun snake_case_keys_match_iOS_parity() {
+        // Cross-platform interop pin — iOS will use JSONEncoder with
+        // explicit CodingKeys; the Android side must emit the same
+        // snake_case spelling so a Swift JSONDecoder can pick it up.
+        val payload = JoinRequestPayload(
+            joinerInboxPublicKey = ByteArray(32),
+            joinerDisplayLabel = "Bob",
+            groupId = ByteArray(32),
+        )
+        val obj = json.parseToJsonElement(
+            json.encodeToString(JoinRequestPayload.serializer(), payload),
+        ).jsonObject
+        assertNotNull(obj["joiner_inbox_pub"])
+        assertNotNull(obj["joiner_display_label"])
+        assertNotNull(obj["group_id"])
+        assertEquals("Bob", obj["joiner_display_label"]!!.jsonPrimitive.contentOrNull)
+    }
+
+    @Test
+    fun constructor_rejectsWrongSizedKeys() {
+        assertThrows(IllegalArgumentException::class.java) {
+            JoinRequestPayload(
+                joinerInboxPublicKey = ByteArray(31),
+                joinerDisplayLabel = "x",
+                groupId = ByteArray(32),
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            JoinRequestPayload(
+                joinerInboxPublicKey = ByteArray(32),
+                joinerDisplayLabel = "x",
+                groupId = ByteArray(33),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR-4 of the Level-2 deeplink stack. Stacked on #62. Wires the joiner→sender→joiner round-trip.

**Shared crypto seam**: extracted \`IdentityRepository.decryptSealedEnvelopeWithKey(env, recipientPriv)\` static — both the existing identity-keyed decrypt + the new intro-keyed decrypt share the X25519+AES-GCM core. Existing wrapper unchanged.

**New types**:
- \`JoinRequestPayload\` — joiner's inner plaintext (joinerInboxPubkey + joinerDisplayLabel + groupId echo). iOS-parity snake_case wire format.
- \`JoinRequestSender\` (joiner side) — seal + ship via inbox tag of \`introPub\`.
- \`JoinRequestApprover\` (sender side) — \`start()\` decrypts incoming requests; \`pending: StateFlow<PendingRequest>\` for UI; \`approve(id)\` builds the existing \`GroupInvitationPayload\` from the local \`ChatGroup\` and ships sealed to joiner; \`decline(id)\` drops silently.

## Test plan

- [x] 3 unit tests on \`JoinRequestPayloadTest\` (round-trip, snake_case pin, ctor validation)
- [x] All other unit tests still green
- [ ] Crypto round-trip → androidTest in PR-7's E2E

## Stack

#60 → #61 → #62 → #(this) → ux/share-invite-link (PR-5) → transport/deeplink-intent-filter (PR-6) → ux/joinscreen-completion (PR-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)