### PR TITLE
ux: redesign Settings flow (Apple-style, brand-anchored)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
@@ -119,7 +119,7 @@ class IdentitiesUITest {
         }
         // Exactly one identity row is visible.
         val rowCount = composeRule.onAllNodesWithTag(
-            identityStore.listIds().first().testTagPrefix() + ".remove",
+            identityStore.listIds().first().testTagPrefix(),
         ).fetchSemanticsNodes().size
         assert(rowCount == 1) { "expected 1 identity row, saw $rowCount" }
     }
@@ -152,12 +152,20 @@ class IdentitiesUITest {
         }
 
         // The newly-added identity gets the auto-fill name "Identity 2".
+        // Post-redesign: removal moved into IdentityDetailScreen — tap
+        // the row to drill in, then "Delete identity" → typed-name
+        // confirm → Delete.
         val secondId = identityStore.listIds()[1]
-        composeRule.onNodeWithTag("identities.row.${secondId.value}.remove").performClick()
+        composeRule.onNodeWithTag("identities.row.${secondId.value}").performClick()
+        composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
+            composeRule.onAllNodesWithTag("identity_detail.delete").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag("identity_detail.delete").performClick()
 
-        // Type the expected name; tap Remove.
-        composeRule.onNodeWithTag("identities.remove.confirm.input").performTextInput("Identity 2")
-        composeRule.onNodeWithTag("identities.remove.confirm").performClick()
+        // Type the expected name; tap Delete.
+        composeRule.onNodeWithTag("identity_detail.delete.confirm.input")
+            .performTextInput("Identity 2")
+        composeRule.onNodeWithTag("identity_detail.delete.confirm").performClick()
 
         composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
             identityStore.listIds().size == 1

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -43,11 +43,15 @@ import chat.onym.android.recovery.RecoveryPhraseBackupScreen
 import chat.onym.android.recovery.RecoveryPhraseBackupViewModel
 import chat.onym.android.search.SearchScreen
 import chat.onym.android.identity.IdentitiesViewModel
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.settings.AboutOnymScreen
 import chat.onym.android.settings.AnchorsNetworkScreen
 import chat.onym.android.settings.AnchorsPickerViewModel
 import chat.onym.android.settings.AnchorsRootScreen
 import chat.onym.android.settings.AnchorsVersionScreen
 import chat.onym.android.settings.IdentitiesScreen
+import chat.onym.android.settings.IdentityDetailScreen
+import chat.onym.android.settings.PrivacyEncryptionScreen
 import chat.onym.android.settings.RelayerSettingsScreen
 import chat.onym.android.settings.RelayerSettingsViewModel
 import chat.onym.android.settings.SettingsScreen
@@ -164,11 +168,21 @@ fun RootScreen(
                     initialValue = dependencies.networkPreferenceProvider.current(),
                 )
                 val coroutineScope = rememberCoroutineScope()
