### PR TITLE
fix: identity-rename pencil tap was a no-op on first try

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentityDetailScreen.kt
@@ -467,6 +467,15 @@ private fun EditableIdentityName(
     var editing by remember { mutableStateOf(false) }
     var draft by remember(currentName) { mutableStateOf(currentName) }
     val focusRequester = remember { FocusRequester() }
+    // Tracks whether the field has ever held focus this editing
+    // session. Compose fires `onFocusChanged` once with
+    // `isFocused=false` when the field first enters the focus tree
+    // — *before* the `LaunchedEffect` below gets a chance to call
+    // `requestFocus()`. Without this latch the initial Inactive
+    // event would call `commit()` immediately and snap `editing`
+    // back to `false`, making the tap look broken (the field would
+    // appear for one frame and disappear).
+    var hasGainedFocus by remember(editing) { mutableStateOf(false) }
 
     val commit: () -> Unit = {
         // Repository trims + treats blank as no-op; we still gate
@@ -500,7 +509,15 @@ private fun EditableIdentityName(
             keyboardActions = KeyboardActions(onDone = { commit() }),
             modifier = Modifier
                 .focusRequester(focusRequester)
-                .onFocusChanged { if (!it.isFocused) commit() }
+                .onFocusChanged { state ->
+                    if (state.isFocused) {
+                        hasGainedFocus = true
+                    } else if (hasGainedFocus) {
+                        // Real blur — only fires after focus was
+                        // genuinely held at least once.
+                        commit()
+                    }
+                }
                 .clip(RoundedCornerShape(8.dp))
                 .border(
                     width = 1.5.dp,
@@ -511,13 +528,19 @@ private fun EditableIdentityName(
                 .testTag("identity_detail.name_field"),
         )
     } else {
+        // Min 44dp tall tap target (Material's accessible-touch
+        // minimum is 48dp; we sit just under because the headline
+        // glyph itself is ~32dp tall and pushing further breaks the
+        // hero's vertical rhythm). Pre-fix the row was 22dp tall —
+        // small enough that tap misses got blamed on the listener
+        // being broken.
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier
-                .clip(RoundedCornerShape(8.dp))
+                .clip(RoundedCornerShape(10.dp))
                 .clickable { editing = true }
-                .padding(horizontal = 6.dp, vertical = 2.dp)
+                .padding(horizontal = 10.dp, vertical = 6.dp)
                 .testTag("identity_detail.name_edit"),
         ) {
             Text(
@@ -529,7 +552,7 @@ private fun EditableIdentityName(
                 Icons.Filled.Edit,
                 contentDescription = stringResource(R.string.identity_detail_rename_action),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f),
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(20.dp),
             )
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #74. The rename pencil felt unresponsive on the emulator — the `BasicTextField` would appear for one frame and snap back to the idle Row.

**Cause**: when the field enters the focus tree, Compose fires `onFocusChanged` once with `isFocused=false` *before* the `LaunchedEffect` calls `requestFocus()`. The blur handler interpreted that initial Inactive event as "user tapped away" and ran `commit()`, which set `editing=false` and collapsed the field.

**Fix**: gate `commit()` behind a `hasGainedFocus` latch keyed on the `editing` session, so blur only fires after focus was genuinely held at least once. Standard Compose pattern for focus-requested fields.

**Drive-by**: bumped the idle Row tap target from ~22 dp to ~32 dp (icon `size=20.dp`, vertical padding `6.dp`) so misses don't compound the "is the listener broken?" feeling. Material's accessible-touch min is 48 dp; we sit just under because the headline glyph is ~32 dp tall and pushing further breaks the hero's vertical rhythm.

## Test plan

- [x] `./gradlew :app:assembleDebug` — green
- [ ] Emulator: tap the pencil → field appears + keeps focus + keyboard pops; tap outside or hit Done → field collapses back to idle, name persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)