### PR TITLE
ux: invite QR hero on Settings + Identity detail

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -149,6 +149,13 @@ dependencies {
 
     implementation(libs.bouncycastle)
 
+    // ZXing core — pure-Java QR encoder. Used by `OnymQrCode` to turn
+    // an invite URL into a 1-bit module grid; the Compose Canvas does
+    // the actual drawing (so we get rounded modules + center logo
+    // overlay matching the iOS design without ZXing's stock bitmap
+    // renderer).
+    implementation(libs.zxing.core)
+
     implementation(libs.onym.sdk)
 
     // Room — `suspend` DAO + KSP-generated bindings. PersistenceStore

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityInviteUrl.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityInviteUrl.kt
@@ -1,0 +1,33 @@
+package chat.onym.android.identity
+
+import java.util.Base64
+
+/**
+ * Public, deterministic invite URL for an identity.
+ *
+ * Encodes the identity's [IdentitySummary.inboxPublicKey] (the
+ * 32-byte X25519 ECDH key peers ECDH against to encrypt invitations)
+ * as URL-safe base64 in a `https://onym.chat/i?k=…` link. Mirrors
+ * the existing [chat.onym.android.group.IntroCapability.toAppLink]
+ * convention (`/join?c=…` for group invites; `/i?k=…` here for
+ * identity invites) so a future App Link entry covers both with the
+ * same `onym.chat` autoVerify host.
+ *
+ * Identity-invite onboarding (someone scans this and lands in a
+ * one-on-one chat with the holder) isn't implemented end-to-end
+ * yet — see follow-up. The URL is already correct for that future
+ * flow: every byte the joiner needs is here, and the URL is stable
+ * across app sessions (no per-scan minting).
+ *
+ * Uses URL-safe Base64 (no `=` padding, no `+`/`/`) so the result
+ * drops straight into the URL query without percent-encoding.
+ */
+fun IdentitySummary.inviteUrl(): String {
+    val payload = Base64.getUrlEncoder()
+        .withoutPadding()
+        .encodeToString(inboxPublicKey)
+    return "$IDENTITY_INVITE_URL_BASE$payload"
+}
+
+/** Base of the identity-invite App Link. */
+const val IDENTITY_INVITE_URL_BASE: String = "https://onym.chat/i?k="

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.settings
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,6 +24,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -56,6 +59,7 @@ import chat.onym.android.R
 import chat.onym.android.group.OnymMark
 import chat.onym.android.identity.IdentitiesViewModel
 import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.inviteUrl
 
 /**
  * Identity Detail — per-identity hero, backup status, set-active,
@@ -167,6 +171,113 @@ fun IdentityDetailScreen(
                     )
                 }
             }
+
+            // ─── INVITE KEY card ─────────────────────────────────
+            // Full-size QR for the identity's invite URL with Copy /
+            // Share actions underneath. Mirrors `settings.jsx` lines
+            // 873–909 in the iOS prototype.
+            item { SettingsSectionLabel(stringResource(R.string.identity_detail_invite_section).uppercase()) }
+            item {
+                val inviteUrl = remember(row.summary) { row.summary.inviteUrl() }
+                val shareTextTemplate = stringResource(
+                    R.string.identity_detail_invite_share_text,
+                    inviteUrl,
+                )
+                val shareChooserTitle = stringResource(R.string.identity_detail_invite_share_chooser)
+                SettingsCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 18.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(18.dp))
+                                .background(Color.White)
+                                .padding(12.dp),
+                        ) {
+                            OnymQrCode(
+                                value = inviteUrl,
+                                size = 220.dp,
+                                modifier = Modifier.testTag("identity_detail.invite_qr"),
+                            )
+                        }
+                        Text(
+                            text = stringResource(R.string.identity_detail_invite_caption),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                .padding(horizontal = 12.dp, vertical = 8.dp),
+                        ) {
+                            Text(
+                                text = inviteUrl,
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                            )
+                        }
+                    }
+                    SettingsHairline(insetStart = 16.dp)
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        TextButton(
+                            onClick = {
+                                copyToClipboard(context, "Invite link", inviteUrl)
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                                .testTag("identity_detail.invite_copy"),
+                        ) {
+                            Icon(
+                                Icons.Filled.ContentCopy,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.size(8.dp))
+                            Text(stringResource(R.string.identity_detail_invite_copy))
+                        }
+                        Box(
+                            modifier = Modifier
+                                .width(0.5.dp)
+                                .height(48.dp)
+                                .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
+                        )
+                        TextButton(
+                            onClick = {
+                                val sendIntent = Intent().apply {
+                                    action = Intent.ACTION_SEND
+                                    putExtra(Intent.EXTRA_TEXT, shareTextTemplate)
+                                    type = "text/plain"
+                                }
+                                context.startActivity(
+                                    Intent.createChooser(sendIntent, shareChooserTitle),
+                                )
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                                .testTag("identity_detail.invite_share"),
+                        ) {
+                            Icon(
+                                Icons.Filled.Share,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(Modifier.size(8.dp))
+                            Text(stringResource(R.string.identity_detail_invite_share))
+                        }
+                    }
+                }
+            }
+            item { SettingsFootnote(stringResource(R.string.identity_detail_invite_footnote)) }
 
             // ─── BACKUP card ──────────────────────────────────────
             item { SettingsSectionLabel(stringResource(R.string.identity_detail_backup_section)) }

--- a/app/src/main/kotlin/chat/onym/android/settings/OnymQrCode.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/OnymQrCode.kt
@@ -1,0 +1,142 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import chat.onym.android.group.OnymMark
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+
+/**
+ * Brand-anchored QR rendering of [value], with the broken-ring Onym
+ * mark badged over the centre.
+ *
+ * Encoder: ZXing core's [QRCodeWriter] at error-correction level
+ * **H (~30%)**. The high ECC budget is what makes the centre logo
+ * cutout safe — up to ~30% of modules can be obscured (or otherwise
+ * unreadable) while the QR still decodes cleanly. We obscure ~22% by
+ * area (the white badge), well inside the budget.
+ *
+ * Renderer: hand-drawn on a Compose [Canvas] so we can match the
+ * iOS prototype's chunky **rounded modules** + white centre badge
+ * with the [OnymMark] inside. ZXing's stock `MatrixToImageWriter`
+ * would give us a hard-pixel raster bitmap — wrong feel and an extra
+ * bitmap allocation per recomposition.
+ *
+ * The bit matrix is memoised on [value]; the draw block is pure (it
+ * only reads the memoised matrix + the Compose-resolved colours), so
+ * recompositions on layout-only changes don't re-encode.
+ *
+ * Mirrors the iOS design's `QRCode` component (`settings.jsx` lines
+ * 414–474) — same finder-corner shape, same centre badge, same
+ * rounded modules. The Android port differs only in the encoder
+ * (real QR via ZXing; iOS used a deterministic visual placeholder).
+ */
+@Composable
+internal fun OnymQrCode(
+    value: String,
+    modifier: Modifier = Modifier,
+    size: Dp = 200.dp,
+    foreground: Color = Color(0xFF0A0A0C),
+    background: Color = Color.White,
+) {
+    val matrix = remember(value) { encodeQrMatrix(value) }
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(12.dp))
+            .background(background),
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(modifier = Modifier.size(size)) {
+            val px = this.size.minDimension
+            val cell = px / matrix.dimension
+            // Inset each module very slightly so adjacent rounded
+            // squares don't visually merge into a single blob.
+            val inset = cell * 0.04f
+            val cornerRadius = CornerRadius(cell * 0.18f)
+            for (y in 0 until matrix.dimension) {
+                for (x in 0 until matrix.dimension) {
+                    if (!matrix.isOn(x, y)) continue
+                    drawRoundRect(
+                        color = foreground,
+                        topLeft = Offset(x * cell + inset, y * cell + inset),
+                        size = Size(cell - 2 * inset, cell - 2 * inset),
+                        cornerRadius = cornerRadius,
+                    )
+                }
+            }
+        }
+        // Centre badge — ~22% of the QR side. White rounded square,
+        // OnymMark sits on top in the foreground colour. Matches the
+        // iOS prototype proportions exactly.
+        val badgeSize = size * 0.22f
+        Box(
+            modifier = Modifier
+                .size(badgeSize)
+                .clip(RoundedCornerShape(badgeSize * 0.22f))
+                .background(background)
+                .padding(badgeSize * 0.13f),
+            contentAlignment = Alignment.Center,
+        ) {
+            OnymMark(
+                size = badgeSize * 0.74f,
+                color = foreground,
+            )
+        }
+    }
+}
+
+/**
+ * Bit-grid view of a ZXing [com.google.zxing.common.BitMatrix]. We
+ * don't pass the matrix around directly so the call site doesn't
+ * pull in ZXing types and so we can cache a small int instead of
+ * holding the whole matrix's internal long-array.
+ */
+private class QrBitMatrix(
+    val dimension: Int,
+    private val bits: BooleanArray,
+) {
+    fun isOn(x: Int, y: Int): Boolean = bits[y * dimension + x]
+}
+
+private fun encodeQrMatrix(value: String): QrBitMatrix {
+    // Hint the highest error-correction level so the centre logo
+    // cutout doesn't break decode. Margin = 0 because the Compose
+    // surface around the QR provides its own padding (the iOS
+    // design wraps the QR in a 12-pt white card, mirrored here).
+    val hints = mapOf(
+        EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.H,
+        EncodeHintType.MARGIN to 0,
+        EncodeHintType.CHARACTER_SET to "UTF-8",
+    )
+    // Pass size 1 → ZXing returns the smallest BitMatrix that
+    // satisfies the encoded version's module count. We then scale
+    // it ourselves on the canvas, so the input "pixel" size is
+    // immaterial.
+    val matrix = QRCodeWriter().encode(value, BarcodeFormat.QR_CODE, 1, 1, hints)
+    val dim = matrix.width
+    val bits = BooleanArray(dim * dim)
+    for (y in 0 until dim) {
+        for (x in 0 until dim) {
+            bits[y * dim + x] = matrix.get(x, y)
+        }
+    }
+    return QrBitMatrix(dimension = dim, bits = bits)
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -52,6 +52,8 @@ import chat.onym.android.R
 import chat.onym.android.group.OnymMark
 import chat.onym.android.identity.IdentitiesViewModel
 import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.IdentitySummary
+import chat.onym.android.identity.inviteUrl
 
 /**
  * Settings home — Apple-Settings-style, brand-anchored on the
@@ -90,6 +92,11 @@ fun SettingsScreen(
     val items by identitiesViewModel.items.collectAsStateWithLifecycle()
     val active = items.firstOrNull { it.isActive }
     val identityCount = items.size
+    // Resolve display copy that the LazyColumn item blocks need from
+    // outside the LazyListScope (item content is @Composable, but
+    // LazyListScope itself is not — `stringResource` would fail there).
+    val unnamedFallback = stringResource(R.string.identity_unnamed)
+    val activeName = active?.summary?.name?.ifBlank { unnamedFallback }
 
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -108,13 +115,21 @@ fun SettingsScreen(
                 .testTag("settings.list"),
         ) {
             // ─── Active identity hero ──────────────────────────────
-            if (active != null) {
+            if (active != null && activeName != null) {
                 item {
                     ActiveIdentityHero(
-                        name = active.summary.name.ifBlank {
-                            stringResource(R.string.identity_unnamed)
-                        },
+                        name = activeName,
                         keyHex = heroHex(active.summary.blsPublicKey),
+                        onClick = { onIdentityDetailClick(active.summary.id) },
+                    )
+                }
+                // Invite QR hero — compact card directly under the
+                // active-identity row. Tap opens the identity detail
+                // screen, which surfaces a full-size QR + copy/share.
+                item {
+                    InviteQrHero(
+                        summary = active.summary,
+                        activeName = activeName,
                         onClick = { onIdentityDetailClick(active.summary.id) },
                     )
                 }
@@ -305,6 +320,69 @@ private fun ActiveIdentityHero(
             Text(
                 text = keyHex,
                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+            modifier = Modifier.size(18.dp),
+        )
+    }
+}
+
+/**
+ * Compact "Invite key" hero — a small QR with the active identity's
+ * invite URL on the left, an eyebrow + headline + subtitle on the
+ * right. Tapping the card hands off to the Identity Detail screen
+ * for the full-size QR + Copy / Share actions.
+ *
+ * Mirrors the iOS prototype's second hero card under the active-
+ * identity row (`settings.jsx` lines 559–587).
+ */
+@Composable
+private fun InviteQrHero(
+    summary: IdentitySummary,
+    activeName: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 18.dp)
+            .testTag("settings.invite_qr_hero"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(14.dp))
+                .background(Color.White)
+                .padding(8.dp),
+        ) {
+            OnymQrCode(value = summary.inviteUrl(), size = 92.dp)
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.settings_invite_qr_eyebrow).uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text = stringResource(R.string.settings_invite_qr_title),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.settings_invite_qr_subtitle, activeName),
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -147,6 +147,11 @@
     <string name="settings_about_title">О приложении Onym</string>
     <string name="settings_about_subtitle">Версия %1$s (сборка %2$s)</string>
 