+                val identitiesVm: IdentitiesViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeIdentitiesViewModel() }
+                    },
+                )
                 SettingsScreen(
-                    onBackupClick = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
+                    identitiesViewModel = identitiesVm,
                     onRelayerClick = { navController.navigate(ROUTE_RELAYER_SETTINGS) },
                     onAnchorsClick = { navController.navigate(ROUTE_ANCHORS_ROOT) },
                     onIdentitiesClick = { navController.navigate(ROUTE_IDENTITIES) },
+                    onIdentityDetailClick = { id ->
+                        navController.navigate("identity_detail/${id.value}")
+                    },
+                    onPrivacyClick = { navController.navigate(ROUTE_PRIVACY) },
+                    onAboutClick = { navController.navigate(ROUTE_ABOUT) },
                     useMainnet = networkPref == chat.onym.android.chain.AppNetwork.Mainnet,
                     onToggleMainnet = { on ->
                         coroutineScope.launch {
@@ -262,6 +276,33 @@ fun RootScreen(
                 )
                 IdentitiesScreen(
                     viewModel = vm,
+                    onBack = { navController.popBackStack() },
+                    onIdentityClick = { id ->
+                        navController.navigate("identity_detail/${id.value}")
+                    },
+                )
+            }
+            composable("identity_detail/{identityId}") { entry ->
+                val raw = entry.arguments?.getString("identityId") ?: return@composable
+                val vm: IdentitiesViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeIdentitiesViewModel() }
+                    },
+                )
+                IdentityDetailScreen(
+                    viewModel = vm,
+                    identityId = IdentityId(raw),
+                    onBack = { navController.popBackStack() },
+                    onBackup = { navController.navigate(ROUTE_RECOVERY_BACKUP) },
+                )
+            }
+            composable(ROUTE_PRIVACY) {
+                PrivacyEncryptionScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable(ROUTE_ABOUT) {
+                AboutOnymScreen(
                     onBack = { navController.popBackStack() },
                 )
             }
@@ -364,6 +405,8 @@ private enum class Tab(val route: String, val labelRes: Int) {
 
 private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
 private const val ROUTE_IDENTITIES = "identities"
+private const val ROUTE_PRIVACY = "privacy"
+private const val ROUTE_ABOUT = "about_onym"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"

--- a/app/src/main/kotlin/chat/onym/android/settings/AboutOnymScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AboutOnymScreen.kt
@@ -1,0 +1,375 @@
+package chat.onym.android.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.onym.android.BuildConfig
+import chat.onym.android.R
+import chat.onym.android.group.OnymMark
+
+/**
+ * About Onym — version, GitHub source links, and contact info.
+ *
+ * Repository links point at the **onymchat** GitHub org (single
+ * source of truth as of 2026-05). The design's `onym/onym-ios`
+ * placeholders are corrected here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutOnymScreen(
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    fun openUrl(url: String) {
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        } catch (_: Throwable) {
+            // No browser on the device — silently no-op rather than crash.
+        }
+    }
+    fun sendMail(addr: String) {
+        try {
+            context.startActivity(
+                Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:$addr"))
+            )
+        } catch (_: Throwable) { }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.about_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("about.list"),
+        ) {
+            // ─── Hero ────────────────────────────────────────────
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp, bottom = 28.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(104.dp)
+                            .clip(RoundedCornerShape(26.dp))
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(Color(0xFF1B1F24), Color(0xFF0D1117)),
+                                )
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        OnymMark(size = 64.dp, color = Color.White)
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = stringResource(R.string.app_name),
+                        style = MaterialTheme.typography.displaySmall.copy(
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = stringResource(R.string.brand_tagline),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.about_version_pill,
+                            BuildConfig.VERSION_NAME,
+                            BuildConfig.VERSION_CODE.toString(),
+                        ),
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontFamily = FontFamily.Monospace
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // ─── VERSION ─────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.about_version_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        title = stringResource(R.string.about_version_label),
+                        showChevron = false,
+                        trailing = {
+                            Text(
+                                text = BuildConfig.VERSION_NAME,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        insetHairline = 16.dp,
+                    )
+                    SettingsRow(
+                        title = stringResource(R.string.about_build_label),
+                        showChevron = false,
+                        trailing = {
+                            Text(
+                                text = BuildConfig.VERSION_CODE.toString(),
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontFamily = FontFamily.Monospace
+                                ),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        insetHairline = 16.dp,
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── RESOURCES ───────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.about_resources_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.GitHub) },
+                        title = stringResource(R.string.about_source_android),
+                        subtitle = "github.com/onymchat/onym-android",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-android") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.GitHub) },
+                        title = stringResource(R.string.about_source_ios),
+                        subtitle = "github.com/onymchat/onym-ios",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-ios") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.Indigo) },
+                        title = stringResource(R.string.about_source_contracts),
+                        subtitle = "github.com/onymchat/onym-contracts",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-contracts") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.Indigo) },
+                        title = stringResource(R.string.about_source_relayer),
+                        subtitle = "github.com/onymchat/onym-relayer",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-relayer") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Description, SettingsTile.Indigo) },
+                        title = stringResource(R.string.about_documentation),
+                        subtitle = stringResource(R.string.about_documentation_subtitle),
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.AutoMirrored.Filled.Article, SettingsTile.Green) },
+                        title = stringResource(R.string.about_whitepaper),
+                        subtitle = stringResource(R.string.about_whitepaper_subtitle),
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-paper") },
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── HELP ────────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.about_help_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.AutoMirrored.Filled.HelpOutline, SettingsTile.Blue) },
+                        title = stringResource(R.string.about_issues_title),
+                        subtitle = stringResource(R.string.about_issues_subtitle),
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/onymchat/onym-android/issues") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Forum, SettingsTile.Green) },
+                        title = stringResource(R.string.about_discussions_title),
+                        subtitle = stringResource(R.string.about_discussions_subtitle),
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { openUrl("https://github.com/orgs/onymchat/discussions") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Email, SettingsTile.Orange) },
+                        title = stringResource(R.string.about_contact_title),
+                        subtitle = "hello@onym.chat",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = {
+                            Icon(
+                                Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        onClick = { sendMail("hello@onym.chat") },
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── Credits ─────────────────────────────────────────
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 36.dp, bottom = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    OnymMark(
+                        size = 22.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                    )
+                    Text(
+                        text = stringResource(R.string.about_credits_line1),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                    Text(
+                        text = stringResource(R.string.about_credits_line2),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                    )
+                    Text(
+                        text = stringResource(R.string.about_credits_copyright),
+                        style = MaterialTheme.typography.labelSmall.copy(
+                            fontFamily = FontFamily.Monospace
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
@@ -9,66 +9,69 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ExtendedFloatingActionButton
-import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
+import chat.onym.android.group.OnymMark
 import chat.onym.android.identity.IdentitiesViewModel
 import chat.onym.android.identity.IdentityId
-import kotlinx.coroutines.launch
 
 /**
  * Settings → Identities. Lists every identity on the device, marks
- * the active one, lets the user add a fresh identity ("Add" FAB) or
- * remove an existing one (per-row trash → name-confirm dialog).
+ * the active one. Tap a row to drill into [IdentityDetailScreen]
+ * (set-active, copy keys, delete). Add via the bottom "Add Identity"
+ * button — the redesign moves the FAB into a card-style action so it
+ * sits with the list rather than floating over it.
  *
- * Removing an identity cascades a delete of its local chats via
- * `IdentityRepository.registerRemovalListener` (PR-3 wiring) — the
- * confirm dialog spells that out.
+ * Removal moved to the per-identity detail page; this screen is now
+ * pure listing + add.
  */
-@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun IdentitiesScreen(
     viewModel: IdentitiesViewModel,
     onBack: () -> Unit,
+    onIdentityClick: (IdentityId) -> Unit,
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
     val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
 
     LaunchedEffect(errorMessage) {
         errorMessage?.let {
@@ -77,177 +80,148 @@ fun IdentitiesScreen(
         }
     }
 
-    var pendingRemoval by remember { mutableStateOf<IdentitiesViewModel.Row?>(null) }
-
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(
-                title = { Text("Identities") },
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.identities_screen_title)) },
                 navigationIcon = {
-                    Box(
-                        modifier = Modifier
-                            .padding(8.dp)
-                            .clickable(onClick = onBack)
-                            .testTag("identities.back"),
-                    ) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    IconButton(onClick = onBack, modifier = Modifier.testTag("identities.back")) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                ),
+                scrollBehavior = scrollBehavior,
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        floatingActionButton = {
-            ExtendedFloatingActionButton(
-                text = { Text("Add identity") },
-                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
-                onClick = { viewModel.add() },
-                elevation = FloatingActionButtonDefaults.elevation(defaultElevation = 0.dp),
-                modifier = Modifier.testTag("identities.add"),
-            )
-        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
+            contentPadding = padding,
+            modifier = Modifier.fillMaxSize().testTag("identities.list"),
         ) {
-            items(items, key = { it.summary.id.value }) { row ->
-                IdentityRow(
-                    row = row,
-                    onTap = { if (!row.isActive) viewModel.select(row.summary.id) },
-                    onRemove = { pendingRemoval = row },
-                )
+            item {
+                SettingsFootnote(stringResource(R.string.identities_screen_intro))
             }
-        }
-    }
-
-    pendingRemoval?.let { row ->
-        RemoveIdentityDialog(
-            row = row,
-            onDismiss = { pendingRemoval = null },
-            onConfirm = {
-                viewModel.remove(row.summary.id)
-                pendingRemoval = null
-            },
-        )
-    }
-}
-
-@Composable
-private fun IdentityRow(
-    row: IdentitiesViewModel.Row,
-    onTap: () -> Unit,
-    onRemove: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onTap)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .testTag("identities.row.${row.summary.id.value}"),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        // Active checkmark or empty slot.
-        Box(modifier = Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            if (row.isActive) {
-                Icon(
-                    Icons.Filled.Check,
-                    contentDescription = "Active",
-                    tint = MaterialTheme.colorScheme.primary,
-                )
+            item { SettingsSectionLabel(stringResource(R.string.identities_section_your)) }
+            item {
+                SettingsCard {
+                    items.forEachIndexed { i, row ->
+                        IdentityListRow(
+                            row = row,
+                            isLast = i == items.size - 1,
+                            onClick = { onIdentityClick(row.summary.id) },
+                        )
+                    }
+                }
             }
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = row.summary.name.ifBlank { "Unnamed identity" },
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = if (row.isActive) FontWeight.SemiBold else FontWeight.Normal,
-            )
-            Text(
-                text = "BLS ${row.summary.blsPublicKey.toHexShort()}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clickable(onClick = onRemove)
-                .testTag("identities.row.${row.summary.id.value}.remove"),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                Icons.Filled.Delete,
-                contentDescription = "Remove",
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            item {
+                Spacer(Modifier.height(12.dp))
+                SettingsCard(modifier = Modifier.testTag("identities.add_card")) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { viewModel.add() }
+                            .padding(horizontal = 16.dp, vertical = 13.dp)
+                            .testTag("identities.add"),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(22.dp)
+                                .clip(CircleShape)
+                                .background(SettingsTile.Blue),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Filled.Add,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.identities_add_button),
+                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                            color = SettingsTile.Blue,
+                        )
+                    }
+                }
+            }
+            item {
+                SettingsFootnote(stringResource(R.string.identities_screen_footer))
+            }
+            item { Spacer(Modifier.height(40.dp)) }
         }
     }
 }
 
 @Composable
