### PR TITLE
inbox: per-identity decryption routing

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
@@ -87,7 +87,7 @@ class IdentityRepositoryInvitationDecryptTest {
             payload = payload,
             recipientX25519Pubkey = identity.inboxPublicKey,
         )
-        val plaintext = repo.decryptInvitation(envelope)
+        val plaintext = repo.decryptInvitation(envelope, asIdentity = repo.currentIdentityId.value!!)
         assertArrayEquals(payload, plaintext)
     }
 
@@ -102,7 +102,7 @@ class IdentityRepositoryInvitationDecryptTest {
             recipientX25519Pubkey = identity.inboxPublicKey,
             senderEd25519Private = sender,
         )
-        val plaintext = repo.decryptInvitation(envelope)
+        val plaintext = repo.decryptInvitation(envelope, asIdentity = repo.currentIdentityId.value!!)
         assertArrayEquals(payload, plaintext)
     }
 
@@ -112,7 +112,7 @@ class IdentityRepositoryInvitationDecryptTest {
     fun decrypt_malformedJson_throwsMalformedEnvelope() = runBlocking {
         val garbage = "not really json {{".toByteArray()
         assertThrows(InvitationDecryptError.MalformedEnvelope::class.java) {
-            runBlocking { repo.decryptInvitation(garbage) }
+            runBlocking { repo.decryptInvitation(garbage, asIdentity = repo.currentIdentityId.value!!) }
         }
         Unit
     }
@@ -130,7 +130,7 @@ class IdentityRepositoryInvitationDecryptTest {
             }
         """.trimIndent().toByteArray()
         val thrown = assertThrows(InvitationDecryptError.UnsupportedScheme::class.java) {
-            runBlocking { repo.decryptInvitation(bad) }
+            runBlocking { repo.decryptInvitation(bad, asIdentity = repo.currentIdentityId.value!!) }
         }
         assertEquals("aes-128-cbc-v0", thrown.scheme)
         Unit
@@ -148,7 +148,7 @@ class IdentityRepositoryInvitationDecryptTest {
             }
         """.trimIndent().toByteArray()
         val thrown = assertThrows(InvitationDecryptError.MissingEphemeralKey::class.java) {
-            runBlocking { repo.decryptInvitation(bad) }
+            runBlocking { repo.decryptInvitation(bad, asIdentity = repo.currentIdentityId.value!!) }
         }
         assertSame(InvitationDecryptError.MissingEphemeralKey, thrown)
         Unit
@@ -173,7 +173,7 @@ class IdentityRepositoryInvitationDecryptTest {
             .encodeToString(SealedEnvelope.serializer(), tampered)
             .toByteArray()
         val thrown = assertThrows(InvitationDecryptError.SignatureFailed::class.java) {
-            runBlocking { repo.decryptInvitation(bytes) }
+            runBlocking { repo.decryptInvitation(bytes, asIdentity = repo.currentIdentityId.value!!) }
         }
         assertSame(InvitationDecryptError.SignatureFailed, thrown)
         Unit
@@ -195,7 +195,7 @@ class IdentityRepositoryInvitationDecryptTest {
             .encodeToString(SealedEnvelope.serializer(), tampered)
             .toByteArray()
         assertThrows(InvitationDecryptError.DecryptionFailed::class.java) {
-            runBlocking { repo.decryptInvitation(bytes) }
+            runBlocking { repo.decryptInvitation(bytes, asIdentity = repo.currentIdentityId.value!!) }
         }
         Unit
     }
@@ -211,7 +211,7 @@ class IdentityRepositoryInvitationDecryptTest {
             recipientX25519Pubkey = wellFormedX25519Pubkey(otherInbox),
         )
         assertThrows(InvitationDecryptError.DecryptionFailed::class.java) {
-            runBlocking { repo.decryptInvitation(envelope) }
+            runBlocking { repo.decryptInvitation(envelope, asIdentity = repo.currentIdentityId.value!!) }
         }
         Unit
     }
@@ -225,7 +225,7 @@ class IdentityRepositoryInvitationDecryptTest {
         )
         repo.wipe()
         val thrown = assertThrows(InvitationDecryptError.IdentityNotLoaded::class.java) {
-            runBlocking { repo.decryptInvitation(envelope) }
+            runBlocking { repo.decryptInvitation(envelope, asIdentity = repo.currentIdentityId.value!!) }
         }
         assertSame(InvitationDecryptError.IdentityNotLoaded, thrown)
         Unit

--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositorySealInvitationTest.kt
@@ -91,7 +91,7 @@ class IdentityRepositorySealInvitationTest {
             payload = plaintext,
             recipientInboxPublicKey = recipientIdentity.inboxPublicKey,
         )
-        val decrypted = recipient.decryptInvitation(sealed)
+        val decrypted = recipient.decryptInvitation(sealed, asIdentity = recipient.currentIdentityId.value!!)
         assertArrayEquals(plaintext, decrypted)
     }
 

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -297,13 +297,20 @@ class OnymApplication : Application() {
         // connects on first use via `NostrInboxTransport`).
         val inboxTransport = NostrInboxTransport(signerProvider = nostrSignerProvider)
 
-        // Multi-identity inbox fan-out (PR-4). Subscribes to every
-        // identity's inbox tag concurrently so messages targeted at
-        // a non-active identity still land on disk. Resubscribes
-        // wholesale when the identities list changes (add / remove).
+        // Multi-identity inbox fan-out (PR-4) + per-identity
+        // decryption routing (PR-6). Subscribes to every identity's
+        // inbox tag concurrently so messages targeted at a
+        // non-active identity still land on disk; each persisted
+        // record carries its `ownerIdentityId` so the decrypt path
+        // routes to the right X25519 private key when the user
+        // surfaces the envelope. Resubscribes wholesale when the
+        // identities list changes (add / remove).
         val invitationsRepository = chat.onym.android.inbox.IncomingInvitationsRepository(
             store = chat.onym.android.persistence.InMemoryInvitationStore(),
+            identity = identityRepository,
+            scope = applicationScope,
         )
+        invitationsRepository.start()
         val invitationsInteractor = chat.onym.android.inbox.IncomingInvitationsInteractor(
             inboxTransport = inboxTransport,
             repository = invitationsRepository,
@@ -312,7 +319,7 @@ class OnymApplication : Application() {
             invitationsInteractor.runFanout(
                 identityRepository.identities.map { summaries ->
                     summaries.map { summary ->
-                        chat.onym.android.transport.TransportInboxId(
+                        summary.id to chat.onym.android.transport.TransportInboxId(
                             chat.onym.android.identity.IdentityRepository.inboxTag(summary.inboxPublicKey),
                         )
                     }

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -322,28 +322,35 @@ class IdentityRepository(
 
     /**
      * Open an X25519+AES-GCM-sealed invitation envelope addressed to
-     * this identity's inbox keypair. The X25519 private key is
+     * the [asIdentity] inbox keypair. The X25519 private key is
      * recomputed from the persisted nostr secret on every call and
      * never assigned to a stored property — so the only persistent
      * footprint of this method on the recipient's machine is the
      * already-encrypted SharedPreferences blob.
      *
+     * Loading by [asIdentity] (rather than the currently-selected
+     * identity) is what makes the multi-identity fan-out actually
+     * usable: an envelope addressed to identity B that arrived
+     * while the user was on identity A still decrypts under B's
+     * key when the repository surfaces it. The repository tags
+     * every persisted record with its [asIdentity] at receive
+     * time; this method consumes that tag.
+     *
      * Throws [InvitationDecryptError]; never raw `javax.crypto` /
      * `kotlinx.serialization` exceptions. See [InvitationDecryptError]
      * for the failure-mode taxonomy.
      */
-    override suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray =
-        withContext(ioDispatcher) {
-            // Snapshot read happens off the mutex — store I/O is a
-            // single atomic SharedPreferences read; concurrent `wipe()`
-            // either observes the pre-wipe blob or post-wipe null,
-            // both internally consistent. Reads against the
-            // currently-selected identity; the multi-identity inbox
-            // fan-out (PR-4) will iterate every id instead.
-            val id = store.loadCurrent() ?: throw InvitationDecryptError.IdentityNotLoaded
-            val snapshot = store.load(id) ?: throw InvitationDecryptError.IdentityNotLoaded
-            decryptInvitationLocked(snapshot, envelopeBytes)
-        }
+    override suspend fun decryptInvitation(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): ByteArray = withContext(ioDispatcher) {
+        // Snapshot read happens off the mutex — store I/O is a
+        // single atomic SharedPreferences read; concurrent `wipe()`
+        // either observes the pre-wipe blob or post-wipe null,
+        // both internally consistent.
+        val snapshot = store.load(asIdentity) ?: throw InvitationDecryptError.IdentityNotLoaded
+        decryptInvitationLocked(snapshot, envelopeBytes)
+    }
 
     private fun decryptInvitationLocked(
         snapshot: StoredSnapshot,

--- a/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
@@ -16,10 +16,25 @@ package chat.onym.android.identity
  */
 interface InvitationEnvelopeDecrypter {
     /**
-     * Decrypt an X25519+AES-GCM-sealed invitation envelope.
+     * Decrypt an X25519+AES-GCM-sealed invitation envelope using the
+     * private key of the identity addressed by [asIdentity].
+     *
+     * The explicit [asIdentity] parameter (added in PR-6 of the
+     * deeplink-invite stack, mirroring onym-ios PR #59) is what
+     * makes the multi-identity inbox fan-out actually decrypt
+     * correctly: an envelope addressed to identity B that arrived
+     * while the user was on identity A still decrypts under B's
+     * key when surfaced. The repository tags every persisted record
+     * with its [asIdentity] at receive time
+     * ([chat.onym.android.inbox.IncomingInvitationsRepository.recordIncoming])
+     * and the decrypter consumes that tag here.
      *
      * @param envelopeBytes UTF-8 JSON of a [SealedEnvelope] with
      *        `scheme = "x25519-aes-256-gcm-v1"`.
+     * @param asIdentity the identity whose X25519 private key should
+     *        be used to open the envelope. Pass the value the
+     *        repository stamped on
+     *        [chat.onym.android.inbox.IncomingInvitation.ownerIdentityId].
      * @return the inner plaintext (typically a `BootstrapPayload`
      *         JSON for the inbox interactor to parse downstream).
      * @throws InvitationDecryptError on every failure mode — the
@@ -27,7 +42,7 @@ interface InvitationEnvelopeDecrypter {
      *         `kotlinx.serialization` exceptions, so callers can
      *         classify with a `when (e: InvitationDecryptError)`.
      */
-    suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray
+    suspend fun decryptInvitation(envelopeBytes: ByteArray, asIdentity: IdentityId): ByteArray
 }
 
 /**

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.transport.InboxTransport
 import chat.onym.android.transport.TransportInboxId
 import kotlinx.coroutines.coroutineScope
@@ -21,11 +22,12 @@ import kotlinx.coroutines.launch
  *  - No OnymSDK. No `Context`. No persistence backend.
  *  - One job: forward each [chat.onym.android.transport.InboundInbox]
  *    into [IncomingInvitationsRepository.recordIncoming]. Decryption
- *    + parsing of the inner payload belongs in a future
- *    `InvitationDetailsRepository` that owns the X25519 read; this
- *    interactor stays opaque-byte-shipping by design.
+ *    + parsing of the inner payload belongs in
+ *    [InvitationDecryptor]; this interactor stays opaque-byte-
+ *    shipping by design.
  *
- * Mirrors `IncomingInvitationsInteractor.swift` from onym-ios PR #16.
+ * Mirrors `IncomingInvitationsInteractor.swift` from onym-ios PR
+ * #16 + the per-identity-keyed fan-out from onym-ios PR #59.
  */
 class IncomingInvitationsInteractor(
     private val inboxTransport: InboxTransport,
@@ -34,39 +36,53 @@ class IncomingInvitationsInteractor(
 
     /**
      * Subscribe to [inbox] and forward each delivered message into
-     * the repository. Suspends for the lifetime of the subscription;
-     * cancellation of the calling scope unsubscribes upstream
-     * (production `NostrInboxTransport` runs `unsubscribe` from the
-     * subscribe Flow's `awaitClose`).
+     * the repository, stamping each record with [ownerIdentityId]
+     * so PR-6's per-identity decrypt path can route to the right
+     * X25519 private key.
+     *
+     * Suspends for the lifetime of the subscription; cancellation
+     * of the calling scope unsubscribes upstream (production
+     * `NostrInboxTransport` runs `unsubscribe` from the subscribe
+     * Flow's `awaitClose`).
      */
-    suspend fun run(inbox: TransportInboxId) {
+    suspend fun run(inbox: TransportInboxId, ownerIdentityId: IdentityId) {
         inboxTransport.subscribe(inbox).collect { inbound ->
             repository.recordIncoming(
                 id = inbound.messageId,
                 payload = inbound.payload,
                 receivedAt = inbound.receivedAt,
+                ownerIdentityId = ownerIdentityId,
             )
         }
     }
 
     /**
-     * Multi-identity fan-out. Subscribes to **every** inbox tag in
-     * the latest [tags] emission concurrently — one child coroutine
-     * per tag inside a structured-concurrency scope. When the upstream
-     * flow emits a new list (identity added / removed / selected), the
-     * old subscription set is cancelled wholesale and a fresh set is
-     * launched.
+     * Multi-identity fan-out. Subscribes to **every** entry in the
+     * latest [entries] emission concurrently — one child coroutine
+     * per identity inside a structured-concurrency scope. When the
+     * upstream flow emits a new list (identity added / removed /
+     * selected), the old subscription set is cancelled wholesale
+     * and a fresh set is launched.
      *
-     * Fan-out is the right shape for multi-identity: messages sent to
-     * any identity's inbox MUST land on disk regardless of which
-     * identity the user is currently viewing — otherwise switching
-     * identity would silently drop messages received under the others.
+     * Each emission is a list of `(IdentityId, TransportInboxId)`
+     * pairs so each launched subscription captures the identity
+     * the inbox tag belongs to and stamps inbounds with that ID
+     * on the way to [IncomingInvitationsRepository.recordIncoming].
+     * The identity ID is what makes per-identity decryption routing
+     * work later — without it, the decryptor can't tell which
+     * X25519 key the envelope is addressed to.
      *
-     * Suspends for the lifetime of the calling scope. Cancelling the
-     * caller cancels every subscription.
+     * Fan-out is the right shape for multi-identity: messages sent
+     * to any identity's inbox MUST land on disk regardless of
+     * which identity the user is currently viewing — otherwise
+     * switching identity would silently drop messages received
+     * under the others.
+     *
+     * Suspends for the lifetime of the calling scope. Cancelling
+     * the caller cancels every subscription.
      */
-    suspend fun runFanout(tags: Flow<List<TransportInboxId>>) {
-        tags.distinctUntilChanged().collectLatest { current ->
+    suspend fun runFanout(entries: Flow<List<Pair<IdentityId, TransportInboxId>>>) {
+        entries.distinctUntilChanged().collectLatest { current ->
             // Inner `coroutineScope` is the structured-concurrency
             // anchor for THIS emission. `collectLatest` cancels the
             // outer lambda on the next emission, which propagates
@@ -76,8 +92,8 @@ class IncomingInvitationsInteractor(
             // (each `run(tag)` collects a never-completing Flow), so
             // it stays alive until cancelled.
             coroutineScope {
-                for (tag in current) {
-                    launch { run(tag) }
+                for ((identityId, tag) in current) {
+                    launch { run(tag, identityId) }
                 }
             }
         }

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsRepository.kt
@@ -1,11 +1,16 @@
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.ActiveIdentityProvider
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.persistence.IncomingInvitationRecord
 import chat.onym.android.persistence.IncomingInvitationStatus
 import chat.onym.android.persistence.InvitationStore
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.Instant
@@ -13,35 +18,86 @@ import java.time.Instant
 /**
  * Owns the in-memory view of "incoming invitations the user hasn't
  * dealt with yet" plus the corresponding writes to the persistence
- * seam. Touch-surface compliance:
+ * seam.
  *
- *  - Holds **only** an [InvitationStore] reference. No transport,
- *    no OnymSDK, no Compose, no `Context`.
+ * **Per-identity filter** (PR-6 of the deeplink-invite stack): the
+ * cached store always holds the full on-disk roster across every
+ * identity that's ever received an invite, so envelopes addressed
+ * to a non-active identity don't get dropped while the user is on
+ * a different one. [invitations] only emits rows whose
+ * [IncomingInvitation.ownerIdentityId] matches the
+ * currently-active identity. Switching identity (or removing one)
+ * re-emits with the new filter applied.
+ *
+ * Touch-surface compliance:
+ *
+ *  - Holds an [InvitationStore] reference + an
+ *    [ActiveIdentityProvider]. No transport, no OnymSDK, no
+ *    Compose, no `Context`.
  *  - Exposes a [StateFlow] for observation; [recordIncoming] /
- *    [updateStatus] / [delete] are the suspend mutators.
+ *    [updateStatus] / [delete] / [removeForOwner] are the suspend
+ *    mutators.
  *  - Mutations serialise through a [Mutex]; reads are lock-free off
  *    the [StateFlow].
  *
- * The shape mirrors `IdentityRepository` exactly — same Mutex +
- * StateFlow + asStateFlow pattern. iOS uses `actor + AsyncStream`
- * for the same role; Android stays with [StateFlow] because Compose
- * subscribes via `collectAsStateWithLifecycle()` with no per-view
- * boilerplate (see *Why `StateFlow` instead of `actor + AsyncStream`*
- * in `README.md`).
+ * The shape mirrors `IdentityRepository` and `GroupRepository`
+ * exactly — same Mutex + StateFlow + identity-listener pattern. iOS
+ * uses `actor + AsyncStream` for the same role; Android stays with
+ * [StateFlow] because Compose subscribes via
+ * `collectAsStateWithLifecycle()` with no per-view boilerplate.
  *
- * Mirrors `IncomingInvitationsRepository.swift` from onym-ios PR #16.
+ * Mirrors `IncomingInvitationsRepository.swift` from onym-ios PR
+ * #16 + the per-identity filter from onym-ios PR #59.
  */
 class IncomingInvitationsRepository(
     private val store: InvitationStore,
+    private val identity: ActiveIdentityProvider,
+    /** Scope owning the per-identity-selection collector. The
+     *  collector lives for the process lifetime; pass an
+     *  `applicationScope` (SupervisorJob + Dispatchers.IO). */
+    private val scope: CoroutineScope,
 ) {
     private val mutex = Mutex()
     private val _invitations = MutableStateFlow<List<IncomingInvitation>>(emptyList())
 
-    /** Hot stream of incoming invitations, sorted by [IncomingInvitation.receivedAt]
-     *  desc. Empty until [bootstrap] runs. New collectors get the
-     *  current value immediately, then one new value per successful
-     *  mutation (dedup-only saves don't push a redundant snapshot). */
+    /** Hot stream of the **currently-selected identity's** incoming
+     *  invitations, sorted by [IncomingInvitation.receivedAt] desc.
+     *  Empty until [bootstrap] runs OR until an identity is selected
+     *  — whichever comes first. New collectors get the current value
+     *  immediately, then one new value per successful mutation
+     *  (dedup-only saves don't push a redundant snapshot). */
     val invitations: StateFlow<List<IncomingInvitation>> = _invitations.asStateFlow()
+
+    init {
+        // Cascade-delete on identity removal — wipes the removed
+        // identity's invitations from disk before the identity's
+        // secrets are wiped. The removal-listener slot is multi-
+        // listener (deeplink PR-3 flipped it from single → list).
+        // Order: GroupRepository's chat-wipe runs first (registered
+        // in its `init`), then this repository's invitation-wipe
+        // (registered here), then the deeplink-invite intro-key
+        // wipe (registered in OnymApplication wiring).
+        identity.registerRemovalListener { id ->
+            mutex.withLock {
+                store.deleteForOwner(id.value)
+                refreshLocked(identity.currentIdentityId.value)
+            }
+        }
+    }
+
+    /**
+     * Start observing the active-identity flow. Idempotent — safe to
+     * call from `onCreate`. Recomputes [invitations] every time the
+     * active identity changes (including → null, which empties the
+     * stream).
+     */
+    fun start() {
+        scope.launch {
+            identity.currentIdentityId.collectLatest { id ->
+                mutex.withLock { refreshLocked(id) }
+            }
+        }
+    }
 
     /**
      * Hydrate from disk. Idempotent — safe to call from any
@@ -49,27 +105,36 @@ class IncomingInvitationsRepository(
      * error.
      */
     suspend fun bootstrap() = mutex.withLock {
-        _invitations.value = store.list().map(::toInvitation)
+        refreshLocked(identity.currentIdentityId.value)
     }
 
     /**
      * Persist a freshly-arrived inbound. No-op (and no snapshot
-     * push) if [id] was already persisted — relays can replay events
-     * across reconnects, so dedup-on-id is the correctness property.
+     * push) if [id] was already persisted — relays can replay
+     * events across reconnects, so dedup-on-id is the correctness
+     * property.
+     *
+     * [ownerIdentityId] is the identity whose inbox tag the fan-out
+     * delivered this on. Stamped at receive time so PR-6's
+     * per-identity decrypt path can route to the right private key
+     * (otherwise envelopes addressed to identity B would sit
+     * undecryptable while the user is on identity A).
      */
     suspend fun recordIncoming(
         id: String,
         payload: ByteArray,
         receivedAt: Instant,
+        ownerIdentityId: IdentityId,
     ) = mutex.withLock {
         val record = IncomingInvitationRecord(
             id = id,
             payload = payload,
             receivedAt = receivedAt,
             status = IncomingInvitationStatus.Pending,
+            ownerIdentityIdString = ownerIdentityId.value,
         )
         if (store.save(record)) {
-            _invitations.value = store.list().map(::toInvitation)
+            refreshLocked(identity.currentIdentityId.value)
         }
     }
 
@@ -78,13 +143,42 @@ class IncomingInvitationsRepository(
      *  swallows them, and the snapshot rebuild is idempotent). */
     suspend fun updateStatus(id: String, status: IncomingInvitationStatus) = mutex.withLock {
         store.updateStatus(id, status)
-        _invitations.value = store.list().map(::toInvitation)
+        refreshLocked(identity.currentIdentityId.value)
     }
 
     /** Remove the invitation by id; refresh the StateFlow snapshot. */
     suspend fun delete(id: String) = mutex.withLock {
         store.delete(id)
-        _invitations.value = store.list().map(::toInvitation)
+        refreshLocked(identity.currentIdentityId.value)
+    }
+
+    /**
+     * Cascade-delete every invitation owned by [ownerIdentityId].
+     * Public surface for callers that need explicit (non-listener-
+     * driven) wipes — tests, debug menus, or the future "wipe
+     * everything for this identity" admin path.
+     *
+     * The init-time removal listener on
+     * [ActiveIdentityProvider.registerRemovalListener] also calls
+     * this internally; production wiping happens automatically
+     * there.
+     */
+    suspend fun removeForOwner(ownerIdentityId: IdentityId): Int = mutex.withLock {
+        val removed = store.deleteForOwner(ownerIdentityId.value)
+        if (removed > 0) {
+            refreshLocked(identity.currentIdentityId.value)
+        }
+        removed
+    }
+
+    private suspend fun refreshLocked(activeId: IdentityId?) {
+        _invitations.value = if (activeId == null) {
+            emptyList()
+        } else {
+            store.list()
+                .filter { it.ownerIdentityIdString == activeId.value }
+                .map(::toInvitation)
+        }
     }
 
     private fun toInvitation(rec: IncomingInvitationRecord) = IncomingInvitation(
@@ -92,6 +186,7 @@ class IncomingInvitationsRepository(
         payload = rec.payload,
         receivedAt = rec.receivedAt,
         status = rec.status,
+        ownerIdentityId = IdentityId(rec.ownerIdentityIdString),
     )
 }
 
@@ -107,6 +202,7 @@ data class IncomingInvitation(
     val payload: ByteArray,
     val receivedAt: Instant,
     val status: IncomingInvitationStatus,
+    val ownerIdentityId: IdentityId,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -114,7 +210,8 @@ data class IncomingInvitation(
         return id == other.id &&
             payload.contentEquals(other.payload) &&
             receivedAt == other.receivedAt &&
-            status == other.status
+            status == other.status &&
+            ownerIdentityId == other.ownerIdentityId
     }
 
     override fun hashCode(): Int {
@@ -122,6 +219,7 @@ data class IncomingInvitation(
         result = 31 * result + payload.contentHashCode()
         result = 31 * result + receivedAt.hashCode()
         result = 31 * result + status.hashCode()
+        result = 31 * result + ownerIdentityId.hashCode()
         return result
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/inbox/InvitationDecryptor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/InvitationDecryptor.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.identity.InvitationEnvelopeDecrypter
 import kotlinx.serialization.json.Json
 
@@ -17,14 +18,22 @@ import kotlinx.serialization.json.Json
  *  - Stateless — the only mutable thing in scope is the [Json]
  *    parser, which is thread-safe + immutable after construction.
  *
- * Mirrors `InvitationDecryptor.swift` from onym-ios PR #17.
+ * Mirrors `InvitationDecryptor.swift` from onym-ios PR #17 + the
+ * per-identity routing arg from onym-ios PR #59.
  */
 class InvitationDecryptor(
     private val envelopeDecrypter: InvitationEnvelopeDecrypter,
 ) {
     /**
      * Open + parse [envelopeBytes] (UTF-8 JSON of a
-     * [chat.onym.android.identity.SealedEnvelope]).
+     * [chat.onym.android.identity.SealedEnvelope]) using the X25519
+     * key of the identity addressed by [asIdentity].
+     *
+     * Pass the value the repository stamped on
+     * [IncomingInvitation.ownerIdentityId]. Hard-coding the
+     * currently-selected identity here would silently fail to
+     * decrypt envelopes addressed to a non-active identity — the
+     * whole reason PR-6 of the deeplink-invite stack exists.
      *
      * @throws chat.onym.android.identity.InvitationDecryptError on
      *         decryption failure; propagated verbatim from the seam.
@@ -32,8 +41,8 @@ class InvitationDecryptor(
      *         decrypted plaintext isn't a well-formed
      *         [DecryptedInvitation] JSON.
      */
-    suspend fun decrypt(envelopeBytes: ByteArray): DecryptedInvitation {
-        val plaintext = envelopeDecrypter.decryptInvitation(envelopeBytes)
+    suspend fun decrypt(envelopeBytes: ByteArray, asIdentity: IdentityId): DecryptedInvitation {
+        val plaintext = envelopeDecrypter.decryptInvitation(envelopeBytes, asIdentity)
         return jsonFormat.decodeFromString(plaintext.toString(Charsets.UTF_8))
     }
 

--- a/app/src/main/kotlin/chat/onym/android/persistence/InMemoryInvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InMemoryInvitationStore.kt
@@ -40,4 +40,12 @@ class InMemoryInvitationStore : InvitationStore {
     override suspend fun delete(id: String) {
         mutex.withLock { rows.remove(id) }
     }
+
+    override suspend fun deleteForOwner(ownerIdentityIdString: String): Int = mutex.withLock {
+        val toRemove = rows.values
+            .filter { it.ownerIdentityIdString == ownerIdentityIdString }
+            .map { it.id }
+        for (id in toRemove) rows.remove(id)
+        toRemove.size
+    }
 }

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationDao.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationDao.kt
@@ -33,4 +33,11 @@ interface InvitationDao {
 
     @Query("DELETE FROM incoming_invitations WHERE id = :id")
     suspend fun delete(id: String): Int
+
+    /** Cascade-delete every row owned by [ownerIdentityIdString].
+     *  Returns the number of rows removed. Used by the
+     *  identity-removed listener (see
+     *  [chat.onym.android.inbox.IncomingInvitationsRepository]). */
+    @Query("DELETE FROM incoming_invitations WHERE ownerIdentityIdString = :ownerIdentityIdString")
+    suspend fun deleteForOwner(ownerIdentityIdString: String): Int
 }

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationDatabase.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationDatabase.kt
@@ -15,11 +15,18 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [PersistedInvitation::class],
-    version = 1,
+    // v2: PR-6 of the deeplink-invite stack adds the
+    // `ownerIdentityIdString` column for the per-identity
+    // decryption-routing filter. Pre-1.0 + greenfield licence — no
+    // Migration class. Builders MUST set
+    // `.fallbackToDestructiveMigration()` so a v1→v2 jump on an
+    // existing install drops the table (re-fetched from relays on
+    // next launch) instead of crashing on schema mismatch.
+    version = 2,
     // Schema export is for cross-version diffing during migration
-    // authoring; nothing to diff at v1 and KSP warns loudly about
-    // the missing `room.schemaLocation` directory otherwise.
-    // Flip to true and add the apt arg when version 2 lands.
+    // authoring; we don't write Migration classes (destructive
+    // fallback per the greenfield licence), so KSP-warn-suppression
+    // by leaving this off is fine.
     exportSchema = false,
 )
 abstract class InvitationDatabase : RoomDatabase() {

--- a/app/src/main/kotlin/chat/onym/android/persistence/InvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/InvitationStore.kt
@@ -31,18 +31,38 @@ interface InvitationStore {
 
     /** No-op if [id] is absent. */
     suspend fun delete(id: String)
+
+    /**
+     * Cascade-delete every record whose
+     * [IncomingInvitationRecord.ownerIdentityIdString] matches.
+     * Used by the identity-removed listener to wipe an identity's
+     * inbox when the user removes that identity. Returns the number
+     * of rows removed (0 when no records belonged to the owner).
+     *
+     * The arg is the raw [chat.onym.android.identity.IdentityId.value]
+     * string so this seam stays free of the identity-layer type.
+     */
+    suspend fun deleteForOwner(ownerIdentityIdString: String): Int
 }
 
 /**
  * Plaintext value type the seam exposes. Persistence-side encryption
  * is invisible to callers — the [payload] is the unwrapped bytes
  * delivered by [InvitationStore.list].
+ *
+ * [ownerIdentityIdString] is the raw
+ * [chat.onym.android.identity.IdentityId.value] of the identity this
+ * envelope was addressed to (i.e., the identity whose inbox tag the
+ * fan-out subscription delivered it on). Stored plaintext + indexed
+ * so per-identity filters happen in SQL, not in-process. Random
+ * per-device UUIDs — nothing to leak.
  */
 data class IncomingInvitationRecord(
     val id: String,
     val payload: ByteArray,
     val receivedAt: Instant,
     val status: IncomingInvitationStatus,
+    val ownerIdentityIdString: String,
 ) {
     // Override equals / hashCode so tests can compare records (data
     // class auto-generated equals uses ByteArray reference equality).
@@ -52,7 +72,8 @@ data class IncomingInvitationRecord(
         return id == other.id &&
             payload.contentEquals(other.payload) &&
             receivedAt == other.receivedAt &&
-            status == other.status
+            status == other.status &&
+            ownerIdentityIdString == other.ownerIdentityIdString
     }
 
     override fun hashCode(): Int {
@@ -60,6 +81,7 @@ data class IncomingInvitationRecord(
         result = 31 * result + payload.contentHashCode()
         result = 31 * result + receivedAt.hashCode()
         result = 31 * result + status.hashCode()
+        result = 31 * result + ownerIdentityIdString.hashCode()
         return result
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/persistence/PersistedInvitation.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/PersistedInvitation.kt
@@ -1,6 +1,8 @@
 package chat.onym.android.persistence
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -22,13 +24,26 @@ import androidx.room.PrimaryKey
  * `encryptedPayload` is the AES-GCM-wrapped output of
  * [StorageEncryption.encrypt] over the inbound NaCl-sealed bytes.
  * Stored as BLOB; opaque to SQLite.
+ *
+ * `ownerIdentityIdString` is the
+ * [chat.onym.android.identity.IdentityId.value] of the identity
+ * this envelope was addressed to (the identity whose inbox tag
+ * the fan-out subscription delivered it on). Stored plaintext +
+ * indexed so the per-identity filter happens in SQL, not
+ * in-process. The owner ID is a random per-device UUID — nothing
+ * to leak. Added in PR-6 of the deeplink-invite stack (mirrors
+ * onym-ios PR #59).
  */
-@Entity(tableName = "incoming_invitations")
+@Entity(
+    tableName = "incoming_invitations",
+    indices = [Index(value = ["ownerIdentityIdString"])],
+)
 data class PersistedInvitation(
     @PrimaryKey val id: String,
     val encryptedPayload: ByteArray,
     val receivedAt: Long,
     val statusRaw: String,
+    @ColumnInfo(defaultValue = "") val ownerIdentityIdString: String,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -36,7 +51,8 @@ data class PersistedInvitation(
         return id == other.id &&
             encryptedPayload.contentEquals(other.encryptedPayload) &&
             receivedAt == other.receivedAt &&
-            statusRaw == other.statusRaw
+            statusRaw == other.statusRaw &&
+            ownerIdentityIdString == other.ownerIdentityIdString
     }
 
     override fun hashCode(): Int {
@@ -44,6 +60,7 @@ data class PersistedInvitation(
         result = 31 * result + encryptedPayload.contentHashCode()
         result = 31 * result + receivedAt.hashCode()
         result = 31 * result + statusRaw.hashCode()
+        result = 31 * result + ownerIdentityIdString.hashCode()
         return result
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/persistence/RoomInvitationStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/persistence/RoomInvitationStore.kt
@@ -26,6 +26,7 @@ class RoomInvitationStore(
                 payload = encryption.decrypt(row.encryptedPayload),
                 receivedAt = Instant.ofEpochMilli(row.receivedAt),
                 status = parseStatus(row.statusRaw),
+                ownerIdentityIdString = row.ownerIdentityIdString,
             )
         }
     }
@@ -37,6 +38,7 @@ class RoomInvitationStore(
                 encryptedPayload = encryption.encrypt(record.payload),
                 receivedAt = record.receivedAt.toEpochMilli(),
                 statusRaw = record.status.name,
+                ownerIdentityIdString = record.ownerIdentityIdString,
             )
         )
         rowId != -1L
@@ -49,6 +51,9 @@ class RoomInvitationStore(
     override suspend fun delete(id: String) {
         withContext(ioDispatcher) { dao.delete(id) }
     }
+
+    override suspend fun deleteForOwner(ownerIdentityIdString: String): Int =
+        withContext(ioDispatcher) { dao.deleteForOwner(ownerIdentityIdString) }
 
     /** Tolerant parse: an unknown enum value (from a future schema
      *  rolled back, say) falls back to [IncomingInvitationStatus.Pending]

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.support
 
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.identity.InvitationDecryptError
 import chat.onym.android.identity.InvitationEnvelopeDecrypter
 
@@ -45,11 +46,21 @@ class FakeInvitationEnvelopeDecrypter(var mode: Mode) : InvitationEnvelopeDecryp
     /** Every envelope this fake has been asked to decrypt, in call
      *  order. Tests assert with `decryptCalls.last().contentEquals(...)`
      *  or by counting size. */
-    val decryptCalls: List<ByteArray> get() = _decryptCalls.toList()
-    private val _decryptCalls = mutableListOf<ByteArray>()
+    val decryptCalls: List<ByteArray> get() = _decryptCalls.map { it.envelope }
+    /** Per-call (envelope, asIdentity) tuples — lets the per-identity-
+     *  decryption tests assert that each record was decrypted with
+     *  the right identity, not just that something was decrypted. */
+    val decryptCallsWithIdentity: List<DecryptCall> get() = _decryptCalls.toList()
+    private val _decryptCalls = mutableListOf<DecryptCall>()
 
-    override suspend fun decryptInvitation(envelopeBytes: ByteArray): ByteArray {
-        _decryptCalls.add(envelopeBytes.copyOf())
+    data class DecryptCall(val envelope: ByteArray, val asIdentity: IdentityId) {
+        override fun equals(other: Any?): Boolean = this === other ||
+            (other is DecryptCall && envelope.contentEquals(other.envelope) && asIdentity == other.asIdentity)
+        override fun hashCode(): Int = 31 * envelope.contentHashCode() + asIdentity.hashCode()
+    }
+
+    override suspend fun decryptInvitation(envelopeBytes: ByteArray, asIdentity: IdentityId): ByteArray {
+        _decryptCalls.add(DecryptCall(envelopeBytes.copyOf(), asIdentity))
         return when (val m = mode) {
             is Mode.Fixed -> m.plaintext.copyOf()
             is Mode.Scripted -> m.script[envelopeBytes.toList()]

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractorTest.kt
@@ -2,6 +2,8 @@
 
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.support.FakeActiveIdentityProvider
 import chat.onym.android.support.FakeInboxTransport
 import chat.onym.android.support.InMemoryInvitationStore
 import chat.onym.android.transport.InboundInbox
@@ -23,7 +25,9 @@ import java.time.Instant
  * ([FakeInboxTransport] + [InMemoryInvitationStore]). Validates the
  * one job [IncomingInvitationsInteractor] has — forward each
  * inbound message into the repository, dedup at the repo, exit
- * cleanly on cancellation.
+ * cleanly on cancellation. Per-identity-keyed fan-out (PR-6 of
+ * deeplink-invite stack) is also covered: each subscription
+ * captures its identity ID and stamps inbounds with it.
  *
  * Mirrors `IncomingInvitationsInteractorTests.swift` from onym-ios PR #16.
  */
@@ -31,16 +35,17 @@ class IncomingInvitationsInteractorTest {
 
     private val inbox = TransportInboxId("inbox-test")
     private val now = Instant.parse("2026-05-02T12:00:00Z")
+    private val testOwner = IdentityId("test-owner")
 
     @Test
     fun oneInbound_oneRecord() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = makeRepo(store, this)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
         coroutineScope {
-            val job = async { interactor.run(inbox) }
+            val job = async { interactor.run(inbox, testOwner) }
             transport.emit(inbound("ev1", "p1"))
             transport.finish(inbox)
             job.await()
@@ -50,17 +55,18 @@ class IncomingInvitationsInteractorTest {
         assertEquals(1, all.size)
         assertEquals("ev1", all[0].id)
         assertArrayEquals("p1".toByteArray(), all[0].payload)
+        assertEquals(testOwner.value, all[0].ownerIdentityIdString)
     }
 
     @Test
     fun multipleInbounds_persistedInOrder() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = makeRepo(store, this)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
         coroutineScope {
-            val job = async { interactor.run(inbox) }
+            val job = async { interactor.run(inbox, testOwner) }
             transport.emit(inbound("ev1", "first", at = now))
             transport.emit(inbound("ev2", "second", at = now.plusSeconds(1)))
             transport.emit(inbound("ev3", "third", at = now.plusSeconds(2)))
@@ -76,11 +82,11 @@ class IncomingInvitationsInteractorTest {
     fun duplicateMessageId_dedupedAtRepository() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = makeRepo(store, this)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
         coroutineScope {
-            val job = async { interactor.run(inbox) }
+            val job = async { interactor.run(inbox, testOwner) }
             // Same id, different payload — relays can replay events
             // across reconnects and the dedup-on-id property is what
             // protects the repository.
@@ -99,11 +105,11 @@ class IncomingInvitationsInteractorTest {
     fun cancellation_unsubscribesUpstream() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = makeRepo(store, this)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
         coroutineScope {
-            val job = async { interactor.run(inbox) }
+            val job = async { interactor.run(inbox, testOwner) }
             // Make sure subscribe() has fired before we cancel.
             transport.emit(inbound("ev1", "x"))
             yield()
@@ -125,11 +131,11 @@ class IncomingInvitationsInteractorTest {
     fun finishWhileIdle_exitsCleanly() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = makeRepo(store, this)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
         coroutineScope {
-            val job = async { interactor.run(inbox) }
+            val job = async { interactor.run(inbox, testOwner) }
             // No inbounds — just close the channel.
             yield()
             transport.finish(inbox)
@@ -144,24 +150,34 @@ class IncomingInvitationsInteractorTest {
     }
 
     @Test
-    fun runFanout_subscribesToEveryTagInTheList() = runTest(UnconfinedTestDispatcher()) {
+    fun runFanout_subscribesToEveryEntryInTheList_andStampsOwnerPerSubscription() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val alice = IdentityId("alice-id")
+        val bob = IdentityId("bob-id")
+        val aliceTag = TransportInboxId("alice-tag")
+        val bobTag = TransportInboxId("bob-tag")
+        val repo = makeRepo(store, this, initialActive = alice)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
-        val alice = TransportInboxId("alice-tag")
-        val bob = TransportInboxId("bob-tag")
-        val tags = kotlinx.coroutines.flow.MutableStateFlow(listOf(alice, bob))
+        val entries = kotlinx.coroutines.flow.MutableStateFlow(
+            listOf(alice to aliceTag, bob to bobTag),
+        )
 
         coroutineScope {
-            val job = async { interactor.runFanout(tags) }
+            val job = async { interactor.runFanout(entries) }
             yield()
-            // Inbounds on either tag must land in the store.
-            transport.emit(InboundInbox(alice, "alice-msg".toByteArray(), now, "alice-1"))
-            transport.emit(InboundInbox(bob, "bob-msg".toByteArray(), now, "bob-1"))
+            // Inbounds on either tag must land in the store, each
+            // stamped with its subscription's identity ID.
+            transport.emit(InboundInbox(aliceTag, "alice-msg".toByteArray(), now, "alice-1"))
+            transport.emit(InboundInbox(bobTag, "bob-msg".toByteArray(), now, "bob-1"))
             yield()
-            assertEquals(2, store.list().size)
+            val rows = store.list()
+            assertEquals(2, rows.size)
+            val aliceRow = rows.first { it.id == "alice-1" }
+            val bobRow = rows.first { it.id == "bob-1" }
+            assertEquals(alice.value, aliceRow.ownerIdentityIdString)
+            assertEquals(bob.value, bobRow.ownerIdentityIdString)
             // Cancel the fan-out so the test exits.
             job.cancel()
             job.join()
@@ -169,39 +185,53 @@ class IncomingInvitationsInteractorTest {
     }
 
     @Test
-    fun runFanout_unsubscribesRemovedTags_andSubscribesNewOnes() = runTest(UnconfinedTestDispatcher()) {
+    fun runFanout_unsubscribesRemovedEntries_andSubscribesNewOnes() = runTest(UnconfinedTestDispatcher()) {
         val transport = FakeInboxTransport()
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val alice = IdentityId("alice-id")
+        val carol = IdentityId("carol-id")
+        val aliceTag = TransportInboxId("alice-tag")
+        val carolTag = TransportInboxId("carol-tag")
+        val repo = makeRepo(store, this, initialActive = alice)
         val interactor = IncomingInvitationsInteractor(transport, repo)
 
-        val alice = TransportInboxId("alice-tag")
-        val carol = TransportInboxId("carol-tag")
-        val tags = kotlinx.coroutines.flow.MutableStateFlow(listOf(alice))
+        val entries = kotlinx.coroutines.flow.MutableStateFlow(
+            listOf(alice to aliceTag),
+        )
 
         coroutineScope {
-            val job = async { interactor.runFanout(tags) }
+            val job = async { interactor.runFanout(entries) }
             yield()
             // Initial subscription set is just Alice.
-            assertEquals(setOf(alice), transport.subscribedInboxes)
+            assertEquals(setOf(aliceTag), transport.subscribedInboxes)
 
             // Swap the entire list to [carol]: Alice unsubscribes,
-            // Carol subscribes. The wholesale cancel-and-rebuild
+            // Carol subscribes. Wholesale cancel-and-rebuild
             // semantics — collectLatest cancels the inner scope which
             // cancels every child launch, then re-launches with the
             // new list.
-            tags.value = listOf(carol)
+            entries.value = listOf(carol to carolTag)
             yield()
-            assertEquals(setOf(carol), transport.subscribedInboxes)
+            assertEquals(setOf(carolTag), transport.subscribedInboxes)
             assertTrue(
                 "Alice was unsubscribed when she dropped off the list",
-                transport.unsubscribedInboxes.contains(alice),
+                transport.unsubscribedInboxes.contains(aliceTag),
             )
 
             job.cancel()
             job.join()
         }
     }
+
+    private fun makeRepo(
+        store: InMemoryInvitationStore,
+        scope: kotlinx.coroutines.CoroutineScope,
+        initialActive: IdentityId = testOwner,
+    ): IncomingInvitationsRepository = IncomingInvitationsRepository(
+        store = store,
+        identity = FakeActiveIdentityProvider(initial = initialActive),
+        scope = scope,
+    )
 
     private fun inbound(id: String, payload: String, at: Instant = now) = InboundInbox(
         inbox = inbox,

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingInvitationsRepositoryTest.kt
@@ -1,8 +1,16 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.persistence.IncomingInvitationRecord
 import chat.onym.android.persistence.IncomingInvitationStatus
+import chat.onym.android.support.FakeActiveIdentityProvider
 import chat.onym.android.support.InMemoryInvitationStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -16,37 +24,42 @@ import java.time.Instant
  * Room-backed companion ([chat.onym.android.persistence.RoomInvitationStoreTest])
  * exercises the same seam against the real backend; this suite
  * focuses on repository semantics — StateFlow emission discipline,
- * dedup, mutation propagation.
+ * dedup, mutation propagation, and the per-identity filter +
+ * cascade-delete from PR-6 of the deeplink-invite stack.
  *
- * Mirrors `IncomingInvitationsRepositoryTests.swift` from onym-ios PR #16.
+ * Mirrors `IncomingInvitationsRepositoryTests.swift` from onym-ios PR
+ * #16 + the per-identity-routing tests from onym-ios PR #59.
  */
 class IncomingInvitationsRepositoryTest {
 
     private val now = Instant.parse("2026-05-02T12:00:00Z")
+    private val alice = IdentityId("alice-id")
+    private val bob = IdentityId("bob-id")
 
     // ─── recordIncoming ───────────────────────────────────────────
 
     @Test
-    fun recordIncoming_savesViaStore() = runTest {
+    fun recordIncoming_savesViaStore() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = repo(store, this, initialActive = alice)
 
-        repo.recordIncoming(id = "ev1", payload = "p1".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev1", payload = "p1".toByteArray(), receivedAt = now, ownerIdentityId = alice)
 
         val stored = store.list().single()
         assertEquals("ev1", stored.id)
         assertArrayEquals("p1".toByteArray(), stored.payload)
         assertEquals(IncomingInvitationStatus.Pending, stored.status)
+        assertEquals(alice.value, stored.ownerIdentityIdString)
     }
 
     @Test
-    fun recordIncoming_idempotentOnId() = runTest {
+    fun recordIncoming_idempotentOnId() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = repo(store, this, initialActive = alice)
 
-        repo.recordIncoming(id = "ev1", payload = "first".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev1", payload = "first".toByteArray(), receivedAt = now, ownerIdentityId = alice)
         // Second record with same id — different payload — must be ignored.
-        repo.recordIncoming(id = "ev1", payload = "second".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev1", payload = "second".toByteArray(), receivedAt = now, ownerIdentityId = alice)
 
         val stored = store.list().single()
         assertArrayEquals("first".toByteArray(), stored.payload)
@@ -55,10 +68,10 @@ class IncomingInvitationsRepositoryTest {
     // ─── status / delete propagation ──────────────────────────────
 
     @Test
-    fun updateStatus_propagatesToStore() = runTest {
+    fun updateStatus_propagatesToStore() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        store.save(record("ev1", "x", now, IncomingInvitationStatus.Pending))
-        val repo = IncomingInvitationsRepository(store)
+        store.save(record("ev1", "x", now, owner = alice))
+        val repo = repo(store, this, initialActive = alice)
         repo.bootstrap()
 
         repo.updateStatus("ev1", IncomingInvitationStatus.Accepted)
@@ -67,11 +80,11 @@ class IncomingInvitationsRepositoryTest {
     }
 
     @Test
-    fun delete_propagatesToStore() = runTest {
+    fun delete_propagatesToStore() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        store.save(record("ev1", "x", now))
-        store.save(record("ev2", "y", now.plusSeconds(1)))
-        val repo = IncomingInvitationsRepository(store)
+        store.save(record("ev1", "x", now, owner = alice))
+        store.save(record("ev2", "y", now.plusSeconds(1), owner = alice))
+        val repo = repo(store, this, initialActive = alice)
         repo.bootstrap()
 
         repo.delete("ev1")
@@ -82,18 +95,18 @@ class IncomingInvitationsRepositoryTest {
     // ─── StateFlow emission discipline ────────────────────────────
 
     @Test
-    fun stateFlow_initialValue_isEmptyBeforeBootstrap() = runTest {
+    fun stateFlow_initialValue_isEmptyBeforeBootstrap() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
+        val repo = repo(store, this, initialActive = alice)
         assertTrue(repo.invitations.value.isEmpty())
     }
 
     @Test
-    fun stateFlow_initialValue_hydratedAfterBootstrap() = runTest {
+    fun stateFlow_initialValue_hydratedAfterBootstrap() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        store.save(record("ev1", "x", now))
-        store.save(record("ev2", "y", now.plusSeconds(1)))
-        val repo = IncomingInvitationsRepository(store)
+        store.save(record("ev1", "x", now, owner = alice))
+        store.save(record("ev2", "y", now.plusSeconds(1), owner = alice))
+        val repo = repo(store, this, initialActive = alice)
 
         repo.bootstrap()
 
@@ -102,23 +115,20 @@ class IncomingInvitationsRepositoryTest {
     }
 
     @Test
-    fun stateFlow_skipsRedundantEmitOnDedup() = runTest {
+    fun stateFlow_skipsRedundantEmitOnDedup() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
-        val seen = mutableListOf<List<String>>()
-        // Subscribe synchronously by snapshot — value-only check.
-        seen.add(repo.invitations.value.map { it.id })
+        val repo = repo(store, this, initialActive = alice)
+        repo.bootstrap()
 
-        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now, ownerIdentityId = alice)
         val firstSnapshot = repo.invitations.value
-        seen.add(firstSnapshot.map { it.id })
 
         // Duplicate id — must NOT push a redundant snapshot. We
         // assert on object identity: the StateFlow's `value` must
         // be the *same* list instance, not a freshly-built equal
         // one. The repository skips the rebuild when store.save
         // returns false.
-        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now, ownerIdentityId = alice)
         assertSame(
             "duplicate recordIncoming must not rebuild the snapshot",
             firstSnapshot,
@@ -127,11 +137,11 @@ class IncomingInvitationsRepositoryTest {
     }
 
     @Test
-    fun stateFlow_emitsAfterUpdateStatusAndDelete() = runTest {
+    fun stateFlow_emitsAfterUpdateStatusAndDelete() = runTest(UnconfinedTestDispatcher()) {
         val store = InMemoryInvitationStore()
-        val repo = IncomingInvitationsRepository(store)
-        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now)
-        repo.recordIncoming(id = "ev2", payload = "y".toByteArray(), receivedAt = now.plusSeconds(1))
+        val repo = repo(store, this, initialActive = alice)
+        repo.recordIncoming(id = "ev1", payload = "x".toByteArray(), receivedAt = now, ownerIdentityId = alice)
+        repo.recordIncoming(id = "ev2", payload = "y".toByteArray(), receivedAt = now.plusSeconds(1), ownerIdentityId = alice)
 
         repo.updateStatus("ev1", IncomingInvitationStatus.Accepted)
         assertEquals(
@@ -143,17 +153,102 @@ class IncomingInvitationsRepositoryTest {
         assertEquals(listOf("ev2"), repo.invitations.value.map { it.id })
     }
 
+    // ─── per-identity filter + cascade (PR-6) ─────────────────────
+
+    @Test
+    fun snapshots_onlyContainCurrentOwnersInvitations_afterFanoutPersistsMultiple() = runTest(UnconfinedTestDispatcher()) {
+        val store = InMemoryInvitationStore()
+        val active = FakeActiveIdentityProvider(initial = alice)
+        // backgroundScope, not `this` — repo.start() launches a
+        // never-completing collectLatest; child jobs of the test
+        // scope would block runTest from returning.
+        val repo = IncomingInvitationsRepository(store, active, backgroundScope)
+        repo.start()
+
+        // Simulate the fan-out persisting envelopes for both
+        // identities (the joiner's app may receive a message
+        // addressed to identity B while the user is on identity A
+        // — that envelope must persist + be filtered out of the
+        // current view, not lost).
+        repo.recordIncoming("a1", "alice-msg".toByteArray(), now, alice)
+        repo.recordIncoming("b1", "bob-msg".toByteArray(), now.plusSeconds(1), bob)
+
+        // While alice is active, snapshots only show alice's row
+        // even though the store holds both.
+        assertEquals(2, store.list().size)
+        assertEquals(listOf("a1"), repo.invitations.value.map { it.id })
+
+        // Switch active to bob — snapshots flip to bob's row. Drain
+        // the test scheduler so the collectLatest body runs before
+        // we assert (UnconfinedTestDispatcher runs eagerly only for
+        // the current coroutine; the backgroundScope collector
+        // needs `runCurrent` to pump).
+        active.setActive(bob)
+        runCurrent()
+        assertEquals(listOf("b1"), repo.invitations.value.map { it.id })
+    }
+
+    @Test
+    fun removeForOwner_wipesThatIdentitysInvitations_andLeavesOthers() = runTest(UnconfinedTestDispatcher()) {
+        val store = InMemoryInvitationStore()
+        val repo = repo(store, this, initialActive = alice)
+        repo.recordIncoming("a1", "x".toByteArray(), now, alice)
+        repo.recordIncoming("a2", "y".toByteArray(), now.plusSeconds(1), alice)
+        repo.recordIncoming("b1", "z".toByteArray(), now.plusSeconds(2), bob)
+
+        val removed = repo.removeForOwner(alice)
+
+        assertEquals(2, removed)
+        assertEquals(listOf("b1"), store.list().map { it.id })
+    }
+
+    @Test
+    fun identityRemovalListener_cascadeWipesPersistedRows() = runTest(UnconfinedTestDispatcher()) {
+        val store = InMemoryInvitationStore()
+        val active = FakeActiveIdentityProvider(initial = alice)
+        // backgroundScope, not `this` — repo.start() launches a
+        // never-completing collectLatest; child jobs of the test
+        // scope would block runTest from returning.
+        val repo = IncomingInvitationsRepository(store, active, backgroundScope)
+        repo.start()
+
+        repo.recordIncoming("a1", "x".toByteArray(), now, alice)
+        repo.recordIncoming("b1", "y".toByteArray(), now.plusSeconds(1), bob)
+
+        // Simulate IdentityRepository removing alice — drives the
+        // listener registered in the repository's `init`.
+        active.emitRemoval(alice)
+        runCurrent()
+
+        assertEquals(
+            "alice's persisted rows should be gone after the cascade",
+            listOf("b1"), store.list().map { it.id },
+        )
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
+
+    private fun repo(
+        store: InMemoryInvitationStore,
+        scope: CoroutineScope,
+        initialActive: IdentityId?,
+    ): IncomingInvitationsRepository = IncomingInvitationsRepository(
+        store = store,
+        identity = FakeActiveIdentityProvider(initial = initialActive),
+        scope = scope,
+    )
 
     private fun record(
         id: String,
         payload: String,
         receivedAt: Instant,
+        owner: IdentityId,
         status: IncomingInvitationStatus = IncomingInvitationStatus.Pending,
     ) = IncomingInvitationRecord(
         id = id,
         payload = payload.toByteArray(Charsets.UTF_8),
         receivedAt = receivedAt,
         status = status,
+        ownerIdentityIdString = owner.value,
     )
 }

--- a/app/src/test/kotlin/chat/onym/android/inbox/InvitationDecryptorTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/InvitationDecryptorTest.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.inbox
 
+import chat.onym.android.identity.IdentityId
 import chat.onym.android.identity.InvitationDecryptError
 import chat.onym.android.support.FakeInvitationEnvelopeDecrypter
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,8 @@ import java.util.Base64
  */
 class InvitationDecryptorTest {
 
+    private val testIdentity = IdentityId("test-identity")
+
     @Test
     fun decrypt_passesEnvelopeBytesThroughToDecrypter() = runTest {
         val plaintext = decryptedInvitationJson("aGVsbG8=", "Group A", 7uL, "abcd")
@@ -36,13 +39,38 @@ class InvitationDecryptorTest {
         val decryptor = InvitationDecryptor(fake)
 
         val envelope = "envelope-bytes".toByteArray()
-        val result = decryptor.decrypt(envelope)
+        val result = decryptor.decrypt(envelope, asIdentity = testIdentity)
 
         assertEquals(1, fake.decryptCalls.size)
         assertArrayEquals(envelope, fake.decryptCalls.single())
         assertEquals("Group A", result.name)
         assertEquals(7uL, result.epoch)
         assertEquals("abcd", result.senderNostrPubkey)
+    }
+
+    @Test
+    fun decrypt_passesPerRecordAsIdentityThroughToEnvelopeDecrypter() = runTest {
+        val plaintext = decryptedInvitationJson("AAA=", "X", 1uL, "pk")
+        val fake = FakeInvitationEnvelopeDecrypter(
+            FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext)
+        )
+        val decryptor = InvitationDecryptor(fake)
+        val alice = IdentityId("alice-id")
+        val bob = IdentityId("bob-id")
+
+        decryptor.decrypt("env-A".toByteArray(), asIdentity = alice)
+        decryptor.decrypt("env-B".toByteArray(), asIdentity = bob)
+
+        // The decryptor's only job for PR-6 (per-identity decryption
+        // routing) is to pass the per-record ownerIdentityId through
+        // to the envelope decrypter unchanged. This assertion is
+        // load-bearing: a regression here means envelopes addressed
+        // to identity B silently fail to decrypt while the user is
+        // on identity A — the exact bug PR-6 fixes.
+        val calls = fake.decryptCallsWithIdentity
+        assertEquals(2, calls.size)
+        assertEquals(alice, calls[0].asIdentity)
+        assertEquals(bob, calls[1].asIdentity)
     }
 
     @Test
@@ -58,8 +86,8 @@ class InvitationDecryptorTest {
         )
         val decryptor = InvitationDecryptor(fake)
 
-        val resA = decryptor.decrypt(envA)
-        val resB = decryptor.decrypt(envB)
+        val resA = decryptor.decrypt(envA, asIdentity = testIdentity)
+        val resB = decryptor.decrypt(envB, asIdentity = testIdentity)
 
         assertEquals("Alpha", resA.name); assertEquals(1uL, resA.epoch)
         assertEquals("Beta",  resB.name); assertEquals(2uL, resB.epoch)
@@ -74,8 +102,8 @@ class InvitationDecryptorTest {
         )
         val decryptor = InvitationDecryptor(fake)
 
-        val r1 = decryptor.decrypt("anything-1".toByteArray())
-        val r2 = decryptor.decrypt("anything-2".toByteArray())
+        val r1 = decryptor.decrypt("anything-1".toByteArray(), asIdentity = testIdentity)
+        val r2 = decryptor.decrypt("anything-2".toByteArray(), asIdentity = testIdentity)
 
         assertEquals(r1, r2)
         assertEquals("Constant", r1.name)
@@ -90,7 +118,7 @@ class InvitationDecryptorTest {
         val decryptor = InvitationDecryptor(fake)
 
         val thrown = assertThrows(InvitationDecryptError.UnsupportedScheme::class.java) {
-            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray()) }
+            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray(), asIdentity = testIdentity) }
         }
         // Same instance — interactor MUST NOT wrap or rewrap the seam's error.
         assertSame(cause, thrown)
@@ -108,7 +136,7 @@ class InvitationDecryptorTest {
         // contract is: seam errors are decryption failures; parser
         // errors are payload-shape failures, surfaced separately.
         val thrown = assertThrows(SerializationException::class.java) {
-            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray()) }
+            kotlinx.coroutines.runBlocking { decryptor.decrypt("env".toByteArray(), asIdentity = testIdentity) }
         }
         assertTrue("expected SerializationException, got ${thrown::class.simpleName}: ${thrown.message}", true)
     }

--- a/app/src/test/kotlin/chat/onym/android/persistence/RoomInvitationStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/persistence/RoomInvitationStoreTest.kt
@@ -163,10 +163,12 @@ class RoomInvitationStoreTest {
         payload: String,
         receivedAt: Instant = Instant.parse("2026-05-02T12:00:00Z"),
         status: IncomingInvitationStatus = IncomingInvitationStatus.Pending,
+        ownerIdentityIdString: String = "test-owner",
     ) = IncomingInvitationRecord(
         id = id,
         payload = payload.toByteArray(Charsets.UTF_8),
         receivedAt = receivedAt,
         status = status,
+        ownerIdentityIdString = ownerIdentityIdString,
     )
 }

--- a/app/src/test/kotlin/chat/onym/android/support/InMemoryInvitationStore.kt
+++ b/app/src/test/kotlin/chat/onym/android/support/InMemoryInvitationStore.kt
@@ -45,4 +45,12 @@ class InMemoryInvitationStore : InvitationStore {
     override suspend fun delete(id: String) {
         mutex.withLock { storage.remove(id) }
     }
+
+    override suspend fun deleteForOwner(ownerIdentityIdString: String): Int = mutex.withLock {
+        val toRemove = storage.values
+            .filter { it.ownerIdentityIdString == ownerIdentityIdString }
+            .map { it.id }
+        for (id in toRemove) storage.remove(id)
+        toRemove.size
+    }
 }


### PR DESCRIPTION
Mirrors onym-ios PR #59. Closes the multi-identity hole left over
from #56 (inbox fan-out): the fan-out was already persisting
envelopes addressed to non-active identities, but
\`decryptInvitation\` read only the currently-selected identity's
X25519 key. So an envelope addressed to identity B that arrived
while the user was on identity A would sit unrecoverable in the
inbox forever — a real product hole.

This PR threads the per-record \`ownerIdentityId\` through the
seam end-to-end: stamped at receive time by the fan-out, persisted
plaintext alongside the encrypted payload, filtered on read, and
consumed by the decrypter when the user opens the envelope.

## Schema change

- \`IncomingInvitationRecord\` + \`IncomingInvitation\` value types
  gain \`ownerIdentityId\`.
- \`PersistedInvitation\` gains an indexed plaintext column.
  Random per-device UUID — nothing to leak.
- \`InvitationDatabase\` v2. Pre-1.0 + greenfield licence — no
  Migration class; \`.fallbackToDestructiveMigration()\` is the
  contract for any builder. Production currently wires the
  in-memory store; only the test Room builder constructs the DB.
- \`InvitationStore.deleteForOwner(...)\` on the seam; both impls
  + the test fake updated.

## Repository

\`IncomingInvitationsRepository\` mirrors \`GroupRepository\`
one-for-one — \`identity: ActiveIdentityProvider\` + \`scope\`
constructor params, \`init\` registers the cascade-wipe removal
listener, \`start()\` collects identity changes, snapshots
filter by current identity, \`removeForOwner\` for explicit wipes.

## Decrypter

\`InvitationEnvelopeDecrypter.decryptInvitation(envelopeBytes,
asIdentity: IdentityId)\` — explicit identity arg replaces the
no-id overload. Single API path: the no-id overload had a silent
multi-identity bug. \`InvitationDecryptor.decrypt(...)\` and
\`IdentityRepository.decryptInvitation(...)\` updated to match.

## Fan-out

\`runFanout(entries: Flow<List<Pair<IdentityId,
TransportInboxId>>>)\` — each subscription captures its identity
ID and stamps inbounds with it. Replaces the
\`Flow<List<TransportInboxId>>\` shape.

## Tests

3 new acceptance assertions per the brief:
- snapshots-only-current-owner after fan-out persists multiple
- removeForOwner-wipes-that-identity-leaves-others
- decryptor-passes-per-record-asIdentity (the load-bearing one)

Plus existing inbox / persistence test suites updated for the new
signature shape. AndroidTest decrypt callsites pass
\`asIdentity = repo.currentIdentityId.value!!\`.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.inbox.*'\` — green
- [x] \`./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.persistence.*'\` — green
- [x] \`./gradlew :app:testDebugUnitTest --tests 'chat.onym.android.identity.*'\` — green
- [x] \`./gradlew :app:assembleDebug\` — green
- [ ] Manual: receive an invitation addressed to identity B while on A — switch to B, see the invitation surface; open it, see it decrypt.