### PR TITLE
build: derive versionName/versionCode from the release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
           # processes pointer text and the build dies with "file
           # failed to compile". Same fix as in release.yml.
           lfs: true
+          # Full history so `resolveReleaseVersion()` (in
+          # `app/build.gradle.kts`) can resolve the latest `v*` tag
+          # via `git describe` and the build's `BuildConfig.VERSION_*`
+          # tracks the most recent release. A shallow clone falls back
+          # to `0.0.0-dev`, which still builds but obscures the
+          # version of the artifact CI is testing.
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,13 @@ jobs:
           # true` the binary content is missing and AAPT2 fails with
           # "file failed to compile" on the pointer text.
           lfs: true
+          # Full history + tags so `resolveReleaseVersion()` in
+          # `app/build.gradle.kts` can fall back to `git describe` if
+          # the explicit `RELEASE_VERSION` env below isn't honoured
+          # for some reason. Belt + braces — the env is the canonical
+          # path; this just keeps a working fallback rather than
+          # silently shipping `0.0.0-dev`.
+          fetch-depth: 0
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
@@ -274,6 +281,11 @@ jobs:
         # (no signingConfig is declared on the release buildType, so
         # AGP emits an unsigned APK rather than failing the build).
         #
+        # RELEASE_VERSION pipes the dispatch tag straight into
+        # `resolveReleaseVersion()` in `app/build.gradle.kts`, which
+        # surfaces it as `BuildConfig.VERSION_NAME` (the About screen
+        # reads this directly). Single source of truth = the tag.
+        #
         # RELAYER_AUTH_TOKEN is consumed by `relayerAuthToken()` in
         # `app/build.gradle.kts` and inlined into BuildConfig at
         # compile time; runtime `BearerAuthInterceptor` reads it from
@@ -281,6 +293,7 @@ jobs:
         # — without it, release builds compile and ship but every
         # relayer call 401s with "missing bearer".
         env:
+          RELEASE_VERSION: ${{ inputs.tag }}
           RELAYER_AUTH_TOKEN: ${{ secrets.RELAYER_AUTH_TOKEN }}
         run: ./gradlew :app:assembleRelease --no-daemon
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,8 +19,15 @@ android {
         // path with no compatibility shims.
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.0.1"
+        // Single source of truth: the GitHub release tag. See
+        // `resolveReleaseVersion()` for the resolution order
+        // (release-workflow env → -PreleaseVersion → git describe →
+        // dev fallback). The release tag flows through here into
+        // `BuildConfig.VERSION_NAME` / `VERSION_CODE`, which the
+        // About screen renders directly — no manual bump needed.
+        val releaseVersion = resolveReleaseVersion()
+        versionCode = releaseVersion.code
+        versionName = releaseVersion.name
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -234,4 +241,64 @@ fun relayerAuthToken(): String {
         if (f.exists()) f.inputStream().use { load(it) }
     }
     return props.getProperty("relayer.authToken").orEmpty()
+}
+
+/**
+ * The app's `versionName` + `versionCode`, derived (in this order) from:
+ *
+ *  1. Environment variable `RELEASE_VERSION` — `release.yml` passes
+ *     the dispatch input through here at `assembleRelease`. This is
+ *     the canonical CI path; the explicit override skips git so the
+ *     APK version always matches the release tag exactly, even on a
+ *     shallow clone.
+ *  2. Gradle property `-PreleaseVersion=v0.0.10` — same purpose,
+ *     command-line equivalent. Useful for one-off local "what would
+ *     this look like at v0.0.X" builds.
+ *  3. `git describe --tags --match 'v*'` — local dev between tags
+ *     gets a descriptor like `v0.0.10-3-gca6471b` that's useful in
+ *     bug reports (encodes the last release + commits-since + SHA).
+ *  4. Fallback `v0.0.0-dev` — covers shallow clones with no tags
+ *     fetched, no-git sandboxes, and brand-new repos before the first
+ *     tag.
+ *
+ * `name` strips the leading `v` (Play / About-screen convention).
+ *
+ * `code` is `MAJOR * 10000 + MINOR * 100 + PATCH` parsed from the
+ * resolved name (any `-N-gXXX` dev suffix is ignored). Monotonic
+ * across `v0.x.y` and across the eventual jump to `v0.1.0`. Floors
+ * at 1 so AGP doesn't reject `versionCode = 0` on a brand-new repo.
+ */
+data class ReleaseVersion(val name: String, val code: Int)
+
+fun resolveReleaseVersion(): ReleaseVersion {
+    val raw = System.getenv("RELEASE_VERSION")?.takeIf { it.isNotBlank() }
+        ?: (project.findProperty("releaseVersion") as? String)?.takeIf { it.isNotBlank() }
+        ?: gitDescribeOrNull()
+        ?: "v0.0.0-dev"
+    val name = raw.removePrefix("v")
+    val parts = name.substringBefore('-').split('.')
+    val code = if (parts.size == 3) {
+        val major = parts[0].toIntOrNull() ?: 0
+        val minor = parts[1].toIntOrNull() ?: 0
+        val patch = parts[2].toIntOrNull() ?: 0
+        major * 10000 + minor * 100 + patch
+    } else 0
+    return ReleaseVersion(name = name, code = code.coerceAtLeast(1))
+}
+
+/** `git describe`-derived release identifier, or `null` if no `v*`
+ *  tag is reachable from `HEAD` (or git itself isn't available).
+ *
+ *  Uses `providers.exec` (Gradle 8.5+) rather than a direct
+ *  `ProcessBuilder` so the call is configuration-cache-safe — direct
+ *  subprocesses at configure time are forbidden by the cache. */
+fun gitDescribeOrNull(): String? {
+    val exec = providers.exec {
+        commandLine("git", "describe", "--tags", "--match", "v*", "--abbrev=7")
+        workingDir = rootProject.projectDir
+        isIgnoreExitValue = true
+    }
+    val exit = exec.result.get().exitValue
+    val output = exec.standardOutput.asText.get().trim()
+    return output.takeIf { exit == 0 && it.isNotBlank() }
 }