-private fun RemoveIdentityDialog(
+private fun IdentityListRow(
     row: IdentitiesViewModel.Row,
-    onDismiss: () -> Unit,
-    onConfirm: () -> Unit,
+    isLast: Boolean,
+    onClick: () -> Unit,
 ) {
-    val expectedName = row.summary.name.ifBlank { "Unnamed identity" }
-    var typed by remember { mutableStateOf("") }
-    val canConfirm = typed.trim() == expectedName
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Remove ${row.summary.name.ifBlank { "this identity" }}?") },
-        text = {
-            Column {
-                Text(
-                    "Removing this identity wipes its local chats and messages permanently. " +
-                        "Anchored groups stay on chain but you'll lose your local copy.",
-                    style = MaterialTheme.typography.bodyMedium,
+    val displayName = row.summary.name.ifBlank { stringResource(R.string.identity_unnamed) }
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 11.dp)
+                .testTag("identities.row.${row.summary.id.value}"),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // Identity tile — OnymMark inside a soft circle. Active gets a blue ring.
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(if (row.isActive) Color(0xFFE0EEFE) else Color(0xFFEAEAEE)),
+                contentAlignment = Alignment.Center,
+            ) {
+                OnymMark(
+                    size = 22.dp,
+                    color = if (row.isActive) SettingsTile.Blue else SettingsTile.Gray,
                 )
-                Spacer(modifier = Modifier.size(12.dp))
+            }
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    "Type \"$expectedName\" to confirm:",
-                    style = MaterialTheme.typography.bodySmall,
+                    text = displayName,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = if (row.isActive) FontWeight.SemiBold else FontWeight.Normal
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = heroHex(row.summary.blsPublicKey),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Spacer(modifier = Modifier.size(4.dp))
-                OutlinedTextField(
-                    value = typed,
-                    onValueChange = { typed = it },
-                    singleLine = true,
+            }
+            if (row.isActive) {
+                Text(
+                    text = stringResource(R.string.identity_detail_active_marker),
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                    color = SettingsTile.Green,
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag("identities.remove.confirm.input"),
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(SettingsTile.Green.copy(alpha = 0.14f))
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
                 )
             }
-        },
-        confirmButton = {
-            Button(
-                onClick = onConfirm,
-                enabled = canConfirm,
-                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.error,
-                ),
-                modifier = Modifier.testTag("identities.remove.confirm"),
-            ) {
-                Text("Remove")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
-        },
-    )
-}
-
-private fun ByteArray.toHexShort(): String {
-    if (isEmpty()) return ""
-    val sb = StringBuilder()
-    for (i in 0 until minOf(4, size)) sb.append("%02x".format(this[i].toInt() and 0xFF))
-    if (size > 4) sb.append("…")
-    return sb.toString()
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        if (!isLast) SettingsHairline(insetStart = 68.dp)
+    }
 }

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
@@ -1,0 +1,386 @@
+package chat.onym.android.settings
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
+import chat.onym.android.group.OnymMark
+import chat.onym.android.identity.IdentitiesViewModel
+import chat.onym.android.identity.IdentityId
+
+/**
+ * Identity Detail — per-identity hero, backup status, set-active,
+ * delete. Backup launches the recovery flow for the active identity;
+ * if this identity isn't the active one, taps switch to it first
+ * (the `RecoveryPhraseBackupViewModel` reads `repository.snapshots`
+ * which always points at the active identity).
+ *
+ * Uses [IdentitiesViewModel] for select/remove intents.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IdentityDetailScreen(
+    viewModel: IdentitiesViewModel,
+    identityId: IdentityId,
+    onBack: () -> Unit,
+    onBackup: () -> Unit,
+) {
+    val items by viewModel.items.collectAsStateWithLifecycle()
+    val row = items.firstOrNull { it.summary.id == identityId }
+    val context = LocalContext.current
+    var pendingRemoval by remember { mutableStateOf(false) }
+
+    if (row == null) {
+        // Identity was removed (or hasn't loaded yet) — show empty
+        // scaffold with the back-button.
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = { Text(stringResource(R.string.identity_detail_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.back))
+                        }
+                    },
+                )
+            },
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ) { padding ->
+            Box(modifier = Modifier.fillMaxSize().padding(padding))
+        }
+        return
+    }
+
+    val displayName = row.summary.name.ifBlank { stringResource(R.string.identity_unnamed) }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(displayName) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("identity_detail.list"),
+        ) {
+            // ─── Hero ─────────────────────────────────────────────
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp, bottom = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Box(
+                        modifier = Modifier.size(100.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(96.dp)
+                                .clip(CircleShape)
+                                .background(
+                                    if (row.isActive) {
+                                        Brush.linearGradient(listOf(Color(0xFFEEF5FF), Color(0xFFD5E8FE)))
+                                    } else {
+                                        Brush.linearGradient(listOf(Color(0xFFEFEFF2), Color(0xFFEFEFF2)))
+                                    }
+                                ),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            OnymMark(
+                                size = 64.dp,
+                                color = if (row.isActive) SettingsTile.Blue else SettingsTile.Gray,
+                            )
+                        }
+                    }
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = heroHex(row.summary.blsPublicKey),
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // ─── BACKUP card ──────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.identity_detail_backup_section)) }
+            item {
+                SettingsCard {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(SettingsTile.Amber),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Filled.Warning,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.identity_detail_backup_status_unknown),
+                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                text = stringResource(R.string.identity_detail_backup_status_subtitle),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    SettingsHairline(insetStart = 16.dp)
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Key, SettingsTile.Orange)
+                        },
+                        title = stringResource(R.string.identity_detail_backup_action),
+                        subtitle = stringResource(R.string.identity_detail_backup_action_subtitle),
+                        onClick = {
+                            // Flip active first (recovery VM reads
+                            // repository.snapshots — always the active
+                            // identity), then launch the flow.
+                            if (!row.isActive) {
+                                viewModel.select(identityId)
+                            }
+                            onBackup()
+                        },
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── STATE ─────────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.identity_detail_state_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Check, SettingsTile.Green)
+                        },
+                        title = stringResource(R.string.identity_detail_set_active),
+                        showChevron = !row.isActive,
+                        trailing = if (row.isActive) {
+                            {
+                                Text(
+                                    text = stringResource(R.string.identity_detail_active_marker),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else null,
+                        onClick = if (row.isActive) null else {
+                            { viewModel.select(identityId) }
+                        },
+                        isLast = true,
+                        modifier = Modifier.testTag("identity_detail.set_active"),
+                    )
+                }
+            }
+
+            // ─── ADVANCED ──────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.identity_detail_advanced_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.ContentCopy, SettingsTile.Gray)
+                        },
+                        title = stringResource(R.string.identity_detail_copy_bls),
+                        subtitle = heroHex(row.summary.blsPublicKey),
+                        subtitleMono = true,
+                        showChevron = false,
+                        onClick = {
+                            val hex = row.summary.blsPublicKey.joinToString("") {
+                                "%02x".format(it.toInt() and 0xFF)
+                            }
+                            copyToClipboard(context, "BLS public key", hex)
+                        },
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.ContentCopy, SettingsTile.Gray)
+                        },
+                        title = stringResource(R.string.identity_detail_copy_inbox),
+                        subtitle = heroHex(row.summary.inboxPublicKey),
+                        subtitleMono = true,
+                        showChevron = false,
+                        onClick = {
+                            val hex = row.summary.inboxPublicKey.joinToString("") {
+                                "%02x".format(it.toInt() and 0xFF)
+                            }
+                            copyToClipboard(context, "Inbox public key", hex)
+                        },
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Delete, SettingsTile.Red)
+                        },
+                        title = stringResource(R.string.identity_detail_delete),
+                        titleColor = MaterialTheme.colorScheme.error,
+                        showChevron = false,
+                        onClick = { pendingRemoval = true },
+                        isLast = true,
+                        modifier = Modifier.testTag("identity_detail.delete"),
+                    )
+                }
+            }
+            item {
+                SettingsFootnote(stringResource(R.string.identity_detail_delete_footnote))
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+
+    if (pendingRemoval) {
+        RemoveIdentityDialog(
+            displayName = displayName,
+            onDismiss = { pendingRemoval = false },
+            onConfirm = {
+                viewModel.remove(identityId)
+                pendingRemoval = false
+                onBack()
+            },
+        )
+    }
+}
+
+@Composable
+private fun RemoveIdentityDialog(
+    displayName: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    var typed by remember { mutableStateOf("") }
+    val canConfirm = typed.trim() == displayName
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.identity_detail_delete_dialog_title, displayName)) },
+        text = {
+            Column {
+                Text(
+                    stringResource(R.string.identity_detail_delete_dialog_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    stringResource(R.string.identity_detail_delete_dialog_typename, displayName),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = typed,
+                    onValueChange = { typed = it },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("identity_detail.delete.confirm.input"),
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = canConfirm,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                ),
+                modifier = Modifier.testTag("identity_detail.delete.confirm"),
+            ) {
+                Text(stringResource(R.string.identity_detail_delete_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) }
+        },
+    )
+}
+
+private fun copyToClipboard(context: Context, label: String, value: String) {
+    val cb = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    cb.setPrimaryClip(ClipData.newPlainText(label, value))
+    Toast.makeText(context, R.string.copied, Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/PrivacyEncryptionScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/PrivacyEncryptionScreen.kt
@@ -1,0 +1,213 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+
+/**
+ * Privacy & Encryption — read-only explainer of how Onym keeps
+ * messages private. Stack: a green "everything is encrypted" hero,
+ * a "How it works" group with the three protocol guarantees, and a
+ * "Your keys" group that names the cryptographic primitives derived
+ * from the user's seed.
+ *
+ * No toggles or destructive actions live here yet — the design's
+ * read-receipts / Face-ID / cache-clear surfaces require backing
+ * features the app doesn't expose; they'll land alongside those
+ * features.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrivacyEncryptionScreen(
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.privacy_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("privacy.list"),
+        ) {
+            // ─── Encryption status hero ───────────────────────────
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(horizontal = 18.dp, vertical = 18.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(Color(0xFFDFFAEA), Color(0xFFB6F0CD)),
+                                )
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Filled.Shield,
+                            contentDescription = null,
+                            tint = SettingsTile.Green,
+                            modifier = Modifier.size(28.dp),
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.privacy_hero_title),
+                            style = MaterialTheme.typography.titleSmall.copy(
+                                fontWeight = FontWeight.SemiBold
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Spacer(Modifier.height(3.dp))
+                        Text(
+                            text = stringResource(R.string.privacy_hero_subtitle),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // ─── How it works ─────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.privacy_how_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Key, SettingsTile.Purple) },
+                        title = stringResource(R.string.privacy_e2e_title),
+                        subtitle = stringResource(R.string.privacy_e2e_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.VisibilityOff, SettingsTile.Indigo) },
+                        title = stringResource(R.string.privacy_anon_title),
+                        subtitle = stringResource(R.string.privacy_anon_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Star, SettingsTile.Green) },
+                        title = stringResource(R.string.privacy_verifiable_title),
+                        subtitle = stringResource(R.string.privacy_verifiable_subtitle),
+                        showChevron = false,
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── Your keys ────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.privacy_keys_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileLabel("39", SettingsTile.Gray) },
+                        title = stringResource(R.string.privacy_keys_bip39),
+                        subtitle = stringResource(R.string.privacy_keys_bip39_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("npub", SettingsTile.Indigo) },
+                        title = stringResource(R.string.privacy_keys_nostr),
+                        subtitle = stringResource(R.string.privacy_keys_nostr_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("BLS", SettingsTile.Purple) },
+                        title = stringResource(R.string.privacy_keys_bls),
+                        subtitle = stringResource(R.string.privacy_keys_bls_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("XLM", SettingsTile.Orange) },
+                        title = stringResource(R.string.privacy_keys_stellar),
+                        subtitle = stringResource(R.string.privacy_keys_stellar_subtitle),
+                        showChevron = false,
+                        isLast = true,
+                    )
+                }
+            }
+            item { SettingsFootnote(stringResource(R.string.privacy_keys_footnote)) }
+
+            // ─── Transport ────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.privacy_transport_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Lock, SettingsTile.Blue) },
+                        title = stringResource(R.string.privacy_transport_relayer_title),
+                        subtitle = stringResource(R.string.privacy_transport_relayer_subtitle),
+                        showChevron = false,
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Public, SettingsTile.Orange) },
+                        title = stringResource(R.string.privacy_transport_chain_title),
+                        subtitle = stringResource(R.string.privacy_transport_chain_subtitle),
+                        showChevron = false,
+                        isLast = true,
+                    )
+                }
+            }
+            item { SettingsFootnote(stringResource(R.string.privacy_transport_footnote)) }
+
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsAtoms.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsAtoms.kt
@@ -1,0 +1,223 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared layout atoms for the redesigned Settings flow. Keep them
+ * private-to-the-package so the rest of the app can't import the
+ * Apple-Settings-style row by accident — each screen wants the
+ * specific spacing tokens these atoms encode.
+ */
+
+internal object SettingsTile {
+    val Purple = Color(0xFFA04CE0)
+    val Blue = Color(0xFF0A84FF)
+    val Indigo = Color(0xFF5B5BE2)
+    val Orange = Color(0xFFFF7A2D)
+    val Green = Color(0xFF30B45A)
+    val Gray = Color(0xFF8E8E93)
+    val Red = Color(0xFFE5392E)
+    val Teal = Color(0xFF2BB3CF)
+    val Amber = Color(0xFFFF9500)
+    val GitHub = Color(0xFF0A0A0C)
+}
+
+@Composable
+internal fun SettingsCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+    ) { content() }
+}
+
+@Composable
+internal fun SettingsSectionLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 32.dp, end = 16.dp, top = 20.dp, bottom = 6.dp),
+    )
+}
+
+@Composable
+internal fun SettingsFootnote(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+internal fun SettingsHairline(insetStart: Dp = 60.dp) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .padding(start = insetStart)
+            .height(0.5.dp)
+            .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+    )
+}
+
+@Composable
+internal fun SettingsTileBox(
+    icon: ImageVector,
+    background: Color,
+    size: Dp = 30.dp,
+) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(RoundedCornerShape(7.dp))
+            .background(background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(size * 0.55f),
+        )
+    }
+}
+
+@Composable
+internal fun SettingsTileLabel(
+    label: String,
+    background: Color,
+    size: Dp = 30.dp,
+) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(RoundedCornerShape(7.dp))
+            .background(background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            color = Color.White,
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+        )
+    }
+}
+
+/**
+ * Apple-Settings-style grouped row. Single tile glyph + title + optional
+ * subtitle; trailing accessory is right-aligned. The trailing chevron
+ * is drawn automatically when [onClick] is non-null and [showChevron]
+ * is true.
+ */
+@Composable
+internal fun SettingsRow(
+    leading: (@Composable () -> Unit)? = null,
+    title: String,
+    subtitle: String? = null,
+    subtitleMono: Boolean = false,
+    trailing: (@Composable () -> Unit)? = null,
+    titleColor: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: (() -> Unit)? = null,
+    showChevron: Boolean = onClick != null,
+    isLast: Boolean = false,
+    insetHairline: Dp = 60.dp,
+    modifier: Modifier = Modifier,
+) {
+    val rowMod = if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(rowMod)
+                .padding(horizontal = 16.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            leading?.invoke()
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = titleColor,
+                )
+                if (subtitle != null) {
+                    Spacer(Modifier.height(1.dp))
+                    Text(
+                        text = subtitle,
+                        style = if (subtitleMono) {
+                            MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                            )
+                        } else {
+                            MaterialTheme.typography.bodySmall
+                        },
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (trailing != null) {
+                trailing()
+            }
+            if (showChevron) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+        if (!isLast) SettingsHairline(insetStart = insetHairline)
+    }
+}
+
+/**
+ * Six-byte hex of a public key, with the universal "BLS …" prefix
+ * stripped if present.
+ */
+internal fun shortHex(bytes: ByteArray, keepBytes: Int = 9): String {
+    if (bytes.isEmpty()) return ""
+    val sb = StringBuilder()
+    val n = minOf(keepBytes, bytes.size)
+    for (i in 0 until n) sb.append("%02x".format(bytes[i].toInt() and 0xFF))
+    if (bytes.size > n) sb.append('…')
+    return sb.toString()
+}
+
+/** Long-form mono fragment: 18 hex chars + ellipsis, suitable for
+ *  the identity hero. */
+internal fun heroHex(bytes: ByteArray): String = shortHex(bytes, keepBytes = 9)

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -2,25 +2,30 @@ package chat.onym.android.settings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -29,42 +34,51 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.BuildConfig
 import chat.onym.android.R
