### PR TITLE
ux: edit identity alias inline in the hero

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryTest.kt
@@ -305,6 +305,77 @@ class IdentityRepositoryTest {
         }
     }
 
+    // ─── rename ────────────────────────────────────────────────────
+
+    @Test
+    fun rename_inactiveIdentity_persistsAndEmitsOnIdentities() = runBlocking {
+        repo.bootstrap()
+        val firstId = repo.currentIdentityId.first()!!
+        val secondId = repo.add(name = "Work")
+        // Active is `secondId`; rename the inactive `firstId`.
+        repo.rename(firstId, "Personal")
+
+        val list = repo.identities.first()
+        assertEquals("Personal", list.single { it.id == firstId }.name)
+        assertEquals("Work", list.single { it.id == secondId }.name)
+        // Active selection unchanged.
+        assertEquals(secondId, repo.currentIdentityId.first())
+
+        // Survives a full reload from disk.
+        val freshRepo = IdentityRepository(IdentitySecretStore(
+            ApplicationProvider.getApplicationContext(),
+            prefsFileName,
+        ))
+        freshRepo.bootstrap()
+        val reloaded = freshRepo.identities.first()
+        assertEquals("Personal", reloaded.single { it.id == firstId }.name)
+    }
+
+    @Test
+    fun rename_activeIdentity_updatesSummaryNotIdentity() = runBlocking {
+        val firstId = repo.add(name = "Original")
+        val originalIdentity = repo.snapshots.first()!!
+        repo.rename(firstId, "Renamed")
+
+        // Summary list reflects the new name.
+        val list = repo.identities.first()
+        assertEquals("Renamed", list.single { it.id == firstId }.name)
+
+        // Active Identity (which doesn't carry a name) is unchanged
+        // — same key bytes, no spurious re-derivation.
+        val afterIdentity = repo.snapshots.first()!!
+        assertArrayEquals(originalIdentity.nostrPublicKey, afterIdentity.nostrPublicKey)
+        assertArrayEquals(originalIdentity.blsPublicKey, afterIdentity.blsPublicKey)
+    }
+
+    @Test
+    fun rename_trimsWhitespace() = runBlocking {
+        val id = repo.add(name = "Original")
+        repo.rename(id, "  Padded   ")
+        val list = repo.identities.first()
+        assertEquals("Padded", list.single { it.id == id }.name)
+    }
+
+    @Test
+    fun rename_blankInput_isNoOp() = runBlocking {
+        val id = repo.add(name = "Keep")
+        repo.rename(id, "   ")
+        repo.rename(id, "")
+        val list = repo.identities.first()
+        assertEquals("Keep", list.single { it.id == id }.name)
+    }
+
+    @Test
+    fun rename_unknownId_throws() = runBlocking {
+        repo.bootstrap()
+        try {
+            repo.rename(IdentityId.new(), "Whatever")
+            fail("expected IdentityNotLoaded")
+        } catch (_: IdentityError.IdentityNotLoaded) {
+            // expected
+        }
+    }
+
     @Test
     fun remove_activeIdentity_pivotsToNext() = runBlocking {
         val firstId = repo.add(name = "A")

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
@@ -24,6 +24,9 @@ import kotlinx.coroutines.launch
  *  - [remove] — gated by a typed-name confirm. The repository's
  *    removal listener (registered by `GroupRepository`) cascades a
  *    delete-by-owner over the identity's chats.
+ *  - [rename] — change an identity's display alias. Trimmed-blank
+ *    input is a silent no-op in the repository (matches the iOS
+ *    inline-edit "blur with empty input keeps old name" pattern).
  *
  * Errors raised by the repository surface on [errorMessage]; UI
  * shows them as a Snackbar / inline banner and clears via
@@ -73,6 +76,18 @@ class IdentitiesViewModel(
                 identity.remove(id)
             } catch (e: Throwable) {
                 _errorMessage.value = "Couldn't remove identity: ${e.message ?: e.javaClass.simpleName}"
+            }
+        }
+    }
+
+    /** Rename [id] to [newName]. Trimmed-blank inputs are a silent
+     *  no-op in the repository — UI doesn't need to pre-validate. */
+    fun rename(id: IdentityId, newName: String) {
+        viewModelScope.launch {
+            try {
+                identity.rename(id, newName)
+            } catch (e: Throwable) {
+                _errorMessage.value = "Couldn't rename identity: ${e.message ?: e.javaClass.simpleName}"
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -294,6 +294,31 @@ class IdentityRepository(
         }
     }
 
+    /**
+     * Rename [id] to [newName]. Trims, then a no-op when the trimmed
+     * value is empty (matches the iOS prototype's `name || i.name`
+     * "blank input keeps old name" behaviour) or unchanged from the
+     * current persisted name.
+     *
+     * Callable on any identity, active or inactive. Refreshes the
+     * [identities] summary stream so listeners see the new name; the
+     * active-[snapshots] stream isn't touched because [Identity]
+     * doesn't carry the display name (only [IdentitySummary] does).
+     *
+     * @throws IdentityError.IdentityNotLoaded if [id] doesn't exist
+     *         on this device.
+     */
+    suspend fun rename(id: IdentityId, newName: String) = mutex.withLock {
+        withContext(ioDispatcher) {
+            val trimmed = newName.trim()
+            if (trimmed.isEmpty()) return@withContext
+            val snapshot = store.load(id) ?: throw IdentityError.IdentityNotLoaded
+            if (snapshot.name == trimmed) return@withContext
+            store.save(id, snapshot.copy(name = trimmed))
+            refreshIdentitiesList()
+        }
+    }
+
     /** Recompute [_identities] from disk. Must be called from inside
      *  [mutex] (caller already holds it). */
     private fun refreshIdentitiesList() {

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
@@ -2,6 +2,7 @@ package chat.onym.android.settings
 
 import android.content.Intent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +18,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -39,6 +43,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,13 +51,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import chat.onym.android.R
@@ -159,10 +171,9 @@ fun IdentityDetailScreen(
                             )
                         }
                     }
-                    Text(
-                        text = displayName,
-                        style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                        color = MaterialTheme.colorScheme.onSurface,
+                    EditableIdentityName(
+                        currentName = displayName,
+                        onSave = { newName -> viewModel.rename(identityId, newName) },
                     )
                     Text(
                         text = heroHex(row.summary.blsPublicKey),
@@ -433,6 +444,101 @@ fun IdentityDetailScreen(
     }
 }
 
+
+/**
+ * Tap-to-edit identity alias. Renders [currentName] as a clickable
+ * pill with a small edit pencil; tap → inline [BasicTextField] with
+ * a thin blue border, autofocus, and a 30-char cap. Commits on
+ * `Enter` (`ImeAction.Done`) or focus loss; commit-blank is a
+ * silent no-op handled in `IdentityRepository.rename`.
+ *
+ * The draft state is keyed on [currentName] so an external rename
+ * (e.g. another window of the same screen) re-seeds the field
+ * cleanly on the next recomposition.
+ *
+ * Mirrors the iOS prototype's hero-name edit affordance
+ * (`settings.jsx` lines 840–865).
+ */
+@Composable
+private fun EditableIdentityName(
+    currentName: String,
+    onSave: (String) -> Unit,
+) {
+    var editing by remember { mutableStateOf(false) }
+    var draft by remember(currentName) { mutableStateOf(currentName) }
+    val focusRequester = remember { FocusRequester() }
+
+    val commit: () -> Unit = {
+        // Repository trims + treats blank as no-op; we still gate
+        // here so a blank submit doesn't trip the unchanged-write
+        // path on every blur.
+        val trimmed = draft.trim()
+        if (trimmed.isNotEmpty() && trimmed != currentName) {
+            onSave(trimmed)
+        } else {
+            draft = currentName
+        }
+        editing = false
+    }
+
+    if (editing) {
+        // Defer focus until after the field is composed so the
+        // keyboard pops on the same frame the field appears.
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+        BasicTextField(
+            value = draft,
+            onValueChange = { draft = it.take(MAX_IDENTITY_NAME_LENGTH) },
+            singleLine = true,
+            textStyle = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+            ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { commit() }),
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .onFocusChanged { if (!it.isFocused) commit() }
+                .clip(RoundedCornerShape(8.dp))
+                .border(
+                    width = 1.5.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(8.dp),
+                )
+                .padding(horizontal = 10.dp, vertical = 4.dp)
+                .testTag("identity_detail.name_field"),
+        )
+    } else {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { editing = true }
+                .padding(horizontal = 6.dp, vertical = 2.dp)
+                .testTag("identity_detail.name_edit"),
+        ) {
+            Text(
+                text = currentName,
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Icon(
+                Icons.Filled.Edit,
+                contentDescription = stringResource(R.string.identity_detail_rename_action),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+/** Cap on the editable display alias — matches the iOS prototype's
+ *  `e.target.value.slice(0, 30)`. The repository accepts any length
+ *  but UI rejects further input past the cap. */
+private const val MAX_IDENTITY_NAME_LENGTH = 30
 
 @Composable
 private fun RemoveIdentityDialog(

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -163,6 +163,8 @@
     <!-- ─── Identity detail ──────────────────────────────────────── -->
     <string name="identity_detail_title">Личность</string>
     <string name="identity_detail_active_marker">Активная</string>
+    <!-- Hero name pencil affordance — content description. -->
+    <string name="identity_detail_rename_action">Переименовать личность</string>
     <string name="identity_detail_backup_section">Резервное копирование</string>
     <string name="identity_detail_backup_status_unknown">Сделайте резервную копию фразы восстановления</string>
     <string name="identity_detail_backup_status_subtitle">Без неё восстановить эту личность будет невозможно.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@
     <!-- ─── Identity detail ──────────────────────────────────────── -->
     <string name="identity_detail_title">Identity</string>
     <string name="identity_detail_active_marker">Active</string>
+    <!-- Hero name pencil affordance — content description for the
+         tap-to-edit Row that flips the alias into a BasicTextField. -->
+    <string name="identity_detail_rename_action">Rename identity</string>
     <string name="identity_detail_backup_section">Backup</string>
     <string name="identity_detail_backup_status_unknown">Back up your recovery phrase</string>
     <string name="identity_detail_backup_status_subtitle">Without your phrase you can\'t restore this identity.</string>


### PR DESCRIPTION
## Summary

Adds the missing rename affordance from the iOS handoff design (`settings.jsx` 840–865). Tap the alias in the Identity Detail hero → inline `BasicTextField` with a blue border, autofocus, 30-char cap → commits on Enter or focus loss.

## Layers

- `IdentityRepository.rename(id, newName)` — trims; blank input is a silent no-op (matches the iOS prototype's `name || i.name` behaviour); unchanged values skip the disk write. Refreshes `identities` summary stream; the active `snapshots` stream is untouched because `Identity` doesn't carry the display name.
- `IdentitiesViewModel.rename` — pass-through with the same error-to-snackbar pattern as add/select/remove.
- `IdentityDetailScreen.EditableIdentityName` — clickable pill with pencil glyph when idle; inline `BasicTextField` (autofocus via `FocusRequester`, `ImeAction.Done`, save-on-blur) when editing.

## Tests

Five new `IdentityRepositoryTest` cases:

- `rename_inactiveIdentity_persistsAndEmitsOnIdentities` — happy path + full reload-from-disk
- `rename_activeIdentity_updatesSummaryNotIdentity` — summary list updates; active keypair bytes unchanged
- `rename_trimsWhitespace`
- `rename_blankInput_isNoOp`
- `rename_unknownId_throws` — IdentityNotLoaded, matching the `select` contract

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [x] `./gradlew :app:lintDebug` — green (MissingTranslation hard-gate; EN + RU strings both updated)
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `python3 scripts/lint-secrets.py` — exit 0
- [ ] Manual: open Identity Detail → tap name → type → Enter; reopen → name persists. Repeat with whitespace-only input → original name preserved.
- [ ] `./gradlew :app:connectedDebugAndroidTest --tests *IdentityRepositoryTest*` on emulator (instrumented test additions need a real Keystore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)