### PR TITLE
ux: post-create share-invite link surface (PR-5/7)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -47,4 +47,6 @@ class AppDependencies(
     val makeChatsViewModel: () -> ChatsViewModel,
     /** Settings → Identities — multi-identity management (PR-5). */
     val makeIdentitiesViewModel: () -> chat.onym.android.identity.IdentitiesViewModel,
+    /** Post-create deeplink invite share (deeplink-invite PR-5). */
+    val makeShareInviteViewModel: () -> chat.onym.android.group.ShareInviteViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -427,6 +427,13 @@ class OnymApplication : Application() {
             makeIdentitiesViewModel = {
                 chat.onym.android.identity.IdentitiesViewModel(identity = identityRepository)
             },
+            makeShareInviteViewModel = {
+                chat.onym.android.group.ShareInviteViewModel(
+                    identity = identityRepository,
+                    introducer = chat.onym.android.group.InviteIntroducer(introKeyStore),
+                    groupRepository = groupRepository,
+                )
+            },
         )
     }
 

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -32,7 +32,9 @@ import chat.onym.android.chain.GovernanceType
 import chat.onym.android.chats.ChatsScreen
 import chat.onym.android.chats.ChatsViewModel
 import chat.onym.android.group.CreateGroupViewModel
+import chat.onym.android.group.ShareInviteViewModel
 import chat.onym.android.group.creategroup.CreateGroupScreen
+import chat.onym.android.group.creategroup.ShareInviteScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.search.SearchScreen
@@ -159,6 +161,9 @@ fun RootScreen(dependencies: AppDependencies) {
                     },
                 )
                 vm.onClose = { navController.popBackStack() }
+                vm.onShareInvite = { id ->
+                    navController.navigate("share_invite/$id")
+                }
                 // OnymTheme provides LocalOnymTokens (light or dark
                 // bundle picked off `isSystemInDarkTheme()`) so every
                 // CreateGroup* screen reads the right surface family.