+import chat.onym.android.group.OnymMark
+import chat.onym.android.identity.IdentitiesViewModel
+import chat.onym.android.identity.IdentityId
 
 /**
- * Settings tab — entry point for the recovery-phrase backup flow.
- * Minimal first cut: one Security section with the Backup row that
- * navigates to [chat.onym.android.recovery.RecoveryPhraseBackupScreen].
+ * Settings home — Apple-Settings-style, brand-anchored on the
+ * broken-ring Onym mark.
  *
- * Mirrors `SettingsView.swift` from onym-ios PR #6 (PR #6 there, not
- * the onym-android #6). More sections (preferences, advanced, about)
- * land as the app grows.
+ * Layout (top → bottom):
  *
- * UX choices vs iOS:
+ *   1. Active-identity hero (tap → identity detail).
+ *   2. SECURITY section: Identities · Privacy & Encryption.
+ *   3. NETWORK section: Relays · Anchors · Use Mainnet toggle.
+ *   4. APP section: About Onym.
+ *   5. Brand watermark + "open · anonymous · onchain" tagline.
  *
- *   - `LargeTopAppBar` = SwiftUI's `.navigationTitle("Settings")` in
- *     iOS 16+ default (large title that collapses on scroll).
- *   - `ListItem` + `headlineContent`/`leadingContent`/`trailingContent`
- *     = the iOS Form row shape.
- *   - The orange key-icon RoundedRect ([SettingsIconBox]) is the same
- *     atom the recovery-flow Intro screen's rules list uses.
+ * The redesign drops the original Backup row + standalone Identities
+ * row in favor of the Identity Detail card (per-identity backup) and
+ * a sectioned home that mirrors iOS Settings.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    onBackupClick: () -> Unit,
+    identitiesViewModel: IdentitiesViewModel,
     onRelayerClick: () -> Unit,
     onAnchorsClick: () -> Unit,
     onIdentitiesClick: () -> Unit,
+    onIdentityDetailClick: (IdentityId) -> Unit,
+    onPrivacyClick: () -> Unit,
+    onAboutClick: () -> Unit,
     /** App-wide network preference. Bound to the Settings → Network
      *  → "Use Mainnet" Switch. */
     useMainnet: Boolean,
