### PR TITLE
ux: custom contract + run-your-own-relayer scaffolds

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -49,12 +49,16 @@ import chat.onym.android.settings.AnchorsNetworkScreen
 import chat.onym.android.settings.AnchorsPickerViewModel
 import chat.onym.android.settings.AnchorsRootScreen
 import chat.onym.android.settings.AnchorsVersionScreen
+import chat.onym.android.settings.ContractDetailScreen
+import chat.onym.android.settings.DeployContractScreen
 import chat.onym.android.settings.IdentitiesScreen
 import chat.onym.android.settings.IdentityDetailScreen
 import chat.onym.android.settings.PrivacyEncryptionScreen
 import chat.onym.android.settings.RelayerSettingsScreen
 import chat.onym.android.settings.RelayerSettingsViewModel
+import chat.onym.android.settings.RunRelayerScreen
 import chat.onym.android.settings.SettingsScreen
+import chat.onym.android.settings.UseExistingContractScreen
 
 /**
  * App shell. `Scaffold` + Material 3 [NavigationBar] across the bottom,
@@ -315,7 +319,11 @@ fun RootScreen(
                 RelayerSettingsScreen(
                     viewModel = vm,
                     onBackClick = { navController.popBackStack() },
+                    onRunYourOwnClick = { navController.navigate(ROUTE_RUN_RELAYER) },
                 )
+            }
+            composable(ROUTE_RUN_RELAYER) {
+                RunRelayerScreen(onBack = { navController.popBackStack() })
             }
             composable(ROUTE_ANCHORS_ROOT) {
                 val vm: AnchorsPickerViewModel = viewModel(
@@ -363,6 +371,56 @@ fun RootScreen(
                     network = network,
                     type = type,
                     onBackClick = { navController.popBackStack() },
+                    onContractDetailClick = { version, contractId ->
+                        navController.navigate(
+                            "contract_detail/${network.wireValue}/${type.wireValue}/${version}?addr=${contractId ?: ""}"
+                        )
+                    },
+                    onUseExistingClick = {
+                        navController.navigate("use_contract/${network.wireValue}/${type.wireValue}")
+                    },
+                    onDeployClick = {
+                        navController.navigate("deploy_contract/${network.wireValue}/${type.wireValue}")
+                    },
+                )
+            }
+            composable("contract_detail/{network}/{type}/{version}?addr={addr}") { entry ->
+                val net = ContractNetwork.fromWire(entry.arguments?.getString("network") ?: "")
+                    ?: return@composable
+                val gov = GovernanceType.fromWire(entry.arguments?.getString("type") ?: "")
+                    ?: return@composable
+                val ver = entry.arguments?.getString("version") ?: return@composable
+                val addr = entry.arguments?.getString("addr")?.takeIf { it.isNotBlank() }
+                ContractDetailScreen(
+                    network = net,
+                    type = gov,
+                    version = ver,
+                    contractAddress = addr,
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable("use_contract/{network}/{type}") { entry ->
+                val net = ContractNetwork.fromWire(entry.arguments?.getString("network") ?: "")
+                    ?: return@composable
+                val gov = GovernanceType.fromWire(entry.arguments?.getString("type") ?: "")
+                    ?: return@composable
+                UseExistingContractScreen(
+                    network = net,
+                    type = gov,
+                    onBack = { navController.popBackStack() },
+                    onUseContract = { _, _ -> navController.popBackStack() },
+                )
+            }
+            composable("deploy_contract/{network}/{type}") { entry ->
+                val net = ContractNetwork.fromWire(entry.arguments?.getString("network") ?: "")
+                    ?: return@composable
+                val gov = GovernanceType.fromWire(entry.arguments?.getString("type") ?: "")
+                    ?: return@composable
+                DeployContractScreen(
+                    network = net,
+                    type = gov,
+                    onBack = { navController.popBackStack() },
+                    onUseDeployed = { navController.popBackStack() },
                 )
             }
             composable(ROUTE_RECOVERY_BACKUP) {
@@ -408,6 +466,7 @@ private const val ROUTE_IDENTITIES = "identities"
 private const val ROUTE_PRIVACY = "privacy"
 private const val ROUTE_ABOUT = "about_onym"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
+private const val ROUTE_RUN_RELAYER = "run_relayer"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"
 private val TAB_ROUTES = setOf(Tab.Chats.route, Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -139,6 +141,9 @@ fun AnchorsVersionScreen(
     network: ContractNetwork,
     type: GovernanceType,
     onBackClick: () -> Unit,
+    onContractDetailClick: (version: String, contractId: String?) -> Unit = { _, _ -> },
+    onUseExistingClick: () -> Unit = {},
+    onDeployClick: () -> Unit = {},
 ) {
     viewModel.state.collectAsStateWithLifecycle()
     val rows = viewModel.versionRows(network, type)
@@ -169,8 +174,37 @@ fun AnchorsVersionScreen(
                         viewModel.pickVersion(network, type, row.release.release)
                         onBackClick()
                     },
+                    onDetailClick = { onContractDetailClick(row.release.release, row.entry.id) },
                 )
             }
+            item {
+                Footer(stringResource(R.string.anchors_releases_detail_footnote))
+            }
+
+            // ─── Custom (deploy / use existing) ──────────────────
+            item { SectionHeader(stringResource(R.string.anchors_section_custom)) }
+            item {
+                CustomActionRow(
+                    leadingTone = SettingsTile.GitHub,
+                    leadingIcon = androidx.compose.material.icons.Icons.Filled.Code,
+                    title = stringResource(R.string.anchors_custom_deploy_title),
+                    subtitle = stringResource(R.string.anchors_custom_deploy_subtitle),
+                    onClick = onDeployClick,
+                    testTagId = "anchors.custom.deploy",
+                )
+            }
+            item {
+                CustomActionRow(
+                    leadingTone = SettingsTile.Indigo,
+                    leadingIcon = androidx.compose.material.icons.Icons.Filled.AccountTree,
+                    title = stringResource(R.string.anchors_custom_use_title),
+                    subtitle = stringResource(R.string.anchors_custom_use_subtitle),
+                    onClick = onUseExistingClick,
+                    testTagId = "anchors.custom.use",
+                )
+            }
+            item { Footer(stringResource(R.string.anchors_custom_footer)) }
+
             item { SectionHeader(stringResource(R.string.anchors_section_reset)) }
             item {
                 ResetRow(
@@ -182,6 +216,51 @@ fun AnchorsVersionScreen(
             }
             item { Footer(stringResource(R.string.anchors_reset_footer)) }
         }
+    }
+}
+
+@Composable
+private fun CustomActionRow(
+    leadingTone: androidx.compose.ui.graphics.Color,
+    leadingIcon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    testTagId: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag(testTagId),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SettingsTileBox(
+            icon = leadingIcon,
+            background = leadingTone,
+        )
+        androidx.compose.foundation.layout.Spacer(Modifier.size(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            modifier = Modifier.size(18.dp),
+        )
     }
 }
 
@@ -272,6 +351,7 @@ private fun VersionRow(
     contractId: String,
     isCurrentlySelected: Boolean,
     onClick: () -> Unit,
+    onDetailClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -306,6 +386,22 @@ private fun VersionRow(
                     modifier = Modifier.size(14.dp),
                 )
             }
+            androidx.compose.foundation.layout.Spacer(Modifier.size(8.dp))
+        }
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onDetailClick)
+                .testTag("anchors.version.$label.detail"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/settings/ContractDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/ContractDetailScreen.kt
@@ -1,0 +1,207 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.GovernanceType
+import chat.onym.android.group.OnymMark
+
+/**
+ * Anchors → version → Contract Detail. Shows the deployed contract
+ * address, links to Stellar Expert, the source on
+ * `github.com/onymchat/onym-contracts`, and the audit status (pending
+ * — no audits yet).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContractDetailScreen(
+    network: ContractNetwork,
+    type: GovernanceType,
+    version: String,
+    contractAddress: String?,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(version) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("contract_detail.list"),
+        ) {
+            // ─── Hero ─────────────────────────────────────────────
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(horizontal = 18.dp, vertical = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(Color(0xFFFEF0E0), Color(0xFFFFE0C0)),
+                                )
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        OnymMark(size = 32.dp, color = Color(0xFFD14B00))
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.contract_detail_hero_eyebrow, stringResource(type.displayNameResId)).uppercase(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = version,
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Monospace,
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.contract_detail_hero_subtitle,
+                                stringResource(network.displayNameResId),
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // ─── ON-CHAIN ─────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.contract_detail_onchain_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileLabel("SX", SettingsTile.Indigo) },
+                        title = stringResource(R.string.contract_detail_explorer_title),
+                        subtitle = if (network == ContractNetwork.Testnet) "testnet.stellar.expert" else "stellar.expert",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = {
+                            val host = if (network == ContractNetwork.Testnet) {
+                                "testnet.stellar.expert"
+                            } else "stellar.expert"
+                            val tail = contractAddress?.let { "/explorer/${if (network == ContractNetwork.Testnet) "testnet" else "public"}/contract/$it" }
+                                ?: "/"
+                            openUrl(context, "https://$host$tail")
+                        },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.ContentCopy, SettingsTile.Gray) },
+                        title = stringResource(R.string.contract_detail_copy_address),
+                        subtitle = contractAddress ?: stringResource(R.string.contract_detail_no_address),
+                        subtitleMono = true,
+                        showChevron = false,
+                        onClick = {
+                            contractAddress?.let { copyToClipboard(context, "Contract address", it) }
+                        },
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── SOURCE ───────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.contract_detail_source_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.GitHub) },
+                        title = stringResource(R.string.contract_detail_view_source),
+                        subtitle = "github.com/onymchat/onym-contracts @ $version",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = {
+                            openUrl(
+                                context,
+                                "https://github.com/onymchat/onym-contracts/releases/tag/$version",
+                            )
+                        },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Warning, SettingsTile.Amber) },
+                        title = stringResource(R.string.contract_detail_audit_title),
+                        subtitle = stringResource(R.string.contract_detail_audit_subtitle),
+                        showChevron = false,
+                        isLast = true,
+                    )
+                }
+            }
+            item {
+                SettingsFootnote(
+                    stringResource(
+                        R.string.contract_detail_footnote,
+                        stringResource(type.displayNameResId).lowercase(),
+                    )
+                )
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/DeployContractScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/DeployContractScreen.kt
@@ -1,0 +1,540 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.GovernanceType
+import kotlinx.coroutines.delay
+
+/**
+ * Anchors → Custom → Deploy from source. Scaffolds the build & deploy
+ * flow against `github.com/onymchat/onym-contracts`. Real deployment
+ * isn't wired here — the "Build & Deploy" button replays a canned
+ * progress-log animation and reveals a stub deployed-contract address
+ * card. The CLI fallback snippet at the bottom is always available
+ * for users who'd rather deploy off-device.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeployContractScreen(
+    network: ContractNetwork,
+    type: GovernanceType,
+    onBack: () -> Unit,
+    onUseDeployed: (address: String) -> Unit,
+) {
+    val context = LocalContext.current
+    var ref by remember { mutableStateOf("main") }
+    var stage by remember { mutableStateOf(DeployStage.Idle) }
+    var progress by remember { mutableStateOf(0) }
+    var logs by remember { mutableStateOf(listOf<String>()) }
+    var deployedAddr by remember { mutableStateOf<String?>(null) }
+    var copiedCli by remember { mutableStateOf(false) }
+    var copiedAddr by remember { mutableStateOf(false) }
+
+    val networkPassphrase = if (network == ContractNetwork.Testnet) {
+        "Test SDF Network ; September 2015"
+    } else "Public Global Stellar Network ; September 2015"
+
+    val cliCmd = "soroban contract deploy \\\n" +
+        "  --network ${if (network == ContractNetwork.Testnet) "testnet" else "public"} \\\n" +
+        "  --source-account onym-deploy \\\n" +
+        "  --wasm onym_${type.wireValue}.wasm"
+
+    LaunchedEffect(stage) {
+        if (stage != DeployStage.Building) return@LaunchedEffect
+        val netName = if (network == ContractNetwork.Testnet) "testnet" else "public"
+        data class Step(
+            val gapMs: Long,
+            val log: String,
+            val percent: Int,
+            val nextStage: DeployStage? = null,
+            val isUpload: Boolean = false,
+        )
+        val steps = listOf(
+            Step(600, "Cloned onymchat/onym-contracts @ $ref", 12),
+            Step(800, "cargo build --release --target wasm32", 38),
+            Step(800, "Built onym_${type.wireValue}.wasm (47 KB)", 56, DeployStage.Deploying),
+            Step(800, "stellar.$netName · uploading wasm", 72, isUpload = true),
+            Step(700, "stellar.$netName · invoking deploy", 88, isUpload = true),
+            Step(700, "Deployed", 100, DeployStage.Done),
+        )
+        for (step in steps) {
+            delay(step.gapMs)
+            val prefix = if (step.isUpload) "↗" else "✓"
+            logs = logs + "$prefix ${step.log}"
+            progress = step.percent
+            step.nextStage?.let { stage = it }
+            if (step.percent == 100) {
+                val alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ234567"
+                deployedAddr = buildString {
+                    append('C')
+                    repeat(55) { append(alphabet[(alphabet.indices).random()]) }
+                }
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.deploy_contract_title)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        enabled = stage == DeployStage.Idle || stage == DeployStage.Done,
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier.fillMaxSize().testTag("deploy_contract.list"),
+        ) {
+            // ─── Hero (dark) ──────────────────────────────────────
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF1B1F24), Color(0xFF0D1117)),
+                            )
+                        )
+                        .padding(20.dp),
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Icon(
+                            Icons.Filled.Code,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(
+                            text = "github.com/onymchat/onym-contracts",
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = Color.White.copy(alpha = 0.65f),
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(R.string.deploy_contract_hero_title),
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        color = Color.White,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(
+                            R.string.deploy_contract_hero_body,
+                            stringResource(type.displayNameResId).lowercase(),
+                            stringResource(network.displayNameResId),
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.7f),
+                    )
+                }
+            }
+
+            // ─── SOURCE ───────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.deploy_contract_source_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileBox(Icons.Filled.Code, SettingsTile.GitHub) },
+                        title = stringResource(R.string.deploy_contract_repo),
+                        subtitle = "github.com/onymchat/onym-contracts",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = { openUrl(context, "https://github.com/onymchat/onym-contracts") },
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 11.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        SettingsTileLabel("REF", SettingsTile.Indigo)
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.deploy_contract_ref_label),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            OutlinedTextField(
+                                value = ref,
+                                onValueChange = { ref = it },
+                                enabled = stage == DeployStage.Idle,
+                                singleLine = true,
+                                placeholder = { Text("main · v0.0.5 · commit sha") },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag("deploy_contract.ref"),
+                                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                                    fontFamily = FontFamily.Monospace,
+                                ),
+                            )
+                        }
+                    }
+                    SettingsHairline(insetStart = 16.dp)
+                    SettingsRow(
+                        leading = { SettingsTileLabel("T", SettingsTile.Green) },
+                        title = stringResource(R.string.deploy_contract_network_label),
+                        showChevron = false,
+                        trailing = {
+                            Text(
+                                text = stringResource(network.displayNameResId),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                    )
+                    SettingsRow(
+                        leading = {
+                            SettingsTileLabel(
+                                stringResource(type.displayNameResId).take(2).uppercase(),
+                                SettingsTile.Purple,
+                            )
+                        },
+                        title = stringResource(R.string.deploy_contract_module_label),
+                        showChevron = false,
+                        trailing = {
+                            Text(
+                                text = stringResource(type.displayNameResId),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        isLast = true,
+                    )
+                }
+            }
+
+            // ─── Build & Deploy button ────────────────────────────
+            if (stage == DeployStage.Idle) {
+                item {
+                    Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                        Button(
+                            onClick = { stage = DeployStage.Building },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp)
+                                .testTag("deploy_contract.start"),
+                            shape = RoundedCornerShape(14.dp),
+                        ) {
+                            Icon(
+                                Icons.Filled.Upload,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.size(8.dp))
+                            Text(
+                                text = stringResource(R.string.deploy_contract_action),
+                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ─── Build/Deploy log ─────────────────────────────────
+            if (stage != DeployStage.Idle) {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(Color(0xFF0D1117))
+                            .padding(14.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(8.dp)
+                                    .clip(CircleShape)
+                                    .background(
+                                        if (stage == DeployStage.Done) SettingsTile.Green else SettingsTile.Amber
+                                    ),
+                            )
+                            Text(
+                                text = when (stage) {
+                                    DeployStage.Building -> stringResource(R.string.deploy_contract_log_building)
+                                    DeployStage.Deploying -> stringResource(R.string.deploy_contract_log_deploying)
+                                    DeployStage.Done -> stringResource(R.string.deploy_contract_log_done)
+                                    else -> ""
+                                },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color.White.copy(alpha = 0.6f),
+                            )
+                            Box(modifier = Modifier.weight(1f))
+                            Text(
+                                text = "$progress%",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color.White.copy(alpha = 0.4f),
+                            )
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        LinearProgressIndicator(
+                            progress = { progress / 100f },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(3.dp)
+                                .clip(RoundedCornerShape(1.5.dp)),
+                            color = if (stage == DeployStage.Done) SettingsTile.Green else SettingsTile.Blue,
+                            trackColor = Color.White.copy(alpha = 0.08f),
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        logs.forEach { line ->
+                            Text(
+                                text = line,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                color = when {
+                                    line.startsWith("✓") -> Color(0xFFA6FF99)
+                                    line.startsWith("↗") -> Color(0xFF7CC2FF)
+                                    else -> Color.White
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ─── Deployed contract card ───────────────────────────
+            if (stage == DeployStage.Done && deployedAddr != null) {
+                item { SettingsSectionLabel(stringResource(R.string.deploy_contract_deployed_section)) }
+                item {
+                    SettingsCard {
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(22.dp)
+                                        .clip(CircleShape)
+                                        .background(SettingsTile.Green),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Check,
+                                        contentDescription = null,
+                                        tint = Color.White,
+                                        modifier = Modifier.size(14.dp),
+                                    )
+                                }
+                                Text(
+                                    text = stringResource(R.string.deploy_contract_deployed_title),
+                                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                            Spacer(Modifier.height(10.dp))
+                            Text(
+                                text = deployedAddr!!,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceContainer)
+                                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                            )
+                        }
+                        SettingsHairline(insetStart = 16.dp)
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clickable {
+                                        copyToClipboard(context, "Contract address", deployedAddr!!)
+                                        copiedAddr = true
+                                    }
+                                    .padding(vertical = 13.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                ) {
+                                    Icon(
+                                        if (copiedAddr) Icons.Filled.Check else Icons.Filled.ContentCopy,
+                                        contentDescription = null,
+                                        tint = SettingsTile.Blue,
+                                        modifier = Modifier.size(14.dp),
+                                    )
+                                    Text(
+                                        text = if (copiedAddr) stringResource(R.string.copied) else stringResource(R.string.copy),
+                                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                                        color = SettingsTile.Blue,
+                                    )
+                                }
+                            }
+                            Box(
+                                modifier = Modifier
+                                    .width(0.5.dp)
+                                    .height(46.dp)
+                                    .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clickable {
+                                        val host = if (network == ContractNetwork.Testnet) {
+                                            "testnet.stellar.expert"
+                                        } else "stellar.expert"
+                                        val net = if (network == ContractNetwork.Testnet) "testnet" else "public"
+                                        openUrl(context, "https://$host/explorer/$net/contract/${deployedAddr}")
+                                    }
+                                    .padding(vertical = 13.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.deploy_contract_view_explorer),
+                                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                                        color = SettingsTile.Blue,
+                                    )
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.OpenInNew,
+                                        contentDescription = null,
+                                        tint = SettingsTile.Blue,
+                                        modifier = Modifier.size(14.dp),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                item {
+                    Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                        Button(
+                            onClick = { onUseDeployed(deployedAddr!!) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp)
+                                .testTag("deploy_contract.use"),
+                            shape = RoundedCornerShape(14.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.deploy_contract_use_button),
+                                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ─── CLI fallback ─────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.deploy_contract_cli_section)) }
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(Color(0xFF0D1117))
+                        .padding(start = 12.dp, end = 36.dp, top = 12.dp, bottom = 12.dp),
+                ) {
+                    Text(
+                        text = cliCmd,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        color = Color(0xFFA6FF99),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .size(26.dp)
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(Color.White.copy(alpha = 0.08f))
+                            .clickable {
+                                copyToClipboard(context, "CLI command", cliCmd)
+                                copiedCli = true
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            if (copiedCli) Icons.Filled.Check else Icons.Filled.ContentCopy,
+                            contentDescription = null,
+                            tint = if (copiedCli) Color(0xFFA6FF99) else Color.White,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
+                }
+            }
+            item {
+                SettingsFootnote(
+                    stringResource(R.string.deploy_contract_passphrase_footnote, networkPassphrase)
+                )
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+}
+
+private enum class DeployStage { Idle, Building, Deploying, Done }

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
@@ -1,9 +1,5 @@
 package chat.onym.android.settings
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -326,6 +322,7 @@ fun IdentityDetailScreen(
     }
 }
 
+
 @Composable
 private fun RemoveIdentityDialog(
     displayName: String,
@@ -379,8 +376,3 @@ private fun RemoveIdentityDialog(
     )
 }
 
-private fun copyToClipboard(context: Context, label: String, value: String) {
-    val cb = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    cb.setPrimaryClip(ClipData.newPlainText(label, value))
-    Toast.makeText(context, R.string.copied, Toast.LENGTH_SHORT).show()
-}

--- a/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RelayerSettingsScreen.kt
@@ -1,24 +1,31 @@
 package chat.onym.android.settings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -70,6 +77,7 @@ import chat.onym.android.chain.RelayerStrategy
 fun RelayerSettingsScreen(
     viewModel: RelayerSettingsViewModel,
     onBackClick: () -> Unit,
+    onRunYourOwnClick: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     Scaffold(
@@ -197,7 +205,64 @@ fun RelayerSettingsScreen(
                 )
             }
             item { Footer(stringResource(R.string.relayer_custom_footer)) }
+
+            // ─── Run your own relayer (dark CTA) ─────────────────
+            item { RunYourOwnRelayerCta(onClick = onRunYourOwnClick) }
+            item { Spacer(Modifier.height(40.dp)) }
         }
+    }
+}
+
+@Composable
+private fun RunYourOwnRelayerCta(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(
+                Brush.linearGradient(
+                    listOf(Color(0xFF1B1F24), Color(0xFF0D1117)),
+                )
+            )
+            .clickable(onClick = onClick)
+            .padding(18.dp)
+            .testTag("relayer.run_your_own"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color.White.copy(alpha = 0.08f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.Code,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.relayer_run_your_own_title),
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                color = Color.White,
+            )
+            Text(
+                text = stringResource(R.string.relayer_run_your_own_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.65f),
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.5f),
+            modifier = Modifier.size(18.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/chat/onym/android/settings/RunRelayerScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RunRelayerScreen.kt
@@ -1,0 +1,351 @@
+package chat.onym.android.settings
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+
+/**
+ * Settings → Relayer → Run your own relayer. Self-host explainer
+ * with shell snippets and one-click deploy targets. Links point at
+ * `github.com/onymchat/onym-relayer`.
+ *
+ * Scaffold: shell snippets are static strings copyable to the
+ * clipboard; the deploy buttons open the host provider's deploy
+ * URL in the browser. No on-device deploy mechanic — the user
+ * runs the commands on their own machine.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RunRelayerScreen(
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    var copiedKey by remember { mutableStateOf<String?>(null) }
+
+    // stringResource() is @Composable; hoist these out of LazyColumn's
+    // (non-Composable) content lambda.
+    val step1Title = stringResource(R.string.run_relayer_step1_title)
+    val step1Body = stringResource(R.string.run_relayer_step1_body)
+    val step2Title = stringResource(R.string.run_relayer_step2_title)
+    val step2Body = stringResource(R.string.run_relayer_step2_body)
+    val step3Title = stringResource(R.string.run_relayer_step3_title)
+    val step3Body = stringResource(R.string.run_relayer_step3_body)
+    val step4Title = stringResource(R.string.run_relayer_step4_title)
+    val step4Body = stringResource(R.string.run_relayer_step4_body)
+    val steps = listOf(
+        StepData(1, step1Title, step1Body, "git clone https://github.com/onymchat/onym-relayer\ncd onym-relayer"),
+        StepData(2, step2Title, step2Body, "cp .env.example .env\necho \"RELAYER_URL=https://your-domain\" >> .env"),
+        StepData(3, step3Title, step3Body, "fly launch --copy-config\nfly deploy"),
+        StepData(4, step4Title, step4Body, null),
+    )
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.run_relayer_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("run_relayer.list"),
+        ) {
+            // ─── Hero ─────────────────────────────────────────────
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(
+                            Brush.linearGradient(
+                                listOf(Color(0xFF1B1F24), Color(0xFF0D1117)),
+                            )
+                        )
+                        .padding(20.dp),
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Icon(
+                            Icons.Filled.Code,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(
+                            text = "github.com/onymchat/onym-relayer",
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = Color.White.copy(alpha = 0.65f),
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(R.string.run_relayer_hero_title),
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        color = Color.White,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(R.string.run_relayer_hero_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White.copy(alpha = 0.7f),
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        DarkHeroButton(
+                            label = stringResource(R.string.run_relayer_view_github),
+                            primary = true,
+                            onClick = { openUrl(context, "https://github.com/onymchat/onym-relayer") },
+                        )
+                        DarkHeroButton(
+                            label = stringResource(R.string.run_relayer_read_docs),
+                            primary = false,
+                            onClick = { openUrl(context, "https://github.com/onymchat/onym-relayer#readme") },
+                        )
+                    }
+                }
+            }
+
+            // ─── Numbered steps ───────────────────────────────────
+            steps.forEachIndexed { idx, step ->
+                item {
+                    NumberedStep(
+                        n = step.n,
+                        title = step.title,
+                        body = step.body,
+                        cmd = step.cmd,
+                        copied = copiedKey == "step${step.n}",
+                        onCopy = {
+                            step.cmd?.let {
+                                copyToClipboard(context, "Step ${step.n}", it)
+                                copiedKey = "step${step.n}"
+                            }
+                        },
+                        showConnector = idx < steps.size - 1,
+                    )
+                }
+            }
+
+            // ─── One-click deploy ─────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.run_relayer_deploy_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileLabel("FLY", Color(0xFF7B3FE4)) },
+                        title = stringResource(R.string.run_relayer_deploy_fly),
+                        subtitle = stringResource(R.string.run_relayer_deploy_fly_subtitle),
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = { openUrl(context, "https://fly.io/launch") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("RWY", Color(0xFF1F1F1F)) },
+                        title = stringResource(R.string.run_relayer_deploy_railway),
+                        subtitle = stringResource(R.string.run_relayer_deploy_railway_subtitle),
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = { openUrl(context, "https://railway.app/new") },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("DKR", Color(0xFF0080FF)) },
+                        title = stringResource(R.string.run_relayer_deploy_docker),
+                        subtitle = stringResource(R.string.run_relayer_deploy_docker_subtitle),
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = { openUrl(context, "https://github.com/onymchat/onym-relayer#docker") },
+                        isLast = true,
+                    )
+                }
+            }
+            item { SettingsFootnote(stringResource(R.string.run_relayer_footnote)) }
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun DarkHeroButton(label: String, primary: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (primary) Color.White else Color.White.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+            color = if (primary) Color(0xFF0A0A0C) else Color.White,
+        )
+    }
+}
+
+@Composable
+private fun NumberedStep(
+    n: Int,
+    title: String,
+    body: String,
+    cmd: String?,
+    copied: Boolean,
+    onCopy: () -> Unit,
+    showConnector: Boolean,
+) {
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        Row(
+            modifier = Modifier.padding(top = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(SettingsTile.Blue),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = n.toString(),
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                    color = Color.White,
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (cmd != null) {
+                    Spacer(Modifier.height(10.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(Color(0xFF0D1117))
+                            .padding(start = 12.dp, end = 36.dp, top = 12.dp, bottom = 12.dp),
+                    ) {
+                        Text(
+                            text = cmd,
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = Color(0xFFA6FF99),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(start = 8.dp)
+                                .size(26.dp)
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(Color.White.copy(alpha = 0.08f))
+                                .clickable(onClick = onCopy),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                if (copied) Icons.Filled.Check else Icons.Filled.ContentCopy,
+                                contentDescription = null,
+                                tint = if (copied) Color(0xFFA6FF99) else Color.White,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if (showConnector) {
+            Spacer(Modifier.height(12.dp))
+            Box(
+                modifier = Modifier
+                    .padding(start = 13.dp)
+                    .size(width = 2.dp, height = 18.dp)
+                    .background(SettingsTile.Blue.copy(alpha = 0.25f)),
+            )
+        } else {
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+internal fun ExternalGlyph() {
+    Icon(
+        Icons.AutoMirrored.Filled.OpenInNew,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(14.dp),
+    )
+}
+
+internal fun openUrl(context: Context, url: String) {
+    try {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+    } catch (_: Throwable) { }
+}
+
+internal fun copyToClipboard(context: Context, label: String, value: String) {
+    val cb = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    cb.setPrimaryClip(ClipData.newPlainText(label, value))
+    Toast.makeText(context, R.string.copied, Toast.LENGTH_SHORT).show()
+}
+
+private data class StepData(val n: Int, val title: String, val body: String, val cmd: String?)

--- a/app/src/main/kotlin/chat/onym/android/settings/UseExistingContractScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/UseExistingContractScreen.kt
@@ -1,0 +1,315 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import chat.onym.android.R
+import chat.onym.android.chain.ContractNetwork
+import chat.onym.android.chain.GovernanceType
+
+/**
+ * Anchors → Custom → Use existing address. Lets the user point new
+ * `(network, governance)` chats at a Stellar Soroban contract they
+ * already deployed. Validates the C-prefixed 56-char address shape
+ * client-side; the actual on-chain probe is a stub here (the
+ * "Verify" button shows a green confirmation card unconditionally
+ * once the format check passes).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UseExistingContractScreen(
+    network: ContractNetwork,
+    type: GovernanceType,
+    onBack: () -> Unit,
+    onUseContract: (address: String, label: String) -> Unit,
+) {
+    val context = LocalContext.current
+    var addr by remember { mutableStateOf("") }
+    var label by remember { mutableStateOf("") }
+    var verified by remember { mutableStateOf(false) }
+
+    val cleanAddr = addr.trim()
+    val looksValid = cleanAddr.matches(Regex("^C[A-Z0-9]{55}$"))
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.use_contract_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier.fillMaxSize().testTag("use_contract.list"),
+        ) {
+            // ─── Hero ─────────────────────────────────────────────
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(horizontal = 18.dp, vertical = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(52.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(Color(0xFFE5E5FE), Color(0xFFC7C7F4)),
+                                )
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            Icons.Filled.AccountTree,
+                            contentDescription = null,
+                            tint = SettingsTile.Indigo,
+                            modifier = Modifier.size(26.dp),
+                        )
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.use_contract_hero_title),
+                            style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Spacer(Modifier.height(3.dp))
+                        Text(
+                            text = stringResource(
+                                R.string.use_contract_hero_body,
+                                stringResource(type.displayNameResId).lowercase(),
+                                stringResource(network.displayNameResId),
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            // ─── Stellar contract address ─────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.use_contract_address_section)) }
+            item {
+                SettingsCard {
+                    Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+                        OutlinedTextField(
+                            value = addr,
+                            onValueChange = { addr = it.replace("\\s".toRegex(), "").uppercase(); verified = false },
+                            placeholder = { Text("C…") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("use_contract.address.input"),
+                            singleLine = false,
+                            minLines = 2,
+                            maxLines = 3,
+                            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                                fontFamily = FontFamily.Monospace,
+                            ),
+                            keyboardOptions = KeyboardOptions(
+                                capitalization = KeyboardCapitalization.None,
+                                autoCorrect = false,
+                            ),
+                        )
+                        if (cleanAddr.isNotEmpty()) {
+                            Spacer(Modifier.height(6.dp))
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Text(
+                                    text = if (looksValid) {
+                                        stringResource(R.string.use_contract_validity_ok)
+                                    } else {
+                                        stringResource(R.string.use_contract_validity_progress, cleanAddr.length)
+                                    },
+                                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                                    color = if (looksValid) SettingsTile.Green else SettingsTile.Red,
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(
+                                            (if (looksValid) SettingsTile.Green else SettingsTile.Red).copy(alpha = 0.14f)
+                                        )
+                                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                                )
+                                Text(
+                                    text = stringResource(R.string.use_contract_address_helper),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ─── Label ────────────────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.use_contract_label_section)) }
+            item {
+                SettingsCard {
+                    Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+                        OutlinedTextField(
+                            value = label,
+                            onValueChange = { if (it.length <= 30) label = it },
+                            placeholder = { Text(stringResource(R.string.use_contract_label_placeholder)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag("use_contract.label.input"),
+                            singleLine = true,
+                        )
+                    }
+                }
+            }
+            item { SettingsFootnote(stringResource(R.string.use_contract_label_footnote)) }
+
+            item {
+                Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                    Button(
+                        onClick = {
+                            if (!verified) verified = true
+                            else onUseContract(cleanAddr, label.ifBlank { "Custom contract" })
+                        },
+                        enabled = looksValid,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .testTag("use_contract.verify"),
+                        shape = RoundedCornerShape(14.dp),
+                    ) {
+                        Text(
+                            text = if (verified) stringResource(R.string.use_contract_use_button)
+                            else stringResource(R.string.use_contract_verify_button),
+                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                        )
+                    }
+                }
+            }
+
+            if (verified) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 4.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(SettingsTile.Green.copy(alpha = 0.1f))
+                            .padding(horizontal = 14.dp, vertical = 12.dp),
+                        verticalAlignment = Alignment.Top,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(22.dp)
+                                .clip(RoundedCornerShape(11.dp))
+                                .background(SettingsTile.Green),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                tint = Color.White,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.use_contract_verified_title),
+                                style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                                color = Color(0xFF175E2F),
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                text = stringResource(R.string.use_contract_verified_body),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = Color(0xFF306E48),
+                            )
+                        }
+                    }
+                }
+            }
+
+            // ─── How to find it ───────────────────────────────────
+            item { SettingsSectionLabel(stringResource(R.string.use_contract_findit_section)) }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = { SettingsTileLabel("SX", SettingsTile.Indigo) },
+                        title = stringResource(R.string.use_contract_findit_explorer),
+                        subtitle = if (network == ContractNetwork.Testnet) "testnet.stellar.expert" else "stellar.expert",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = {
+                            val host = if (network == ContractNetwork.Testnet) "testnet.stellar.expert" else "stellar.expert"
+                            openUrl(context, "https://$host/")
+                        },
+                    )
+                    SettingsRow(
+                        leading = { SettingsTileLabel("CLI", SettingsTile.Gray) },
+                        title = stringResource(R.string.use_contract_findit_cli),
+                        subtitle = "soroban contract id …",
+                        subtitleMono = true,
+                        showChevron = false,
+                        trailing = { ExternalGlyph() },
+                        onClick = { openUrl(context, "https://github.com/onymchat/onym-contracts#deploy") },
+                        isLast = true,
+                    )
+                }
+            }
+            item { Spacer(Modifier.height(40.dp)) }
+        }
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -228,6 +228,92 @@
     <string name="about_credits_line2">Распространяется по лицензии MIT.</string>
     <string name="about_credits_copyright">© 2026 · Onym</string>
 
+    <!-- ─── Run-your-own-relayer ─────────────────────────────────── -->
+    <string name="relayer_run_your_own_title">Запустите свой релеер</string>
+    <string name="relayer_run_your_own_subtitle">Разверните onym-relayer из GitHub за 5 минут</string>
+    <string name="run_relayer_title">Запустите свой релеер</string>
+    <string name="run_relayer_hero_title">Ваш релеер, ваши правила</string>
+    <string name="run_relayer_hero_body">Запустите релеер для себя, своей команды или организации. Сквозное шифрование сохраняется — Onym никогда не видит ваши сообщения.</string>
+    <string name="run_relayer_view_github">Открыть на GitHub</string>
+    <string name="run_relayer_read_docs">Документация</string>
+    <string name="run_relayer_step1_title">Клонируйте репозиторий</string>
+    <string name="run_relayer_step1_body">onym-relayer — открытый исходный код. Получите его на GitHub.</string>
+    <string name="run_relayer_step2_title">Настройте домен</string>
+    <string name="run_relayer_step2_body">Установите RELAYER_URL в .env. Этот URL будут использовать пользователи.</string>
+    <string name="run_relayer_step3_title">Разверните</string>
+    <string name="run_relayer_step3_body">Выберите хостинг. У Fly.io и Railway есть развёртывание в один клик.</string>
+    <string name="run_relayer_step4_title">Добавьте в Onym</string>
+    <string name="run_relayer_step4_body">Вернитесь в раздел «Релеер» и вставьте свой URL в «Добавить произвольный URL».</string>
+    <string name="run_relayer_deploy_section">Развёртывание в один клик</string>
+    <string name="run_relayer_deploy_fly">Развернуть на Fly.io</string>
+    <string name="run_relayer_deploy_fly_subtitle">Бесплатный тариф · глобальный edge</string>
+    <string name="run_relayer_deploy_railway">Развернуть на Railway</string>
+    <string name="run_relayer_deploy_railway_subtitle">Простая настройка</string>
+    <string name="run_relayer_deploy_docker">Запуск через Docker</string>
+    <string name="run_relayer_deploy_docker_subtitle">Самостоятельный хостинг где угодно</string>
+    <string name="run_relayer_footnote">Нужна помощь? Создайте issue на GitHub или присоединитесь к чату разработчиков.</string>
+
+    <!-- ─── Anchors → Custom (deploy / use existing) ─────────────── -->
+    <string name="anchors_section_custom">Произвольный</string>
+    <string name="anchors_releases_detail_footnote">Нажмите на версию, чтобы посмотреть контракт, исходный код и аудит.</string>
+    <string name="anchors_custom_deploy_title">Развернуть из исходников</string>
+    <string name="anchors_custom_deploy_subtitle">Соберите и опубликуйте свой контракт</string>
+    <string name="anchors_custom_use_title">Использовать существующий адрес</string>
+    <string name="anchors_custom_use_subtitle">Указать на уже развёрнутый контракт</string>
+    <string name="anchors_custom_footer">Onym поставляет только проверенные (или ожидающие аудита) контракты. Если у вас свой форк или развёртывание, укажите его здесь — он будет использоваться для новых чатов. Существующие чаты сохраняют свой контракт.</string>
+
+    <!-- ─── Contract Detail ──────────────────────────────────────── -->
+    <string name="contract_detail_hero_eyebrow">Контракт · %1$s</string>
+    <string name="contract_detail_hero_subtitle">Stellar %1$s</string>
+    <string name="contract_detail_onchain_section">В блокчейне</string>
+    <string name="contract_detail_explorer_title">Stellar Expert</string>
+    <string name="contract_detail_copy_address">Скопировать адрес контракта</string>
+    <string name="contract_detail_no_address">Не развернут</string>
+    <string name="contract_detail_source_section">Исходный код</string>
+    <string name="contract_detail_view_source">Открыть исходник на GitHub</string>
+    <string name="contract_detail_audit_title">Отчёт об аудите</string>
+    <string name="contract_detail_audit_subtitle">Ожидается — аудиты ещё не проведены</string>
+    <string name="contract_detail_footnote">Этот контракт привязывает группы типа «%1$s». Существующие чаты сохраняют контракт, с которым были созданы — выбор другой версии затрагивает только новые чаты.</string>
+
+    <!-- ─── Use existing contract address ────────────────────────── -->
+    <string name="use_contract_title">Использовать существующий адрес</string>
+    <string name="use_contract_hero_title">Свой контракт</string>
+    <string name="use_contract_hero_body">Привязать новые %1$s-чаты к Stellar %2$s контракту, который вы уже развернули.</string>
+    <string name="use_contract_address_section">Адрес Stellar контракта</string>
+    <string name="use_contract_address_helper">ID контракта Stellar Soroban</string>
+    <string name="use_contract_validity_ok">Корректный формат</string>
+    <string name="use_contract_validity_progress">%1$d/56 символов</string>
+    <string name="use_contract_label_section">Подпись</string>
+    <string name="use_contract_label_placeholder">Мой форк v0.0.5</string>
+    <string name="use_contract_label_footnote">Показывается рядом с адресом контракта в чатах и в списке якорей.</string>
+    <string name="use_contract_verify_button">Проверить</string>
+    <string name="use_contract_use_button">Использовать этот контракт</string>
+    <string name="use_contract_verified_title">Контракт проверен</string>
+    <string name="use_contract_verified_body">Проверка формата пройдена. Нажмите «Использовать этот контракт», чтобы привязать к нему новые чаты.</string>
+    <string name="use_contract_findit_section">Как его найти</string>
+    <string name="use_contract_findit_explorer">Открыть Stellar Expert</string>
+    <string name="use_contract_findit_cli">Soroban CLI</string>
+
+    <!-- ─── Deploy contract from source ──────────────────────────── -->
+    <string name="deploy_contract_title">Развернуть из исходников</string>
+    <string name="deploy_contract_hero_title">Собрать, развернуть, привязать</string>
+    <string name="deploy_contract_hero_body">Скомпилируйте контракт «%1$s» из исходников и разверните в Stellar %2$s прямо с этого устройства. Onym подписывает одноразовым ключом развёртывания.</string>
+    <string name="deploy_contract_source_section">Исходный код</string>
+    <string name="deploy_contract_repo">Репозиторий</string>
+    <string name="deploy_contract_ref_label">Ref</string>
+    <string name="deploy_contract_network_label">Сеть</string>
+    <string name="deploy_contract_module_label">Модуль</string>
+    <string name="deploy_contract_action">Собрать и развернуть</string>
+    <string name="deploy_contract_log_building">Сборка wasm…</string>
+    <string name="deploy_contract_log_deploying">Развёртывание в Stellar…</string>
+    <string name="deploy_contract_log_done">Готово</string>
+    <string name="deploy_contract_deployed_section">Развёрнутый контракт</string>
+    <string name="deploy_contract_deployed_title">Контракт развёрнут</string>
+    <string name="deploy_contract_view_explorer">Stellar Expert</string>
+    <string name="deploy_contract_use_button">Использовать этот контракт</string>
+    <string name="deploy_contract_cli_section">Или используйте CLI</string>
+    <string name="deploy_contract_passphrase_footnote">Сетевая passphrase: %1$s. После развёртывания через CLI вернитесь и выберите «Использовать существующий адрес».</string>
+
     <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
     <string name="network_testnet">Тестовая сеть</string>
     <string name="network_public">Основная сеть</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,6 +232,92 @@
     <string name="about_credits_line2">Released under the MIT license.</string>
     <string name="about_credits_copyright">© 2026 · Onym</string>
 
+    <!-- ─── Run-your-own-relayer ─────────────────────────────────── -->
+    <string name="relayer_run_your_own_title">Run your own relayer</string>
+    <string name="relayer_run_your_own_subtitle">Deploy onym-relayer from GitHub in 5 minutes</string>
+    <string name="run_relayer_title">Run your own relayer</string>
+    <string name="run_relayer_hero_title">Your relayer, your rules</string>
+    <string name="run_relayer_hero_body">Run a relayer for yourself, your team, or your org. End-to-end encryption stays intact — Onym never sees your messages.</string>
+    <string name="run_relayer_view_github">View on GitHub</string>
+    <string name="run_relayer_read_docs">Read the docs</string>
+    <string name="run_relayer_step1_title">Clone the repo</string>
+    <string name="run_relayer_step1_body">onym-relayer is open source. Grab it from GitHub.</string>
+    <string name="run_relayer_step2_title">Configure your domain</string>
+    <string name="run_relayer_step2_body">Set RELAYER_URL in .env. This is what users will paste.</string>
+    <string name="run_relayer_step3_title">Deploy</string>
+    <string name="run_relayer_step3_body">Pick a host. Fly.io and Railway have one-click deploys.</string>
+    <string name="run_relayer_step4_title">Add it to Onym</string>
+    <string name="run_relayer_step4_body">Back on Relayer, paste your URL into "Add Custom URL".</string>
+    <string name="run_relayer_deploy_section">One-click deploy</string>
+    <string name="run_relayer_deploy_fly">Deploy to Fly.io</string>
+    <string name="run_relayer_deploy_fly_subtitle">Free tier · global edge</string>
+    <string name="run_relayer_deploy_railway">Deploy to Railway</string>
+    <string name="run_relayer_deploy_railway_subtitle">Simple setup</string>
+    <string name="run_relayer_deploy_docker">Run with Docker</string>
+    <string name="run_relayer_deploy_docker_subtitle">Self-host anywhere</string>
+    <string name="run_relayer_footnote">Need help? Open an issue on GitHub or join the dev chat.</string>
+
+    <!-- ─── Anchors → Custom (deploy / use existing) ─────────────── -->
+    <string name="anchors_section_custom">Custom</string>
+    <string name="anchors_releases_detail_footnote">Tap a version to view the contract, source code, and audit report.</string>
+    <string name="anchors_custom_deploy_title">Deploy from source</string>
+    <string name="anchors_custom_deploy_subtitle">Build &amp; publish your own contract</string>
+    <string name="anchors_custom_use_title">Use existing address</string>
+    <string name="anchors_custom_use_subtitle">Point to a deployed contract</string>
+    <string name="anchors_custom_footer">Onym only ships audited (or pending-audit) contracts. If you\'ve forked or deployed your own, point new chats at it here. Existing chats keep the contract they were created with.</string>
+
+    <!-- ─── Contract Detail ──────────────────────────────────────── -->
+    <string name="contract_detail_hero_eyebrow">Contract · %1$s</string>
+    <string name="contract_detail_hero_subtitle">Stellar %1$s</string>
+    <string name="contract_detail_onchain_section">On-chain</string>
+    <string name="contract_detail_explorer_title">Stellar Expert</string>
+    <string name="contract_detail_copy_address">Copy contract address</string>
+    <string name="contract_detail_no_address">Not deployed</string>
+    <string name="contract_detail_source_section">Source</string>
+    <string name="contract_detail_view_source">View source on GitHub</string>
+    <string name="contract_detail_audit_title">Audit report</string>
+    <string name="contract_detail_audit_subtitle">Pending — no audits yet</string>
+    <string name="contract_detail_footnote">This is the contract that anchors %1$s groups. Existing chats keep the contract they were created with — picking a different version only affects new chats.</string>
+
+    <!-- ─── Use existing contract address ────────────────────────── -->
+    <string name="use_contract_title">Use existing address</string>
+    <string name="use_contract_hero_title">Bring your own contract</string>
+    <string name="use_contract_hero_body">Anchor new %1$s chats on a Stellar %2$s contract you\'ve already deployed.</string>
+    <string name="use_contract_address_section">Stellar contract address</string>
+    <string name="use_contract_address_helper">Stellar Soroban contract ID</string>
+    <string name="use_contract_validity_ok">Valid format</string>
+    <string name="use_contract_validity_progress">%1$d/56 chars</string>
+    <string name="use_contract_label_section">Label</string>
+    <string name="use_contract_label_placeholder">My fork v0.0.5</string>
+    <string name="use_contract_label_footnote">Shown alongside the contract address in chats and on the Anchors list.</string>
+    <string name="use_contract_verify_button">Verify</string>
+    <string name="use_contract_use_button">Use this contract</string>
+    <string name="use_contract_verified_title">Contract verified</string>
+    <string name="use_contract_verified_body">Format check passed. Tap "Use this contract" to anchor new chats here.</string>
+    <string name="use_contract_findit_section">How to find it</string>
+    <string name="use_contract_findit_explorer">Browse on Stellar Expert</string>
+    <string name="use_contract_findit_cli">Soroban CLI</string>
+
+    <!-- ─── Deploy contract from source ──────────────────────────── -->
+    <string name="deploy_contract_title">Deploy from source</string>
+    <string name="deploy_contract_hero_title">Build, deploy, anchor</string>
+    <string name="deploy_contract_hero_body">Compile the %1$s contract from source and deploy it to Stellar %2$s from this device. Onym signs with a one-time deploy key.</string>
+    <string name="deploy_contract_source_section">Source</string>
+    <string name="deploy_contract_repo">Repository</string>
+    <string name="deploy_contract_ref_label">Ref</string>
+    <string name="deploy_contract_network_label">Network</string>
+    <string name="deploy_contract_module_label">Module</string>
+    <string name="deploy_contract_action">Build &amp; Deploy</string>
+    <string name="deploy_contract_log_building">Building wasm…</string>
+    <string name="deploy_contract_log_deploying">Deploying to Stellar…</string>
+    <string name="deploy_contract_log_done">Complete</string>
+    <string name="deploy_contract_deployed_section">Deployed contract</string>
+    <string name="deploy_contract_deployed_title">Contract deployed</string>
+    <string name="deploy_contract_view_explorer">Stellar Expert</string>
+    <string name="deploy_contract_use_button">Use this contract</string>
+    <string name="deploy_contract_cli_section">Or use the CLI</string>
+    <string name="deploy_contract_passphrase_footnote">Network passphrase: %1$s. After deploying via CLI, come back and choose "Use existing address".</string>
+
     <!-- ─── ContractNetwork.displayName ──────────────────────────── -->
     <string name="network_testnet">Testnet</string>
     <string name="network_public">Mainnet</string>


### PR DESCRIPTION
## Summary

- Builds on PR #69 (already merged) to close the gap between the Apple-style home and the deeper sub-flows the design specifies — custom contract setup, custom relayer self-hosting, and per-version contract detail.
- All four new screens are UI-complete; the side effects (real `cargo build` + `soroban contract deploy`, on-chain wasm-hash probe) are scaffolded so the visual review can land first.

## What's new

- **`RunRelayerScreen`** — dark "Your relayer, your rules" hero pinned to `github.com/onymchat/onym-relayer`, four numbered steps with copyable shell snippets (clone / configure / deploy / add-to-Onym), one-click deploy targets for Fly.io · Railway · Docker. Reachable from a new dark CTA at the bottom of `RelayerSettingsScreen`.
- **`ContractDetailScreen`** — opens from the chevron on each version row in `AnchorsVersionScreen`. ON-CHAIN: Stellar Expert link (testnet vs public-wired) + copy-address row. SOURCE: GitHub source row at `github.com/onymchat/onym-contracts/releases/tag/{version}`, audit-pending tile.
- **`UseExistingContractScreen`** — Anchors → Custom → "Use existing address". Multiline mono input with `C…` 56-char format check (live "Valid format" / "n/56 chars" pill), label field, Verify → "Use this contract" two-step button, helper section linking Stellar Expert + the Soroban CLI docs at `github.com/onymchat/onym-contracts#deploy`.
- **`DeployContractScreen`** — Anchors → Custom → "Deploy from source". Dark hero pinned to `github.com/onymchat/onym-contracts`, repo / ref / network / module rows, Build & Deploy button replays a 5-stage progress log (clone → cargo build → upload wasm → invoke deploy → deployed) and reveals a deployed-contract card with copy + Stellar Expert links. CLI fallback snippet always at the bottom.

## Wiring on existing screens

- `RelayerSettingsScreen` — new `onRunYourOwnClick` parameter and a dark CTA card under "Add Custom URL".
- `AnchorsVersionScreen` — added CUSTOM section (Deploy from source / Use existing address) and a dedicated chevron-zone per version row that drills into ContractDetail without flipping the selection.
- `RootScreen` — four new routes: `run_relayer`, `contract_detail/{network}/{type}/{version}?addr={addr}`, `use_contract/{network}/{type}`, `deploy_contract/{network}/{type}`.

## i18n

~50 more keys land in both `values/strings.xml` and `values-ru/strings.xml`. `MissingTranslation` lint is satisfied.

## What's still scaffold (intentional — out of scope for the UI pass)

- `DeployContract`'s Build & Deploy is a canned animation; on-device cargo + soroban-cli wiring is a separate effort.
- `UseExistingContract`'s Verify is a client-side regex; the on-chain probe (existence + matching wasm hash) lands when the contracts manifest fetcher gains an arbitrary-address mode.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:lintDebug` — green (no `MissingTranslation`)
- [ ] Manual: Settings → Relayer → "Run your own relayer" CTA → all four step copy buttons + three deploy links
- [ ] Manual: Settings → Anchors → Testnet → any governance type → tap chevron on a version row → ContractDetail (Stellar Expert + GitHub source rows open)
- [ ] Manual: Settings → Anchors → Testnet → any governance type → "Use existing address" → paste a `C…56` address → Verify → "Use this contract"
- [ ] Manual: Settings → Anchors → Testnet → any governance type → "Deploy from source" → Build & Deploy → progress log animates → deployed card shows
- [ ] Manual: ru locale renders all new strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)