+    <!-- ─── Settings home → Invite QR hero ───────────────────────── -->
+    <string name="settings_invite_qr_eyebrow">Ключ-приглашение</string>
+    <string name="settings_invite_qr_title">Начните чат, отсканировав код</string>
+    <string name="settings_invite_qr_subtitle">Дайте кому-нибудь отсканировать этот код в Onym, чтобы открыть приватный чат с %1$s.</string>
+
     <!-- ─── Identities list (redesigned) ─────────────────────────── -->
     <string name="identities_screen_title">Личности</string>
     <string name="identities_screen_intro">Нажмите на личность, чтобы открыть её. У каждой личности свои ключи, чаты и фраза восстановления.</string>
@@ -163,6 +168,15 @@
     <string name="identity_detail_backup_status_subtitle">Без неё восстановить эту личность будет невозможно.</string>
     <string name="identity_detail_backup_action">Показать фразу восстановления</string>
     <string name="identity_detail_backup_action_subtitle">12 слов · BIP-39</string>
+    <!-- Per-identity invite QR card on the Identity Detail screen. -->
+    <string name="identity_detail_invite_section">Ключ-приглашение</string>
+    <string name="identity_detail_invite_caption">Отсканируйте в Onym на другом устройстве, чтобы открыть приватный чат с этой личностью.</string>
+    <string name="identity_detail_invite_copy">Копировать ссылку</string>
+    <string name="identity_detail_invite_share">Поделиться</string>
+    <string name="identity_detail_invite_footnote">Любой обладатель этого кода может начать чат с вами. Сам чат сквозно зашифрован.</string>
+    <string name="identity_detail_invite_share_chooser">Поделиться ссылкой-приглашением</string>
+    <string name="identity_detail_invite_share_text">Начните чат со мной в Onym: %1$s</string>
+
     <string name="identity_detail_state_section">Статус</string>
     <string name="identity_detail_set_active">Сделать активной</string>
     <string name="identity_detail_advanced_section">Расширенные</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,11 @@
     <string name="settings_about_title">About Onym</string>
     <string name="settings_about_subtitle">Version %1$s (build %2$s)</string>
 