@@ -167,6 +172,19 @@ fun RootScreen(dependencies: AppDependencies) {
                 chat.onym.android.group.OnymTheme {
                     CreateGroupScreen(viewModel = vm)
                 }
+            }
+            composable("share_invite/{groupId}") { entry ->
+                val groupId = entry.arguments?.getString("groupId") ?: return@composable
+                val vm: ShareInviteViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeShareInviteViewModel() }
+                    },
+                )
+                ShareInviteScreen(
+                    groupId = groupId,
+                    viewModel = vm,
+                    onDone = { navController.popBackStack() },
+                )
             }
             composable(Tab.Search.route) {
                 SearchScreen()

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -181,6 +181,11 @@ class CreateGroupViewModel(
      *  dismisses. */
     var onClose: () -> Unit = {}
 
+    /** Tapped "Share invite link" from the Success screen. Host
+     *  navigates to `share_invite/{groupId}` (see [RootScreen]).
+     *  No-op default keeps the VM testable in isolation. */
+    var onShareInvite: (groupId: String) -> Unit = {}
+
     /**
      * Called by the Step1 view when the name TextField gets focus.
      * On the *first* focus we clear the field so the user can type a
@@ -351,6 +356,25 @@ class CreateGroupViewModel(
     fun tappedDone() {
         reset()
         onClose()
+    }
+
+    /**
+     * From the Success screen. Hands the just-created group's hex id
+     * to the host so it can push the share-invite destination, then
+     * resets + closes the create-group flow underneath — back from
+     * the share screen lands on Chats, not on a stale Success
+     * screen. The host is responsible for navigating; the VM only
+     * fans out the id.
+     */
+    fun tappedShareInvite() {
+        val groupId = _state.value.createdGroup?.id ?: return
+        reset()
+        // Pop create-group first, then push share-invite. The
+        // reverse order would land share-invite on top of
+        // create-group, and the subsequent pop would tear it down
+        // immediately — leaving the user on a stale Success.
+        onClose()
+        onShareInvite(groupId)
     }
 
     fun tappedDismissError() {

--- a/app/src/main/kotlin/chat/onym/android/group/ShareInviteViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ShareInviteViewModel.kt
@@ -1,0 +1,84 @@
+package chat.onym.android.group
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.identity.ActiveIdentityProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the post-create "Share invite" surface. Owns one piece of
+ * state — the [State.Ready.link] for the just-minted invite — and
+ * exposes one intent ([mintFor]) to refresh / re-mint.
+ *
+ * Why minting is decoupled from the screen's first composition:
+ * minting is a side effect (writes to [IntroKeyStore]); doing it
+ * in `LaunchedEffect(Unit)` ties it to recomposition timing
+ * (config-change reflows would mint twice). The view-model pulls
+ * the side-effect off the composition tree where it belongs.
+ *
+ * Resolves the [ChatGroup] internally from [groupRepository] given
+ * a hex group id — this lets the navigation host pass a `String`
+ * path arg without having to look the group up itself or thread
+ * the value type through Compose nav arguments.
+ */
+class ShareInviteViewModel(
+    private val identity: ActiveIdentityProvider,
+    private val introducer: InviteIntroducer,
+    private val groupRepository: GroupRepository,
+) : ViewModel() {
+
+    sealed class State {
+        object Idle : State()
+        object Minting : State()
+        data class Ready(val link: String, val groupName: String?) : State()
+        data class Failed(val reason: String) : State()
+    }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    /**
+     * Mint a fresh capability for the group with hex id [groupId] and
+     * surface the share link. Idempotent for repeated taps from the
+     * same screen — re-mints a fresh keypair so each share goes
+     * through a distinct intro slot (per-link revocation friendly).
+     *
+     * If [groupId] does not resolve to a local group (race between
+     * persistence + navigation, or a stale deeplink back into share)
+     * the state flips to [State.Failed] so the UI can render a
+     * message + retry button without crashing.
+     */
+    fun mintFor(groupId: String) {
+        val group = groupRepository.snapshots.value.firstOrNull { it.id == groupId }
+        if (group == null) {
+            _state.value = State.Failed("Group not found on this device")
+            return
+        }
+        val activeIdentityId = identity.currentIdentityId.value
+        if (activeIdentityId == null) {
+            _state.value = State.Failed("No identity selected")
+            return
+        }
+        _state.value = State.Minting
+        viewModelScope.launch {
+            try {
+                val capability = introducer.mint(
+                    ownerIdentityId = activeIdentityId,
+                    groupId = group.groupIdBytes,
+                    groupName = group.name,
+                )
+                _state.value = State.Ready(
+                    link = capability.toAppLink(),
+                    groupName = group.name,
+                )
+            } catch (e: Throwable) {
+                _state.value = State.Failed(
+                    e.message ?: e.javaClass.simpleName,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -863,8 +863,13 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
         Spacer(Modifier.weight(1f))
         FlowFooter {
             OnymPrimaryButton(
-                title = "Done",
+                title = "Share invite link",
                 accent = accent,
+                onClick = viewModel::tappedShareInvite,
+            )
+            Spacer(Modifier.height(6.dp))
+            OnymQuietButton(
+                title = "Done",
                 onClick = viewModel::tappedDone,
             )
         }

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/ShareInviteScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/ShareInviteScreen.kt
@@ -1,0 +1,185 @@
+package chat.onym.android.group.creategroup
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.group.IntroCapability
+import chat.onym.android.group.ShareInviteViewModel
+
+/**
+ * Post-create surface. The just-created group is identified by hex
+ * [groupId]; the VM resolves it from the repository, mints a fresh
+ * deeplink capability, and surfaces the link. The user shares via
+ * the system share sheet, copies it, or skips.
+ *
+ * Mints exactly once per screen entry — re-entry (after Done →
+ * back) re-mints with a fresh intro keypair so the previous share
+ * stays revocable independently.
+ */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+fun ShareInviteScreen(
+    groupId: String,
+    viewModel: ShareInviteViewModel,
+    onDone: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    var copied by remember { mutableStateOf(false) }
+
+    LaunchedEffect(groupId) {
+        viewModel.mintFor(groupId)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Invite") },
+                actions = {
+                    TextButton(onClick = onDone) { Text("Done") }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(24.dp))
+            Icon(
+                Icons.Filled.CheckCircle,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Your group is ready",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Share this link with the people you want to invite. " +
+                    "You'll see and approve each request before they join.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(24.dp))
+
+            when (val s = state) {
+                is ShareInviteViewModel.State.Idle,
+                is ShareInviteViewModel.State.Minting -> {
+                    Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(28.dp).testTag("share_invite.minting"),
+                        )
+                    }
+                }
+
+                is ShareInviteViewModel.State.Ready -> {
+                    Button(
+                        onClick = {
+                            val sendIntent = Intent().apply {
+                                action = Intent.ACTION_SEND
+                                putExtra(
+                                    Intent.EXTRA_TEXT,
+                                    IntroCapability.shareText(s.link, s.groupName),
+                                )
+                                type = "text/plain"
+                            }
+                            context.startActivity(
+                                Intent.createChooser(sendIntent, "Share invite link"),
+                            )
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("share_invite.share_button"),
+                    ) {
+                        Icon(
+                            Icons.Default.Share,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.size(8.dp))
+                        Text("Share invite link")
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedButton(
+                        onClick = {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
+                                as ClipboardManager
+                            clipboard.setPrimaryClip(ClipData.newPlainText("Invite link", s.link))
+                            copied = true
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag("share_invite.copy_button"),
+                    ) {
+                        Text(if (copied) "Copied!" else "Copy invite link")
+                    }
+                }
+
+                is ShareInviteViewModel.State.Failed -> {
+                    Text(
+                        text = "Couldn't generate an invite: ${s.reason}",
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Button(onClick = { viewModel.mintFor(groupId) }) { Text("Retry") }
+                }
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            TextButton(onClick = onDone) {
+                Text(
+                    "I'll do this later",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -2,6 +2,8 @@
 
 package chat.onym.android.group
 
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -331,6 +333,48 @@ class CreateGroupViewModelTest {
     }
 
     @Test
+    fun tappedShareInvite_handsOffGroupIdAndClosesFlow() = runTest {
+        val createdGroupId = "ab".repeat(32)
+        val vm = makeViewModelReturning(makeFakeGroup(id = createdGroupId))
+        var closedCount = 0
+        var sharedId: String? = null
+        vm.onClose = { closedCount++ }
+        vm.onShareInvite = { sharedId = it }
+
+        vm.submit()
+        // Sanity: pipeline succeeded.
+        assertNotNull(vm.state.value.createdGroup)
+
+        vm.tappedShareInvite()
+
+        // Order is "close → share" so the host can pop the create
+        // screen first then push share-invite. Both happen.
+        assertEquals(1, closedCount)
+        assertEquals(createdGroupId, sharedId)
+        // State is reset back to a fresh Step1 — re-entering the
+        // create flow doesn't carry the prior group along.
+        val state = vm.state.value
+        assertEquals(CreateGroupRoute.Step1, state.route)
+        assertNull(state.createdGroup)
+    }
+
+    @Test
+    fun tappedShareInvite_isNoOpWhenNoGroupCreated() = runTest {
+        val vm = makeViewModel()
+        var closedCount = 0
+        var sharedId: String? = null
+        vm.onClose = { closedCount++ }
+        vm.onShareInvite = { sharedId = it }
+
+        vm.tappedShareInvite()
+
+        // Without a createdGroup the call is a no-op — protects
+        // against a stray tap before submit() resolves.
+        assertEquals(0, closedCount)
+        assertNull(sharedId)
+    }
+
+    @Test
     fun cancelFromError_closesAndResets() = runTest {
         val vm = makeViewModel()
         var closedCount = 0
@@ -377,5 +421,30 @@ class CreateGroupViewModelTest {
         createGroup = { _, _, _, _ ->
             error("createGroup must not be invoked from VM tests")
         },
+    )
+
+    /** For tests that need a populated [CreateGroupState.createdGroup].
+     *  The lambda ignores its inputs and returns a canned [ChatGroup]
+     *  so the VM can be driven through `submit()` without standing up
+     *  the real interactor. */
+    private fun makeViewModelReturning(group: ChatGroup): CreateGroupViewModel =
+        CreateGroupViewModel(
+            createGroup = { _, _, _, _ -> group },
+        )
+
+    private fun makeFakeGroup(id: String): ChatGroup = ChatGroup(
+        id = id,
+        name = "Fake group",
+        groupSecret = ByteArray(32) { 0x11 },
+        createdAtMillis = 1_700_000_000_000L,
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32) { 0x22 },
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = null,
+        isPublishedOnChain = false,
+        ownerIdentityId = "test-identity",
     )
 }

--- a/app/src/test/kotlin/chat/onym/android/group/ShareInviteViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ShareInviteViewModelTest.kt
@@ -1,0 +1,170 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.support.FakeActiveIdentityProvider
+import chat.onym.android.support.InMemoryGroupStore
+import chat.onym.android.support.InMemoryIntroKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * State-machine tests for [ShareInviteViewModel] — the post-create
+ * deeplink-share surface. Verifies:
+ *
+ *  - happy path: known group + active identity → [State.Ready] with
+ *    a parseable [IntroCapability] link
+ *  - missing group → [State.Failed] (e.g. host raced ahead before
+ *    the persistence layer flushed)
+ *  - missing identity → [State.Failed]
+ *  - re-mint produces a fresh keypair (intro slots are
+ *    independently revocable per share)
+ */
+class ShareInviteViewModelTest {
+
+    // Share the scheduler with `runTest` so dispatches onto Main
+    // (where `viewModelScope.launch` lands) get drained by the
+    // test scope's `advanceUntilIdle`. Using a freshly-constructed
+    // `UnconfinedTestDispatcher()` here would put Main on a
+    // separate scheduler and the launched body would never run.
+    private val mainDispatcher = UnconfinedTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(mainDispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun mintFor_knownGroupAndIdentity_emitsReadyWithParseableLink() = runTest(mainDispatcher.scheduler) {
+        val owner = IdentityId("alice")
+        val group = makeGroup(id = "ab".repeat(32), owner = owner)
+        val (vm, _) = harness(initialActive = owner, seed = listOf(group))
+
+        vm.mintFor(group.id)
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue("expected Ready, got $state", state is ShareInviteViewModel.State.Ready)
+        val ready = state as ShareInviteViewModel.State.Ready
+        // Decode round-trips back to a capability for the same group.
+        val cap = IntroCapability.fromLink(ready.link)
+        assertNotNull(cap)
+        assertEquals(group.name, ready.groupName)
+        assertEquals(group.name, cap!!.groupName)
+        assertEquals(group.id, cap.groupId.joinToString("") { "%02x".format(it) })
+    }
+
+    @Test
+    fun mintFor_unknownGroup_failsWithoutTouchingStore() = runTest(mainDispatcher.scheduler) {
+        val owner = IdentityId("alice")
+        val (vm, store) = harness(initialActive = owner, seed = emptyList())
+
+        vm.mintFor("ab".repeat(32))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue("expected Failed, got $state", state is ShareInviteViewModel.State.Failed)
+        // No keypair was persisted for an unknown group.
+        assertEquals(0, store.listForOwner(owner).size)
+    }
+
+    @Test
+    fun mintFor_noActiveIdentity_failsBeforeMinting() = runTest(mainDispatcher.scheduler) {
+        val owner = IdentityId("alice")
+        val group = makeGroup(id = "ab".repeat(32), owner = owner)
+        // Active identity is null — VM should bail before touching
+        // the introducer.
+        val (vm, store) = harness(initialActive = null, seed = listOf(group))
+
+        vm.mintFor(group.id)
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertTrue("expected Failed, got $state", state is ShareInviteViewModel.State.Failed)
+        assertEquals(0, store.listForOwner(owner).size)
+    }
+
+    @Test
+    fun mintFor_calledTwice_mintsTwoIndependentKeypairs() = runTest(mainDispatcher.scheduler) {
+        val owner = IdentityId("alice")
+        val group = makeGroup(id = "ab".repeat(32), owner = owner)
+        val (vm, store) = harness(initialActive = owner, seed = listOf(group))
+
+        vm.mintFor(group.id)
+        advanceUntilIdle()
+        val first = (vm.state.value as ShareInviteViewModel.State.Ready).link
+        vm.mintFor(group.id)
+        advanceUntilIdle()
+        val second = (vm.state.value as ShareInviteViewModel.State.Ready).link
+
+        // Per-link revocation depends on this — re-shares cannot
+        // collapse to the same intro slot or revoking one would kill
+        // the other.
+        assertTrue("two shares should produce different links", first != second)
+        assertEquals(2, store.listForOwner(owner).size)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun TestScope.harness(
+        initialActive: IdentityId?,
+        seed: List<ChatGroup>,
+    ): Pair<ShareInviteViewModel, InMemoryIntroKeyStore> {
+        val store = InMemoryGroupStore()
+        // preload is suspend; runBlocking inside a test scope is
+        // fine — no foreign coroutines to coordinate with.
+        kotlinx.coroutines.runBlocking { store.preload(seed) }
+        val active = FakeActiveIdentityProvider(initial = initialActive)
+        val groupRepo = GroupRepository(
+            store = store,
+            identity = active,
+            scope = this,
+        )
+        kotlinx.coroutines.runBlocking { groupRepo.reload() }
+        val introKeyStore = InMemoryIntroKeyStore()
+        val vm = ShareInviteViewModel(
+            identity = active,
+            // Pin the introducer's IO dispatcher to the test
+            // scheduler. Otherwise `withContext(Dispatchers.IO)`
+            // dispatches onto the real I/O pool and the resume back
+            // to Main races test teardown — visible as
+            // CoroutinesInternalError reported on whichever test
+            // happens to be running when the leaked continuation
+            // resumes.
+            introducer = InviteIntroducer(
+                store = introKeyStore,
+                ioDispatcher = mainDispatcher,
+            ),
+            groupRepository = groupRepo,
+        )
+        return vm to introKeyStore
+    }
+
+    private fun makeGroup(id: String, owner: IdentityId): ChatGroup = ChatGroup(
+        id = id,
+        name = "Test group",
+        groupSecret = ByteArray(32) { 0x11 },
+        createdAtMillis = 1_700_000_000_000L,
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32) { 0x22 },
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = null,
+        isPublishedOnChain = false,
+        ownerIdentityId = owner.value,
+    )
+}


### PR DESCRIPTION
Stacked on PR-4 (#63). Wires the post-create surface where the
inviter mints a deeplink + shares it via the system share sheet.
PR-6 lands the Manifest intent-filter; PR-7 lands the JoinScreen.

## Flow

```
Step1 → Step2 → Creating → Success
                            │
                     [Share invite link] ─→ share_invite/{groupId}
                            │
                        [ Done ]                ↑
                                                │
                                        mint capability +
                                        system share / copy
```

- Success screen footer: primary "Share invite link" CTA on top,
  quiet "Done" underneath. Defaults the most-likely next action
  to share — but Done remains a one-tap escape for users who
  invited everyone via paste-by-key already.
- Tapping share pops Create from the back stack first then
  pushes share_invite — so back from share lands on Chats, not
  on a stale Success. Order matters: reverse would push then
  immediately pop.

## ShareInviteViewModel

- Resolves the group from `GroupRepository.snapshots` by hex
  id (path arg). Failed lookup → `State.Failed("Group not
  found")` rather than a crash — protects against the host
  racing past the persistence flush.
- Each `mintFor()` mints a fresh X25519 keypair via
  `InviteIntroducer`, so re-shares produce independently
  revocable intro slots (one leaked link only burns its own
  slot).
- Depends on `ActiveIdentityProvider`, not the full
  `IdentityRepository` — only needs `currentIdentityId.value`,
  testable with `FakeActiveIdentityProvider`.

## ShareInviteScreen

- Material 3 Scaffold with TopAppBar Done action. Mints once
  per entry (`LaunchedEffect(groupId)`), surfaces a system
  share sheet (`Intent.ACTION_SEND` with
  `IntroCapability.shareText`) and a clipboard copy fallback.
  Failed state shows reason + Retry. "I'll do this later"
  quiet button at bottom — same destination as Done.

## Tests

- 4 unit cases on `ShareInviteViewModelTest` (happy
  parseable-link, unknown-group fail, no-active-identity fail,
  re-mint produces distinct intro slots). Pin
  `InviteIntroducer.ioDispatcher` to the test scheduler so the
  `withContext(IO)` switch doesn't leak past test boundaries.
- 2 cases on `CreateGroupViewModelTest` covering
  `tappedShareInvite` (close-then-share order, no-op when
  no `createdGroup` yet).

## Test plan

- [ ] CreateGroup → Success: "Share invite link" primary, "Done" quiet
- [ ] Tap Share → share-invite screen, link mints, share sheet opens
- [ ] Copy → clipboard contains the URL; label flips to "Copied!"
- [ ] Done from share-invite returns to Chats (not Success)
- [ ] Re-enter create-group: the prior Success state isn't carried