### PR DESCRIPTION
## Summary

Make the **git tag the single source of truth** for `versionName` / `versionCode`. We cut `v0.0.10` but the APK still reports `0.0.1` and the About screen renders the stale value — this fixes that, permanently.

New `resolveReleaseVersion()` in `app/build.gradle.kts` resolves (in order):

1. ENV `RELEASE_VERSION` — `release.yml` pipes the dispatch input `tag` straight here at `assembleRelease`. Canonical CI path.
2. Gradle `-PreleaseVersion=v0.0.10` — command-line equivalent for one-off local builds.
3. `git describe --tags --match 'v*' --abbrev=7` — local dev between tags renders as `0.0.10-3-gca6471b`, handy in bug reports.
4. Fallback `0.0.0-dev` — shallow clones / no-git sandboxes / fresh repos before the first tag.

`versionCode` is derived as `MAJOR*10000 + MINOR*100 + PATCH` from the same value. Monotonic across `v0.x.y` and across future minor bumps.

## Workflow changes

- **`release.yml`**: pipes `RELEASE_VERSION: ${{ inputs.tag }}` into `assembleRelease`; `fetch-depth: 0` on the build-job checkout (belt + braces fallback).
- **`ci.yml`**: `fetch-depth: 0` on the JVM-tests checkout so `git describe` sees tags. Shallow clones would silently fall back to `0.0.0-dev`.

## Why `providers.exec` instead of `ProcessBuilder`

Direct subprocesses at configure time are forbidden by Gradle's configuration cache (`ConfigurationCacheProblemsException`). `providers.exec` (Gradle 8.5+) is the cache-safe API.

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:lintDebug` — green (`MissingTranslation` hard gate passes)
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `python3 scripts/lint-secrets.py` — exit 0
- [x] **Default path (git describe)** → `package: name='chat.onym.android' versionCode='12' versionName='0.0.12-14-g0f5bb8c'`
- [x] **`RELEASE_VERSION=v0.0.10`** → `versionCode='10' versionName='0.0.10'`
- [x] **`-PreleaseVersion=v0.1.0`** → `versionCode='100' versionName='0.1.0'`

## After merge

The next `gh workflow run Release -f tag=v0.0.13` will produce an APK whose About screen reads "Version 0.0.13 (build 13)" — no manual `versionName` bump in `app/build.gradle.kts` needed (or possible to forget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)