+    <!-- ─── Settings home → Invite QR hero ───────────────────────── -->
+    <string name="settings_invite_qr_eyebrow">Invite key</string>
+    <string name="settings_invite_qr_title">Start a chat by scanning</string>
+    <string name="settings_invite_qr_subtitle">Have someone scan this code with Onym to open a private chat with %1$s.</string>
+
     <!-- ─── Identities list (redesigned) ─────────────────────────── -->
     <string name="identities_screen_title">Identities</string>
     <string name="identities_screen_intro">Tap an identity to open it. Each identity has its own keys, chats, and recovery phrase.</string>
@@ -167,6 +172,15 @@
     <string name="identity_detail_backup_status_subtitle">Without your phrase you can\'t restore this identity.</string>
     <string name="identity_detail_backup_action">View recovery phrase</string>
     <string name="identity_detail_backup_action_subtitle">12 words · BIP-39</string>
+    <!-- Per-identity invite QR card on the Identity Detail screen. -->
+    <string name="identity_detail_invite_section">Invite key</string>
+    <string name="identity_detail_invite_caption">Scan with Onym on another device to open a private chat with this identity.</string>
+    <string name="identity_detail_invite_copy">Copy link</string>
+    <string name="identity_detail_invite_share">Share</string>
+    <string name="identity_detail_invite_footnote">Anyone with this code can start a chat with you. The chat itself is end-to-end encrypted.</string>
+    <string name="identity_detail_invite_share_chooser">Share invite link</string>
+    <string name="identity_detail_invite_share_text">Start a chat with me on Onym: %1$s</string>
+
     <string name="identity_detail_state_section">State</string>
     <string name="identity_detail_set_active">Set as active</string>
     <string name="identity_detail_advanced_section">Advanced</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,12 @@ onym-sdk = "0.0.2"
 # Crypto
 bouncycastle = "1.78.1"
 
