### PR TITLE
transport: deeplink intent-filter + URL parsing (PR-6/7)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,39 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!--
+                Universal "App Link" entry point for Level-2 invite
+                deeplinks (PR-6/7 in the deeplink-invite stack).
+
+                `autoVerify="true"`: Android fetches
+                https://onym.chat/.well-known/assetlinks.json on
+                install; if the SHA-256 cert fingerprint matches our
+                signing cert (40:AD:4E:78:…:CAD), the system opens
+                the link directly in onym-android without the
+                disambiguator chooser. assetlinks.json is already
+                served (verified live) — no server change needed.
+
+                Custom-scheme `onym://join` filter is the fallback for
+                pre-verification states (e.g., install-via-sideload
+                before assetlinks fetch completes) and for direct
+                test invocations from adb / shell.
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                      android:host="onym.chat"
+                      android:pathPrefix="/join" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="onym" android:host="join" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/app/src/main/kotlin/chat/onym/android/MainActivity.kt
+++ b/app/src/main/kotlin/chat/onym/android/MainActivity.kt
@@ -1,11 +1,21 @@
 package chat.onym.android
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.core.util.Consumer
 import androidx.fragment.app.FragmentActivity
+import chat.onym.android.group.IntroCapability
+import chat.onym.android.transport.DeeplinkCapture
 
 /**
  * Sole entry point. Mounts [RootScreen] as the content; the recovery-
@@ -31,6 +41,29 @@ import androidx.fragment.app.FragmentActivity
  * [OnymApplication.dependencies]. This Activity is purely a host
  * surface; the only thing it knows about the rest of the app is
  * that there is an [AppDependencies] to forward into [RootScreen].
+ *
+ * ## Deeplink intake (PR-6 of the deeplink-invite stack)
+ *
+ * Captures `https://onym.chat/join?c=…` (App Link, autoVerify=true)
+ * and `onym://join?c=…` (custom-scheme fallback) intents and threads
+ * the decoded [IntroCapability] into [RootScreen] as a one-shot
+ * `pendingCapability`. RootScreen consumes it (navigates to the
+ * join destination) and acks via the `onPendingCapabilityHandled`
+ * callback, which clears the slot so a back-navigation doesn't
+ * re-trigger the same capability.
+ *
+ *  - **Cold start**: the launching intent is `getIntent()`. Captured
+ *    once via `LaunchedEffect(Unit)` in the composable so the
+ *    capability is available the first time RootScreen composes.
+ *  - **Warm start**: subsequent intents arrive via
+ *    [addOnNewIntentListener]. The listener is registered/unregistered
+ *    inside `DisposableEffect` so it lives exactly as long as the
+ *    setContent composition.
+ *
+ * Captured but unhandled capabilities are NOT lost on configuration
+ * change — the `mutableStateOf` slot survives recomposition; only
+ * the `onPendingCapabilityHandled` callback (after RootScreen
+ * navigates) clears it.
  */
 class MainActivity : FragmentActivity() {
 
@@ -43,8 +76,40 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         val dependencies = (application as OnymApplication).dependencies
         setContent {
+            var pending by remember { mutableStateOf<IntroCapability?>(null) }
+
+            // Cold-start intake. `intent` is the Activity's launch
+            // intent. Re-running this effect on Activity recreation
+            // is intentional — `setIntent(...)` keeps the data URI
+            // around, so the capability is recovered after
+            // configuration change too.
+            LaunchedEffect(Unit) {
+                DeeplinkCapture.introCapabilityFromIntent(intent)?.let { pending = it }
+            }
+
+            // Warm-start intake. The OS calls `onNewIntent` on the
+            // already-running Activity instead of restarting it
+            // (because the launchMode default `standard` re-uses
+            // the existing Activity for `singleTask`-equivalent
+            // behavior in this app shell). The Compose-friendly
+            // way to listen is via `addOnNewIntentListener` —
+            // installed/uninstalled with the composition.
+            DisposableEffect(Unit) {
+                val listener = Consumer<Intent> { newIntent ->
+                    DeeplinkCapture.introCapabilityFromIntent(newIntent)?.let {
+                        pending = it
+                    }
+                }
+                addOnNewIntentListener(listener)
+                onDispose { removeOnNewIntentListener(listener) }
+            }
+
             MaterialTheme {
-                RootScreen(dependencies = dependencies)
+                RootScreen(
+                    dependencies = dependencies,
+                    pendingCapability = pending,
+                    onPendingCapabilityHandled = { pending = null },
+                )
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -32,6 +33,8 @@ import chat.onym.android.chain.GovernanceType
 import chat.onym.android.chats.ChatsScreen
 import chat.onym.android.chats.ChatsViewModel
 import chat.onym.android.group.CreateGroupViewModel
+import chat.onym.android.group.IntroCapability
+import chat.onym.android.group.JoinInviteCapturedPlaceholder
 import chat.onym.android.group.ShareInviteViewModel
 import chat.onym.android.group.creategroup.CreateGroupScreen
 import chat.onym.android.group.creategroup.ShareInviteScreen
@@ -76,10 +79,32 @@ import chat.onym.android.settings.SettingsScreen
  * composable in this graph holds a reference to a repository.
  */
 @Composable
-fun RootScreen(dependencies: AppDependencies) {
+fun RootScreen(
+    dependencies: AppDependencies,
+    /** Set by [MainActivity] when an `https://onym.chat/join?c=…` or
+     *  `onym://join?c=…` intent arrives — cold start or via
+     *  `addOnNewIntentListener`. RootScreen navigates to the join
+     *  destination when this flips non-null. */
+    pendingCapability: IntroCapability? = null,
+    /** Called immediately after RootScreen has issued the navigation
+     *  for [pendingCapability]. Lets the host clear its slot so a
+     *  later back-navigation doesn't re-fire the same capability. */
+    onPendingCapabilityHandled: () -> Unit = {},
+) {
     val navController = rememberNavController()
     val currentEntry by navController.currentBackStackEntryAsState()
     val currentRoute = currentEntry?.destination?.route
+
+    // Forward an inbound deeplink capability to the join destination.
+    // The capability's encoded form is short and URL-safe — embed it
+    // as a path arg so the target composable can decode it without
+    // touching shared state. Acks the host immediately after the
+    // navigate() call (no need to wait for the destination to render).
+    LaunchedEffect(pendingCapability) {
+        val cap = pendingCapability ?: return@LaunchedEffect
+        navController.navigate("join_invite/${cap.encode()}")
+        onPendingCapabilityHandled()
+    }
 
     Scaffold(
         bottomBar = {
@@ -184,6 +209,30 @@ fun RootScreen(dependencies: AppDependencies) {
                     groupId = groupId,
                     viewModel = vm,
                     onDone = { navController.popBackStack() },
+                )
+            }
+            // Inbound deeplink destination. Path arg carries the
+            // url-safe-base64-of-JSON capability — re-decoded here
+            // (rather than threading the value type through nav args)
+            // so the screen survives process death: the system
+            // rebuilds the back stack from the saved route strings,
+            // and re-decoding from the path arg restores the same
+            // capability without round-tripping through a Parcelable.
+            //
+            // Placeholder body in PR-6 — PR-7 swaps in the real
+            // JoinScreen + JoinViewModel that calls
+            // JoinRequestSender.send(...).
+            composable("join_invite/{capability}") { entry ->
+                val encoded = entry.arguments?.getString("capability")
+                    ?: return@composable
+                val capability = try {
+                    IntroCapability.decode(encoded)
+                } catch (_: Throwable) {
+                    return@composable
+                }
+                JoinInviteCapturedPlaceholder(
+                    capability = capability,
+                    onBackClick = { navController.popBackStack() },
                 )
             }
             composable(Tab.Search.route) {

--- a/app/src/main/kotlin/chat/onym/android/group/JoinInviteCapturedPlaceholder.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinInviteCapturedPlaceholder.kt
@@ -1,0 +1,110 @@
+package chat.onym.android.group
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Placeholder destination for inbound `https://onym.chat/join?c=…`
+ * deeplinks. **PR-7 will replace this** with `JoinScreen` +
+ * `JoinViewModel` that ships the actual join request via
+ * [JoinRequestSender] and watches for the sealed invitation to
+ * arrive. PR-6's job is just to prove the intent-filter wiring
+ * works end-to-end (tap a link → land on a screen that knows the
+ * capability).
+ *
+ * Renders the inviter's intro pubkey hex prefix + group_id hex
+ * prefix so a manual tester can confirm the right capability was
+ * decoded from the URL. No interaction wired beyond Back.
+ */
+@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@Composable
+fun JoinInviteCapturedPlaceholder(
+    capability: IntroCapability,
+    onBackClick: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Join invite") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Icon(
+                Icons.Filled.Link,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = capability.groupName ?: "Invite to join a chat",
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = "Captured from deeplink. PR-7 wires the actual " +
+                    "send-request UI; this screen is a stand-in so the " +
+                    "intent-filter wiring can be exercised manually.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(24.dp))
+            // Hex prefixes — short enough to read off the screen but
+            // long enough to disambiguate two captures during testing.
+            Text(
+                text = "intro_pub: ${capability.introPublicKey.toHexPrefix()}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "group_id: ${capability.groupId.toHexPrefix()}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(24.dp))
+            OutlinedButton(
+                onClick = onBackClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Back to chats")
+            }
+        }
+    }
+}
+
+private fun ByteArray.toHexPrefix(): String =
+    take(8).joinToString("") { "%02x".format(it.toInt() and 0xFF) } + "…"

--- a/app/src/main/kotlin/chat/onym/android/transport/DeeplinkCapture.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/DeeplinkCapture.kt
@@ -1,0 +1,64 @@
+package chat.onym.android.transport
+
+import android.content.Intent
+import chat.onym.android.group.IntroCapability
+import java.net.URI
+
+/**
+ * Glue between Android `Intent`s and the platform-agnostic
+ * [IntroCapability.fromLink] decoder. Lives in `transport/` so the
+ * `group/` package stays Android-type-free (kotlinx.serialization +
+ * java.net only — testable on plain JVM).
+ *
+ * Two functions:
+ *
+ *  - [introCapabilityFromUri] is pure (`String?` in, `IntroCapability?`
+ *    out) and unit-testable on JVM. Holds the **scheme/host
+ *    allowlist** — the manifest intent-filters already gate inbound
+ *    intents to `https://onym.chat/join*` and `onym://join`, but a
+ *    misconfigured launcher / share target could still surface other
+ *    URIs to MainActivity. We re-check here as defense in depth and
+ *    so the pre-flight reasoning lives in code, not in XML.
+ *
+ *  - [introCapabilityFromIntent] is the one-line Activity adapter.
+ *    Called from MainActivity on cold start (`onCreate`) and warm
+ *    start (`addOnNewIntentListener`).
+ *
+ * Returns `null` for non-deeplink intents so callers can fall through
+ * to normal app launch without special-casing.
+ */
+internal object DeeplinkCapture {
+
+    /** Allowlist of `(scheme, host)` pairs that may carry an
+     *  [IntroCapability]. Mirrors the intent-filter shape declared
+     *  in `AndroidManifest.xml`; keep the two in lockstep. */
+    private val ALLOWED: Set<Pair<String, String>> = setOf(
+        "https" to "onym.chat",
+        "onym" to "join",
+    )
+
+    /** Extract a capability from a raw URI string. Returns `null` for:
+     *
+     *  - non-onym URIs (host/scheme not on the allowlist),
+     *  - URIs that parse but have no `c=` query parameter,
+     *  - URIs with a malformed `c=` payload (bad base64, bad JSON,
+     *    wrong byte sizes).
+     *
+     *  Pure JVM — no `android.net.Uri` dependency, so this can be
+     *  unit-tested without Robolectric. */
+    fun introCapabilityFromUri(rawUri: String?): IntroCapability? {
+        if (rawUri.isNullOrEmpty()) return null
+        val parsed = try { URI(rawUri) } catch (_: Throwable) { return null }
+        val scheme = parsed.scheme?.lowercase() ?: return null
+        val host = parsed.host?.lowercase() ?: return null
+        if (scheme to host !in ALLOWED) return null
+        return try { IntroCapability.fromLink(rawUri) } catch (_: Throwable) { null }
+    }
+
+    /** Activity adapter — pulls `intent.dataString` out and delegates
+     *  to [introCapabilityFromUri]. Tolerates `null` intent (the case
+     *  where the Activity was started without one, e.g. from the app
+     *  launcher). */
+    fun introCapabilityFromIntent(intent: Intent?): IntroCapability? =
+        introCapabilityFromUri(intent?.dataString)
+}

--- a/app/src/test/kotlin/chat/onym/android/transport/DeeplinkCaptureTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/transport/DeeplinkCaptureTest.kt
@@ -1,0 +1,106 @@
+package chat.onym.android.transport
+
+import chat.onym.android.group.IntroCapability
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [DeeplinkCapture.introCapabilityFromUri]. The
+ * `Intent` overload is one line of glue and trusted to delegate
+ * correctly; the host/scheme allowlist + `IntroCapability.fromLink`
+ * call live here and are exercised via the `String?` form.
+ *
+ * Pin the allowlist semantics:
+ *  - `https://onym.chat/join?c=…` → decoded
+ *  - `onym://join?c=…` → decoded
+ *  - any other scheme/host → null (the manifest is the primary gate;
+ *    this is defense in depth)
+ *  - malformed payload → null (`fromLink`'s thrown
+ *    `InvalidIntroCapability` is swallowed; the activity should
+ *    no-op rather than crash on a dud intent)
+ */
+class DeeplinkCaptureTest {
+
+    private val introPub = ByteArray(32) { it.toByte() }
+    private val groupId = ByteArray(32) { (0x40 + it).toByte() }
+
+    private fun fixture(name: String? = null): IntroCapability =
+        IntroCapability(introPub, groupId, name)
+
+    @Test
+    fun universalLink_decodes() {
+        val link = fixture(name = "Test").toAppLink()
+        val decoded = DeeplinkCapture.introCapabilityFromUri(link)
+        assertNotNull(decoded)
+        assertArrayEquals(introPub, decoded!!.introPublicKey)
+        assertArrayEquals(groupId, decoded.groupId)
+        assertEquals("Test", decoded.groupName)
+    }
+
+    @Test
+    fun customScheme_decodes() {
+        val link = fixture().toCustomSchemeLink()
+        val decoded = DeeplinkCapture.introCapabilityFromUri(link)
+        assertNotNull(decoded)
+        assertArrayEquals(introPub, decoded!!.introPublicKey)
+        assertNull(decoded.groupName)
+    }
+
+    @Test
+    fun foreignHost_returnsNull() {
+        // Same path + valid `c=` payload but the host isn't ours.
+        // A malicious app could construct this and ACTION_VIEW it
+        // at us if our intent-filter were too loose; the in-code
+        // allowlist makes the boundary explicit.
+        val good = fixture().encode()
+        val link = "https://example.com/join?c=$good"
+        assertNull(DeeplinkCapture.introCapabilityFromUri(link))
+    }
+
+    @Test
+    fun foreignScheme_returnsNull() {
+        val good = fixture().encode()
+        val link = "ftp://onym.chat/join?c=$good"
+        assertNull(DeeplinkCapture.introCapabilityFromUri(link))
+    }
+
+    @Test
+    fun nullOrEmpty_returnsNull() {
+        assertNull(DeeplinkCapture.introCapabilityFromUri(null))
+        assertNull(DeeplinkCapture.introCapabilityFromUri(""))
+    }
+
+    @Test
+    fun malformedUri_returnsNull() {
+        assertNull(DeeplinkCapture.introCapabilityFromUri("not a uri"))
+    }
+
+    @Test
+    fun knownHostMissingC_returnsNull() {
+        assertNull(DeeplinkCapture.introCapabilityFromUri("https://onym.chat/join"))
+        assertNull(DeeplinkCapture.introCapabilityFromUri("onym://join"))
+    }
+
+    @Test
+    fun knownHostBadCPayload_returnsNull() {
+        // Allowed scheme/host, but the `c` value is not valid base64 +
+        // the JSON payload doesn't decode. `fromLink` throws
+        // InvalidIntroCapability; we swallow → null so the activity
+        // doesn't crash on a bad share.
+        assertNull(DeeplinkCapture.introCapabilityFromUri("https://onym.chat/join?c=not-base64!!!"))
+    }
+
+    @Test
+    fun caseInsensitiveSchemeAndHost_decodes() {
+        // RFC 3986: scheme + host are case-insensitive. `Uri.parse`
+        // lowercases the scheme but preserves host case; our
+        // allowlist normalizes both. Build a deliberately mixed-case
+        // form to pin the behavior.
+        val good = fixture().encode()
+        val link = "HTTPS://Onym.Chat/join?c=$good"
+        assertNotNull(DeeplinkCapture.introCapabilityFromUri(link))
+    }
+}


### PR DESCRIPTION
Stacked on PR-5 (#64). Captures inbound \`https://onym.chat/join?c=…\`
(App Link) and \`onym://join?c=…\` (custom-scheme fallback) intents,
decodes them to \`IntroCapability\`, and routes the user to a join
destination. PR-7 will swap the placeholder for the real
JoinScreen + JoinViewModel.

## AndroidManifest

- App Link intent-filter: scheme=https, host=onym.chat,
  pathPrefix=/join, autoVerify=true. Android fetches
  \`https://onym.chat/.well-known/assetlinks.json\` on install — it
  is already served (\`chat.onym.android\` package, signing-cert
  SHA-256 \`40:AD:4E:78:…:CAD\`) so no server change is needed and
  the disambiguator chooser is skipped on verified installs.
- Custom-scheme fallback: \`onym://join\`. Used pre-verification
  (sideload installs) and for adb test invocation.

## DeeplinkCapture (new)

Pure-JVM \`introCapabilityFromUri(rawUri)\` holding the scheme/host
allowlist as defense in depth on top of the manifest. Swallows
\`InvalidIntroCapability\` → null so a malformed \`c=\` payload
no-ops instead of crashing.

## MainActivity

Cold-start intake via \`LaunchedEffect(Unit)\` reading \`intent\`;
warm-start intake via \`addOnNewIntentListener\` registered with
\`DisposableEffect\`. Pending capability hoisted as
\`mutableStateOf\` and threaded into RootScreen with an ack
callback to clear the slot once navigation fires.

## RootScreen

\`LaunchedEffect(pendingCapability)\` navigates to
\`join_invite/{capability}\` (encoded form embedded as path arg so
the back stack survives process death without a Parcelable
round-trip).

## Placeholder

\`JoinInviteCapturedPlaceholder\` renders the inviter's group_name
+ intro_pub/group_id hex prefixes — temporary; PR-7 deletes it
and routes to the real \`JoinScreen\`.

## Tests

9 unit cases on \`DeeplinkCaptureTest\`: universal-link decode,
custom-scheme decode, foreign-host rejection, foreign-scheme
rejection, null/empty input, malformed URI, known-host-missing-\`c\`,
known-host-bad-\`c\`, mixed-case scheme/host normalization.

## Test plan

- [ ] Build + install: \`./gradlew :app:installDebug\`
- [ ] \`adb shell am start -W -a android.intent.action.VIEW -d "onym://join?c=<known-good>"\` opens the placeholder with the right hex prefixes
- [ ] \`adb shell am start -W -a android.intent.action.VIEW -d "https://onym.chat/join?c=<known-good>"\` opens the placeholder (or the disambiguator chooser pre-verification)
- [ ] After install, \`adb shell pm get-app-links chat.onym.android\` reports onym.chat as \`verified\`
- [ ] Tap a link from Gmail / SMS opens onym-android, not the browser
- [ ] Cold-start (app not running) and warm-start (app already in recents) both surface the placeholder