### PR TITLE
fix: three latent instrumented-test failures uncovered by Release run

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/identity/IdentityRepositoryInvitationDecryptTest.kt
@@ -219,13 +219,21 @@ class IdentityRepositoryInvitationDecryptTest {
     @Test
     fun decrypt_afterWipe_throwsIdentityNotLoaded() = runBlocking {
         val identity = repo.snapshots.value!!
+        // Capture the active id BEFORE wipe — `repo.wipe()` clears
+        // the active selection (and the snapshot stream) to null, so
+        // reading `currentIdentityId.value!!` afterwards would NPE
+        // before reaching `decryptInvitation`. The contract under
+        // test is that calling decrypt for a no-longer-present
+        // identity throws `IdentityNotLoaded` — same id, post-wipe
+        // store is what exercises that.
+        val identityId = repo.currentIdentityId.value!!
         val envelope = TestInvitationEncryptor.envelopeBytes(
             payload = "p".toByteArray(),
             recipientX25519Pubkey = identity.inboxPublicKey,
         )
         repo.wipe()
         val thrown = assertThrows(InvitationDecryptError.IdentityNotLoaded::class.java) {
-            runBlocking { repo.decryptInvitation(envelope, asIdentity = repo.currentIdentityId.value!!) }
+            runBlocking { repo.decryptInvitation(envelope, asIdentity = identityId) }
         }
         assertSame(InvitationDecryptError.IdentityNotLoaded, thrown)
         Unit

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/IdentitiesUITest.kt
@@ -1,9 +1,11 @@
 package chat.onym.android.uitests
 
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -157,9 +159,17 @@ class IdentitiesUITest {
         // confirm → Delete.
         val secondId = identityStore.listIds()[1]
         composeRule.onNodeWithTag("identities.row.${secondId.value}").performClick()
+        // Wait for IdentityDetailScreen's LazyColumn to mount, then
+        // scroll into it to materialise the Delete row's semantics.
+        // After the QR-hero PR, the screen's first viewport ends
+        // around the BACKUP card — Delete sits below the fold and
+        // never enters the semantic tree until scrolled into view,
+        // so a `waitUntil(... delete in tree)` would time out.
         composeRule.waitUntil(timeoutMillis = 5.seconds.inWholeMilliseconds) {
-            composeRule.onAllNodesWithTag("identity_detail.delete").fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag("identity_detail.list").fetchSemanticsNodes().isNotEmpty()
         }
+        composeRule.onNodeWithTag("identity_detail.list")
+            .performScrollToNode(hasTestTag("identity_detail.delete"))
         composeRule.onNodeWithTag("identity_detail.delete").performClick()
 
         // Type the expected name; tap Delete.

--- a/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/AnchorsScreenObjects.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/uitests/screens/AnchorsScreenObjects.kt
@@ -2,10 +2,12 @@ package chat.onym.android.uitests.screens
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 
 /**
  * Page object for the Anchors drill-down. Three layers:
@@ -41,7 +43,17 @@ class AnchorsScreenObjects(private val rule: ComposeContentTestRule) {
     }
 
     fun tapReset(): AnchorsScreenObjects {
-        resetRow().performScrollTo().performClick()
+        // The reset row sits at the bottom of `AnchorsVersionScreen`,
+        // past the releases list, the custom-action rows, and the
+        // section header. On a CI emulator the row is below the
+        // initial viewport and the LazyColumn never realises its
+        // semantics, so a plain `performScrollTo()` (which only
+        // scrolls when the node is already in the tree) fails with
+        // "could not find any node". Scroll the parent list to the
+        // matcher first so the row materialises.
+        rule.onNodeWithTag("anchors.version.list")
+            .performScrollToNode(hasTestTag("anchors.version.reset"))
+        resetRow().performClick()
         return this
     }
 

--- a/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/AnchorsScreen.kt
@@ -163,7 +163,14 @@ fun AnchorsVersionScreen(
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) { padding ->
-        LazyColumn(contentPadding = padding) {
+        // testTag lets instrumented tests scroll into the list to
+        // reach off-screen rows (Reset is at the bottom and may not
+        // be in the semantic tree on a CI emulator until scrolled
+        // into view).
+        LazyColumn(
+            contentPadding = padding,
+            modifier = Modifier.testTag("anchors.version.list"),
+        ) {
             item { SectionHeader(stringResource(R.string.anchors_section_releases)) }
             items(rows, key = { it.release.release }) { row ->
                 VersionRow(


### PR DESCRIPTION
## Summary

Release run [#25282881740](https://github.com/onymchat/onym-android/actions/runs/25282881740/job/74122782194) — the first Release dispatched after the QR-hero merge cycle — failed three instrumented tests. The CI-on-PR workflow only runs JVM units, so these had been latent on `main` for a few PRs. All three are real bugs; fixing in place rather than disabling.

## 1. `IdentityRepositoryInvitationDecryptTest.decrypt_afterWipe_throwsIdentityNotLoaded`

```
expected:<IdentityNotLoaded> but was:<java.lang.NullPointerException>
```

Test reads `repo.currentIdentityId.value!!` *after* `repo.wipe()` clears it to null. The `!!` NPEs before `decryptInvitation` runs.

**Fix**: capture the active id before wipe and pass it through. The contract under test ("decrypt against no-longer-present identity throws IdentityNotLoaded") is exactly what same-id-against-post-wipe-store exercises.

## 2. `IdentitiesUITest.removeIdentity_typedConfirm_deletesFromStore`

```
ComposeTimeoutException: Condition still not satisfied after 5000 ms
```

After #71 added the INVITE-KEY QR card to `IdentityDetailScreen`, the screen grew tall enough that the Delete row sits below the initial viewport on the CI emulator. LazyColumn doesn't materialise off-screen items, so the test's `waitUntil(... delete in semantic tree)` never fired.

**Fix**: wait for the LazyColumn (`identity_detail.list`) to mount, then `performScrollToNode` on the list to bring the Delete row into view.

## 3. `AnchorsUITest.resetToDefault_clearsExplicitPick`

```
performScrollTo() failed: could not find any node that satisfies:
  (TestTag = 'anchors.version.reset')
```

Same root cause as #2: the Reset row at the bottom of `AnchorsVersionScreen` is below the fold on the CI emulator. `performScrollTo()` only scrolls when the node is *already* in the semantic tree.

**Fix**: tag the `AnchorsVersionScreen` LazyColumn (`anchors.version.list`) and update `AnchorsScreenObjects.tapReset` to `performScrollToNode` on the parent list before clicking.

## Test plan

- [x] `./gradlew :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug :app:testDebugUnitTest` — green
- [x] `python3 scripts/lint-secrets.py` — exit 0
- [ ] Re-dispatch Release (or run `./gradlew :app:connectedDebugAndroidTest` against a local emulator) and confirm all three tests pass

## Follow-up worth considering

The CI-on-PR workflow only runs JVM unit tests; instrumented failures don't surface until a Release. We could add an emulator job to `ci.yml` so PRs catch this earlier — wall time would jump from ~3 min to ~12-15 min per PR. Tradeoff isn't free; flagging here rather than slipping in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)