+# ZXing — pure-Java QR encoder (Apache 2.0). The `core` artifact is
+# free of any Android dependency; we render the resulting BitMatrix
+# ourselves on a Compose `Canvas`, so the heavier `zxing-android`
+# extras (camera, intent integrators) stay out of the APK.
+zxing-core = "3.5.3"
+
 # Room — Kotlin-coroutines DAO (`suspend` queries) + KSP-generated
 # bindings. 2.6.1 is the newest stable that pairs cleanly with AGP
 # 8.7 and Kotlin 2.0.21 KSP without dragging in 2.7's KMP refactor.
@@ -116,6 +122,10 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 
 # BouncyCastle — Curve25519 (Ed25519 + X25519) raw-key APIs not in the JDK
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+
+# ZXing core — QR-bit-matrix generator. Drawn by `OnymQrCode` onto a
+# Compose Canvas; no Android-side ZXing artifact needed.
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
 
 # Test
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

Implements the two **invite QR hero sections** from the iOS handoff design (`onym-ios/project/Onym Settings.html`):

- **Settings root** — compact "Invite key" hero card directly under the active-identity row. Tap → identity detail.
- **Identity Detail** — full-size 220 dp QR card under the avatar hero with Copy / Share split-button row, mono URL preview, caption, and footnote.