@@ -73,6 +87,10 @@ fun SettingsScreen(
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
     )
+    val items by identitiesViewModel.items.collectAsStateWithLifecycle()
+    val active = items.firstOrNull { it.isActive }
+    val identityCount = items.size
+
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
@@ -85,206 +103,235 @@ fun SettingsScreen(
     ) { padding ->
         LazyColumn(
             contentPadding = padding,
-            modifier = Modifier.testTag("settings.list"),
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("settings.list"),
         ) {
-            // Groups section moved to the Chats tab (PR-30) — Settings
-            // now opens straight to the Security section.
-            item {
-                SectionHeader(stringResource(R.string.security))
-            }
-            item {
-                ListItem(
-                    headlineContent = {
-                        Text(stringResource(R.string.backup_recovery_phrase))
-                    },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = Icons.Filled.Key,
-                            background = Color(0xFFFF9500),
-                        )
-                    },
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        )
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onBackupClick),
-                )
-            }
-            item {
-                Text(
-                    stringResource(R.string.security_footer_view_recovery_phrase),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
-                )
+            // ─── Active identity hero ──────────────────────────────
+            if (active != null) {
+                item {
+                    ActiveIdentityHero(
+                        name = active.summary.name.ifBlank {
+                            stringResource(R.string.identity_unnamed)
+                        },
+                        keyHex = heroHex(active.summary.blsPublicKey),
+                        onClick = { onIdentityDetailClick(active.summary.id) },
+                    )
+                }
             }
 
-            // Identities — multi-identity management (PR-5).
-            item { SectionHeader("Identities") }
+            // ─── SECURITY ──────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.security).uppercase()) }
             item {
-                ListItem(
-                    headlineContent = { Text("Manage identities") },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = Icons.Filled.Person,
-                            background = Color(0xFFAF52DE),
-                        )
-                    },
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        )
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onIdentitiesClick)
-                        .testTag("settings.identities_row"),
-                )
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Person, SettingsTile.Purple)
+                        },
+                        title = stringResource(R.string.settings_identities_title),
+                        subtitle = if (identityCount == 1) {
+                            stringResource(R.string.settings_identities_subtitle_one)
+                        } else {
+                            stringResource(R.string.settings_identities_subtitle_n, identityCount)
+                        },
+                        onClick = onIdentitiesClick,
+                        modifier = Modifier.testTag("settings.identities_row"),
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Shield, SettingsTile.Blue)
+                        },
+                        title = stringResource(R.string.settings_privacy_title),
+                        subtitle = stringResource(R.string.settings_privacy_subtitle),
+                        onClick = onPrivacyClick,
+                        isLast = true,
+                        modifier = Modifier.testTag("settings.privacy_row"),
+                    )
+                }
             }
 
-            // Network section — relayer URL config + anchor contract
-            // versions. Localized via res/values/ + values-ru/ per
-            // PR #21's catalog work.
-            item { SectionHeader(stringResource(R.string.settings_network)) }
+            // ─── NETWORK ───────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.settings_network).uppercase()) }
             item {
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.relayer_title)) },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = Icons.Filled.Cloud,
-                            background = Color(0xFF34C759),
-                        )
-                    },
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        )
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onRelayerClick)
-                        .testTag("settings.relayer_row"),
-                )
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Cloud, SettingsTile.Indigo)
+                        },
+                        title = stringResource(R.string.relayer_title),
+                        subtitle = stringResource(R.string.settings_relayer_subtitle),
+                        onClick = onRelayerClick,
+                        modifier = Modifier.testTag("settings.relayer_row"),
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Anchor, SettingsTile.Orange)
+                        },
+                        title = stringResource(R.string.anchors_title),
+                        subtitle = stringResource(
+                            if (useMainnet) R.string.settings_anchors_subtitle_mainnet
+                            else R.string.settings_anchors_subtitle_testnet
+                        ),
+                        onClick = onAnchorsClick,
+                        modifier = Modifier.testTag("settings.anchors_row"),
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(
+                                icon = if (useMainnet) Icons.Filled.Public else Icons.Filled.Build,
+                                background = if (useMainnet) SettingsTile.Green else SettingsTile.Gray,
+                            )
+                        },
+                        title = stringResource(R.string.settings_use_mainnet),
+                        subtitle = stringResource(
+                            if (useMainnet) R.string.settings_use_mainnet_on_subtitle
+                            else R.string.settings_use_mainnet_off_subtitle
+                        ),
+                        showChevron = false,
+                        trailing = {
+                            Switch(
+                                checked = useMainnet,
+                                onCheckedChange = onToggleMainnet,
+                                modifier = Modifier.testTag("settings.use_mainnet_toggle"),
+                            )
+                        },
+                        onClick = { onToggleMainnet(!useMainnet) },
+                        isLast = true,
+                    )
+                }
             }
             item {
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.anchors_title)) },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = Icons.Filled.Anchor,
-                            background = Color(0xFF5856D6),
-                        )
-                    },
-                    trailingContent = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                        )
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable(onClick = onAnchorsClick)
-                        .testTag("settings.anchors_row"),
-                )
-            }
-            // Use Mainnet toggle (PR-C follow-up). Persisted in
-            // DataStore under `onym.useMainnet`; flipping here changes
-            // the network the next Create Group flow will use.
-            // Existing groups keep whatever network they were created on.
-            item {
-                ListItem(
-                    headlineContent = { Text(stringResource(R.string.settings_use_mainnet)) },
-                    leadingContent = {
-                        SettingsIconBox(
-                            icon = if (useMainnet) Icons.Filled.Public else Icons.Filled.Build,
-                            background = if (useMainnet) Color(0xFF34C759) else Color(0xFF8E8E93),
-                        )
-                    },
-                    trailingContent = {
-                        Switch(checked = useMainnet, onCheckedChange = onToggleMainnet)
-                    },
-                    colors = ListItemDefaults.colors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    ),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .clickable { onToggleMainnet(!useMainnet) }
-                        .testTag("settings.use_mainnet_toggle"),
-                )
-            }
-            item {
-                Text(
+                SettingsFootnote(
                     stringResource(
                         if (useMainnet) R.string.settings_use_mainnet_on_footer
                         else R.string.settings_use_mainnet_off_footer,
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 32.dp, vertical = 8.dp),
+                    )
                 )
             }
+
+            // ─── APP ───────────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.settings_app_section).uppercase()) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(Icons.Filled.Info, SettingsTile.Teal)
+                        },
+                        title = stringResource(R.string.settings_about_title),
+                        subtitle = stringResource(
+                            R.string.settings_about_subtitle,
+                            BuildConfig.VERSION_NAME,
+                            BuildConfig.VERSION_CODE.toString(),
+                        ),
+                        onClick = onAboutClick,
+                        isLast = true,
+                        modifier = Modifier.testTag("settings.about_row"),
+                    )
+                }
+            }
+
+            // ─── Brand watermark ───────────────────────────────────
+            item { Spacer(Modifier.height(28.dp)) }
+            item { BrandFooter() }
+            item { Spacer(Modifier.height(32.dp)) }
         }
     }
 }
 
 @Composable
-private fun SectionHeader(text: String) {
-    Text(
-        text.uppercase(),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+private fun ActiveIdentityHero(
+    name: String,
+    keyHex: String,
+    onClick: () -> Unit,
+) {
+    Row(
         modifier = Modifier
-            .padding(horizontal = 32.dp)
-            .padding(top = 16.dp, bottom = 6.dp),
-    )
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .testTag("settings.identity_hero"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Box(
+            modifier = Modifier.size(60.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.linearGradient(
+                            listOf(Color(0xFFEEF5FF), Color(0xFFE0EEFE)),
+                        )
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                OnymMark(size = 36.dp, color = SettingsTile.Blue)
+            }
+            // Active-state dot (bottom-right)
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .size(16.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(12.dp)
+                        .clip(CircleShape)
+                        .background(SettingsTile.Green),
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.settings_active_identity_label).uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = name,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = keyHex,
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+            modifier = Modifier.size(18.dp),
+        )
+    }
 }
 
-/**
- * 30dp coloured RoundedRect with a centred Icon inside. Matches the
- * iOS `SettingsIconBox` and the recovery-flow `RoundedIcon` from the
- * Intro screen.
- */
 @Composable
-private fun SettingsIconBox(icon: ImageVector, background: Color) {
-    Box(
-        modifier = Modifier
-            .size(30.dp)
-            .clip(RoundedCornerShape(7.dp))
-            .background(background),
-        contentAlignment = Alignment.Center,
+private fun BrandFooter() {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Icon(
-            icon,
-            contentDescription = null,
-            tint = Color.White,
-            modifier = Modifier.size(15.dp),
+        OnymMark(
+            size = 26.dp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+        )
+        Text(
+            text = stringResource(R.string.brand_tagline),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
         )
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -130,6 +130,104 @@
     <string name="anchors_network_footer">Каждый тип управления использует отдельный контракт. Тег версии в скобках — это версия, к которой будет привязан новый чат.</string>
     <string name="anchors_reset_footer">Сброс очищает явный выбор — новые чаты используют последнюю опубликованную версию.</string>
 
+    <!-- ─── Settings home (redesigned) ───────────────────────────── -->
+    <string name="brand_tagline">открыто · анонимно · в блокчейне</string>
+    <string name="settings_active_identity_label">Активная личность</string>
+    <string name="settings_app_section">Приложение</string>
+    <string name="settings_identities_title">Личности</string>
+    <string name="settings_identities_subtitle_one">1 на этом устройстве</string>
+    <string name="settings_identities_subtitle_n">%1$d на этом устройстве</string>
+    <string name="settings_privacy_title">Приватность и шифрование</string>
+    <string name="settings_privacy_subtitle">Сквозное шифрование · BIP-39</string>
+    <string name="settings_relayer_subtitle">Отправляет транзакции от вашего имени</string>
+    <string name="settings_anchors_subtitle_testnet">Stellar · Тестовая сеть</string>
+    <string name="settings_anchors_subtitle_mainnet">Stellar · Основная сеть</string>
+    <string name="settings_use_mainnet_on_subtitle">Новые чаты будут привязаны к основной сети</string>
+    <string name="settings_use_mainnet_off_subtitle">По умолчанию — тестовая сеть, пока контракты подготавливаются</string>
+    <string name="settings_about_title">О приложении Onym</string>
+    <string name="settings_about_subtitle">Версия %1$s (сборка %2$s)</string>
+
+    <!-- ─── Identities list (redesigned) ─────────────────────────── -->
+    <string name="identities_screen_title">Личности</string>
+    <string name="identities_screen_intro">Нажмите на личность, чтобы открыть её. У каждой личности свои ключи, чаты и фраза восстановления.</string>
+    <string name="identities_screen_footer">Видимы только чаты активной личности. Переключайтесь между личностями, чтобы увидеть разные входящие.</string>
+    <string name="identities_section_your">Ваши личности</string>
+    <string name="identities_add_button">Добавить личность</string>
+    <string name="identity_unnamed">Безымянная личность</string>
+
+    <!-- ─── Identity detail ──────────────────────────────────────── -->
+    <string name="identity_detail_title">Личность</string>
+    <string name="identity_detail_active_marker">Активная</string>
+    <string name="identity_detail_backup_section">Резервное копирование</string>
+    <string name="identity_detail_backup_status_unknown">Сделайте резервную копию фразы восстановления</string>
+    <string name="identity_detail_backup_status_subtitle">Без неё восстановить эту личность будет невозможно.</string>
+    <string name="identity_detail_backup_action">Показать фразу восстановления</string>
+    <string name="identity_detail_backup_action_subtitle">12 слов · BIP-39</string>
+    <string name="identity_detail_state_section">Статус</string>
+    <string name="identity_detail_set_active">Сделать активной</string>
+    <string name="identity_detail_advanced_section">Расширенные</string>
+    <string name="identity_detail_copy_bls">Скопировать BLS открытый ключ</string>
+    <string name="identity_detail_copy_inbox">Скопировать ключ входящих</string>
+    <string name="identity_detail_delete">Удалить личность</string>
+    <string name="identity_detail_delete_footnote">Удаление личности стирает её ключи и локальные чаты с этого устройства. Привязанные группы остаются в блокчейне, но локальная копия будет потеряна.</string>
+    <string name="identity_detail_delete_dialog_title">Удалить %1$s?</string>
+    <string name="identity_detail_delete_dialog_body">Это безвозвратно удалит локальные чаты и сообщения этой личности. Привязанные группы остаются в блокчейне.</string>
+    <string name="identity_detail_delete_dialog_typename">Введите \"%1$s\" для подтверждения:</string>
+    <string name="identity_detail_delete_dialog_confirm">Удалить</string>
+
+    <!-- ─── Privacy &amp; Encryption ─────────────────────────────── -->
+    <string name="privacy_screen_title">Приватность и шифрование</string>
+    <string name="privacy_hero_title">Всё зашифровано</string>
+    <string name="privacy_hero_subtitle">Сообщения, состояние группы и ключи зашифрованы на этом устройстве. Никто — даже Onym — не может прочитать ваши чаты.</string>
+    <string name="privacy_how_section">Как это работает</string>
+    <string name="privacy_e2e_title">Сквозное шифрование</string>
+    <string name="privacy_e2e_subtitle">MLS · прямая секретность</string>
+    <string name="privacy_anon_title">Анонимные личности</string>
+    <string name="privacy_anon_subtitle">Без телефона, без email, без профиля</string>
+    <string name="privacy_verifiable_title">Проверяемо в блокчейне</string>
+    <string name="privacy_verifiable_subtitle">Состояние группы привязывается к Stellar</string>
+    <string name="privacy_keys_section">Ваши ключи</string>
+    <string name="privacy_keys_bip39">Фраза восстановления BIP-39</string>
+    <string name="privacy_keys_bip39_subtitle">12 английских слов, сгенерированных на устройстве</string>
+    <string name="privacy_keys_nostr">Идентификатор Nostr (npub)</string>
+    <string name="privacy_keys_nostr_subtitle">secp256k1 Schnorr — подписывает события на релеях</string>
+    <string name="privacy_keys_bls">Групповой ключ BLS</string>
+    <string name="privacy_keys_bls_subtitle">BLS12-381 — подписывает обязательство группы</string>
+    <string name="privacy_keys_stellar">Ключ аккаунта Stellar</string>
+    <string name="privacy_keys_stellar_subtitle">Ed25519 — закрепляет чат в блокчейне</string>
+    <string name="privacy_keys_footnote">Ваша фраза восстановления генерирует мастер-сид. Onym выводит из него пару ключей Nostr (ваша публичная личность), пару ключей Stellar (для якорения) и ключ BLS (для подписей в группе). Фраза никогда не покидает устройство.</string>
+    <string name="privacy_transport_section">Транспорт</string>
+    <string name="privacy_transport_relayer_title">Релеер не видит содержимое</string>
+    <string name="privacy_transport_relayer_subtitle">Он отправляет зашифрованные байты — открытый текст ему недоступен</string>
+    <string name="privacy_transport_chain_title">В блокчейне только обязательства</string>
+    <string name="privacy_transport_chain_subtitle">Идентификаторы группы и ключи участников никогда не появляются в открытом виде</string>
+    <string name="privacy_transport_footnote">Onym никогда не хранит ваши сообщения на своих серверах. Зашифрованное состояние находится на этом устройстве и на выбранных вами релеях.</string>
+
+    <!-- ─── About Onym ───────────────────────────────────────────── -->
+    <string name="about_screen_title">О приложении</string>
+    <string name="about_version_pill">%1$s · сборка %2$s</string>
+    <string name="about_version_section">Версия</string>
+    <string name="about_version_label">Версия</string>
+    <string name="about_build_label">Сборка</string>
+    <string name="about_resources_section">Ресурсы</string>
+    <string name="about_source_android">Исходный код Android</string>
+    <string name="about_source_ios">Исходный код iOS</string>
+    <string name="about_source_contracts">Контракты Soroban</string>
+    <string name="about_source_relayer">Релеер</string>
+    <string name="about_documentation">Документация и организация</string>
+    <string name="about_documentation_subtitle">github.com/onymchat</string>
+    <string name="about_whitepaper">Whitepaper</string>
+    <string name="about_whitepaper_subtitle">Протокол Onym</string>
+    <string name="about_help_section">Помощь</string>
+    <string name="about_issues_title">Сообщить о проблеме</string>
+    <string name="about_issues_subtitle">github.com/onymchat/onym-android/issues</string>
+    <string name="about_discussions_title">Обсуждения сообщества</string>
+    <string name="about_discussions_subtitle">Задавайте вопросы, делитесь идеями</string>
+    <string name="about_contact_title">Контакты</string>
+    <string name="about_credits_line1">Создано теми, кто считает приватность правом.</string>
+    <string name="about_credits_line2">Распространяется по лицензии MIT.</string>
+    <string name="about_credits_copyright">© 2026 · Onym</string>
+
     <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
     <string name="network_testnet">Тестовая сеть</string>
     <string name="network_public">Основная сеть</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,104 @@
     <string name="anchors_network_footer">Each governance type uses a separate contract. The release tag in parentheses is the version a brand-new chat would be anchored to.</string>
     <string name="anchors_reset_footer">Reset clears the explicit pick — new chats fall back to the latest published release.</string>
 
+    <!-- ─── Settings home (redesigned) ───────────────────────────── -->
+    <string name="brand_tagline">open · anonymous · onchain</string>
+    <string name="settings_active_identity_label">Active identity</string>
+    <string name="settings_app_section">App</string>
+    <string name="settings_identities_title">Identities</string>
+    <string name="settings_identities_subtitle_one">1 on this device</string>
+    <string name="settings_identities_subtitle_n">%1$d on this device</string>
+    <string name="settings_privacy_title">Privacy &amp; Encryption</string>
+    <string name="settings_privacy_subtitle">End-to-end · BIP-39</string>
+    <string name="settings_relayer_subtitle">Submits transactions on your behalf</string>
+    <string name="settings_anchors_subtitle_testnet">Stellar · Testnet</string>
+    <string name="settings_anchors_subtitle_mainnet">Stellar · Mainnet</string>
+    <string name="settings_use_mainnet_on_subtitle">New chats anchor on mainnet</string>
+    <string name="settings_use_mainnet_off_subtitle">Testnet by default while contracts are staged</string>
+    <string name="settings_about_title">About Onym</string>
+    <string name="settings_about_subtitle">Version %1$s (build %2$s)</string>
+
+    <!-- ─── Identities list (redesigned) ─────────────────────────── -->
+    <string name="identities_screen_title">Identities</string>
+    <string name="identities_screen_intro">Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.</string>
+    <string name="identities_screen_footer">Only the active identity\'s chats are visible. Switch between identities to see different inboxes.</string>
+    <string name="identities_section_your">Your identities</string>
+    <string name="identities_add_button">Add Identity</string>
+    <string name="identity_unnamed">Unnamed identity</string>
+
+    <!-- ─── Identity detail ──────────────────────────────────────── -->
+    <string name="identity_detail_title">Identity</string>
+    <string name="identity_detail_active_marker">Active</string>
+    <string name="identity_detail_backup_section">Backup</string>
+    <string name="identity_detail_backup_status_unknown">Back up your recovery phrase</string>
+    <string name="identity_detail_backup_status_subtitle">Without your phrase you can\'t restore this identity.</string>
+    <string name="identity_detail_backup_action">View recovery phrase</string>
+    <string name="identity_detail_backup_action_subtitle">12 words · BIP-39</string>
+    <string name="identity_detail_state_section">State</string>
+    <string name="identity_detail_set_active">Set as active</string>
+    <string name="identity_detail_advanced_section">Advanced</string>
+    <string name="identity_detail_copy_bls">Copy BLS public key</string>
+    <string name="identity_detail_copy_inbox">Copy inbox public key</string>
+    <string name="identity_detail_delete">Delete identity</string>
+    <string name="identity_detail_delete_footnote">Deleting an identity removes its keys and local chats from this device. Anchored groups stay on chain but you\'ll lose your local copy.</string>
+    <string name="identity_detail_delete_dialog_title">Delete %1$s?</string>
+    <string name="identity_detail_delete_dialog_body">This wipes the identity\'s local chats and messages permanently. Anchored groups stay on chain.</string>
+    <string name="identity_detail_delete_dialog_typename">Type \"%1$s\" to confirm:</string>
+    <string name="identity_detail_delete_dialog_confirm">Delete</string>
+
+    <!-- ─── Privacy &amp; Encryption ─────────────────────────────── -->
+    <string name="privacy_screen_title">Privacy &amp; Encryption</string>
+    <string name="privacy_hero_title">Everything is encrypted</string>
+    <string name="privacy_hero_subtitle">Messages, group state, and keys are encrypted on this device. No one — not even Onym — can read your chats.</string>
+    <string name="privacy_how_section">How it works</string>
+    <string name="privacy_e2e_title">End-to-end encryption</string>
+    <string name="privacy_e2e_subtitle">MLS · forward secrecy</string>
+    <string name="privacy_anon_title">Anonymous identities</string>
+    <string name="privacy_anon_subtitle">No phone, no email, no profile</string>
+    <string name="privacy_verifiable_title">Verifiable on-chain</string>
+    <string name="privacy_verifiable_subtitle">Group state is anchored on Stellar</string>
+    <string name="privacy_keys_section">Your keys</string>
+    <string name="privacy_keys_bip39">BIP-39 recovery phrase</string>
+    <string name="privacy_keys_bip39_subtitle">12 English words generated on this device</string>
+    <string name="privacy_keys_nostr">Nostr identity (npub)</string>
+    <string name="privacy_keys_nostr_subtitle">secp256k1 Schnorr — signs events on relays</string>
+    <string name="privacy_keys_bls">BLS group key</string>
+    <string name="privacy_keys_bls_subtitle">BLS12-381 — signs the group commitment</string>
+    <string name="privacy_keys_stellar">Stellar account key</string>
+    <string name="privacy_keys_stellar_subtitle">Ed25519 — anchors the chat on chain</string>
+    <string name="privacy_keys_footnote">Your recovery phrase generates a master seed. Onym derives a Nostr keypair (your public identity), a Stellar keypair (for anchoring), and a BLS key (for group signatures). The phrase never leaves this device.</string>
+    <string name="privacy_transport_section">Transport</string>
+    <string name="privacy_transport_relayer_title">Relayer is opaque</string>
+    <string name="privacy_transport_relayer_subtitle">It submits encrypted bytes — never sees plaintext</string>
+    <string name="privacy_transport_chain_title">Chain stores commitments only</string>
+    <string name="privacy_transport_chain_subtitle">Group IDs and member keys never appear in cleartext</string>
+    <string name="privacy_transport_footnote">Onym never stores your messages on our servers. Encrypted state lives on this device and on relays you choose.</string>
+
+    <!-- ─── About Onym ───────────────────────────────────────────── -->
+    <string name="about_screen_title">About</string>
+    <string name="about_version_pill">%1$s · build %2$s</string>
+    <string name="about_version_section">Version</string>
+    <string name="about_version_label">Version</string>
+    <string name="about_build_label">Build</string>
+    <string name="about_resources_section">Resources</string>
+    <string name="about_source_android">Android source</string>
+    <string name="about_source_ios">iOS source</string>
+    <string name="about_source_contracts">Soroban contracts</string>
+    <string name="about_source_relayer">Relayer</string>
+    <string name="about_documentation">Documentation &amp; org</string>
+    <string name="about_documentation_subtitle">github.com/onymchat</string>
+    <string name="about_whitepaper">Whitepaper</string>
+    <string name="about_whitepaper_subtitle">The Onym protocol</string>
+    <string name="about_help_section">Help</string>
+    <string name="about_issues_title">Report an issue</string>
+    <string name="about_issues_subtitle">github.com/onymchat/onym-android/issues</string>
+    <string name="about_discussions_title">Community discussions</string>
+    <string name="about_discussions_subtitle">Ask questions, share ideas</string>
+    <string name="about_contact_title">Contact</string>
+    <string name="about_credits_line1">Built by people who think privacy is a right.</string>
+    <string name="about_credits_line2">Released under the MIT license.</string>
+    <string name="about_credits_copyright">© 2026 · Onym</string>
+
     <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
     <string name="network_testnet">Testnet</string>
     <string name="network_public">Mainnet</string>


### PR DESCRIPTION
## Summary

- Rewires the flat Backup / Identities / Network list as a sectioned, identity-led Settings home that mirrors iOS Settings — large title, active-identity hero (`OnymMark` + green active dot), SECURITY / NETWORK / APP groups, brand watermark.
- Adds three new sub-screens: **Identity Detail** (per-identity backup, set-active, copy keys, delete), **Privacy & Encryption** (E2E hero + key derivation explainer + transport guarantees), **About Onym** (dark Onym-mark hero, version pill, links to all four `github.com/onymchat/*` repos, MIT credits).
- Pulls the inline trash out of the Identities list — removal now lives behind the per-identity drill-in (typed-name confirm dialog still gates it).

## What's new

- `SettingsScreen.kt` — large title, active-identity hero, SECURITY (Identities · Privacy & Encryption) / NETWORK (Relayer · Anchors · Use Mainnet) / APP (About Onym) sections, brand watermark.
- `IdentityDetailScreen.kt` — hero, BACKUP card (warns + launches the existing recovery flow; flips active identity first if needed), STATE (set-as-active), ADVANCED (copy BLS / inbox public keys, delete).
- `PrivacyEncryptionScreen.kt` — green encryption-status hero, "How it works" group, "Your keys" group (BIP-39 / Nostr npub / BLS group key / Stellar account key), "Transport" group.
- `AboutOnymScreen.kt` — dark `OnymMark` hero, version pill, RESOURCES rows pointing at the four `github.com/onymchat` repos (onym-android, onym-ios, onym-contracts, onym-relayer, onym-paper), HELP rows (Issues / Discussions / `hello@onym.chat`), MIT credits.
- `SettingsAtoms.kt` — shared `SettingsCard` / `SettingsRow` / `SettingsSectionLabel` / `SettingsTileBox` atoms encoding the Apple-Settings spacing + 0.5dp hairlines once.

## Wiring + tests

- `RootScreen` wires `identity_detail/{id}`, `privacy`, `about_onym` routes and threads `IdentitiesViewModel` into the home for the active-identity hero.
- `IdentitiesScreen` rewritten — tap a row to drill into `IdentityDetail`; "Add Identity" is a card-style button beneath the list (no floating FAB).
- `IdentitiesUITest` updated — typed-name removal now navigates Identities → row → IdentityDetail → Delete.

## i18n

~50 new keys added to both `values/strings.xml` and `values-ru/strings.xml`. The `MissingTranslation` lint is satisfied.

## Skipped vs. the design

These need backend/spec, not a UI pass — flagged so they don't get lost:

- **QR hero on the home / Identity Detail** — invites today are per-group via `IntroCapability`; there's no group-less per-identity invite handler.
- **"Run your own relay" explainer screen** — content is fine, but the design's repo links and shell snippets want their own pass.
- **Appearance section** — explicitly removed in the design's own chat transcript ("must be configured from device settings").

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — green
- [x] `./gradlew :app:lintDebug` — green (no `MissingTranslation`, no `UnusedMaterial3ScaffoldPaddingParameter`)
- [x] `./gradlew :app:testDebugUnitTest` — green
- [ ] Manual: launch Settings → tap identity hero → IdentityDetail → Set as active / Copy keys / Delete (typed-name)
- [ ] Manual: Settings → Privacy & Encryption renders all groups
- [ ] Manual: Settings → About Onym → tap each `github.com/onymchat/*` row opens the browser
- [ ] Manual: ru locale renders all new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)