QR generation uses **ZXing core 3.5.3** (Apache 2.0, pure-Java, no Android transitive deps) at error-correction level **H** so the centre `OnymMark` badge cutout doesn't break decode. Compose `Canvas` does the actual drawing, so modules render as the prototype's chunky rounded squares + the brand mark sits on top.

Encoded URL: `https://onym.chat/i?k=<base64url(inboxPublicKey)>`. Mirrors the existing `/join?c=…` group-invite App Link convention. The inbox X25519 pubkey is already on `IdentitySummary` — no schema changes.

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:lintDebug` — green (`MissingTranslation` hard gate passes; EN + RU both updated)
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `python3 scripts/lint-secrets.py` — exit 0
- [ ] Visual smoke on emulator: scan generated QR with a phone camera; confirm it opens `https://onym.chat/i?k=…` (the URL doesn't yet route to a real screen — identity-direct-message onboarding is a follow-up — but the QR itself decodes cleanly)
- [ ] Tap Identity hero on Settings root → lands on Identity Detail with full-size QR + Copy/Share buttons working

## Notes

- The full-size QR card is wired with new test tags `identity_detail.invite_qr` / `_copy` / `_share` and the compact hero exposes `settings.invite_qr_hero`, ready for Compose UI tests in a follow-up.
- Identity-direct-message onboarding (someone scans this QR and lands in a one-on-one chat) isn't implemented end-to-end yet; the URL is already correct for that future flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)