### PR TITLE
i18n: localize Create Group + Join + Share Invite flows (en + ru)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupViewModel.kt
@@ -103,21 +103,23 @@ data class CreateGroupState(
     val effectiveName: String
         get() = name.trim().ifEmpty { generatedName }
 
-    /** Label for the primary "Create" CTA on Step2. Per-governance:
+    /** Structured label for the primary "Create" CTA on Step2.
+     *  Compose maps each variant to its [androidx.compose.ui.res.stringResource]
+     *  via `createCtaLabelRes`. Per-governance:
      *  - Tyranny tolerates 0..N invitees ("Create empty group" / "with N").
      *  - 1-on-1 needs exactly 1 invitee — the CTA spells out the gate
      *    so the user understands why it's disabled. */
-    val createCtaLabel: String
+    val createCtaLabel: CreateCtaLabel
         get() = when (governance) {
             OnymUIGovernance.OneOnOne -> when (invitees.size) {
-                0 -> "Add the other person"
-                1 -> "Start 1-on-1"
-                else -> "1-on-1 needs exactly one"
+                0 -> CreateCtaLabel.OneOnOneAddOther
+                1 -> CreateCtaLabel.OneOnOneStart
+                else -> CreateCtaLabel.OneOnOneTooMany
             }
             else -> when (invitees.size) {
-                0 -> "Create empty group"
-                1 -> "Create with 1 person"
-                else -> "Create with ${invitees.size} people"
+                0 -> CreateCtaLabel.Empty
+                1 -> CreateCtaLabel.OnePerson
+                else -> CreateCtaLabel.NPeople(invitees.size)
             }
         }
 
@@ -434,36 +436,20 @@ class CreateGroupViewModel(
 
 /**
  * UI-side mirror of the design's three governance cards. Maps to
- * [SepGroupType] for the actual chain call. PR-C only enables
- * [Tyranny] — the other two render with a "Soon" pill and aren't
- * selectable.
+ * [SepGroupType] for the actual chain call. All three flavours are
+ * wired post-Anarchy — `isAvailable` returns true for every entry.
+ *
+ * Display strings (card label, sub-line, tooltip, Step-2 hint) live
+ * in the `res/values*` localized `strings.xml` files and are resolved
+ * by Compose via `stringResource(governance.cardLabelRes())` etc. —
+ * see `CreateGroupScreen.kt`.
  *
  * Mirrors `OnymUIGovernance` from onym-ios PR #26.
  */
-enum class OnymUIGovernance(
-    val label: String,
-    val sub: String,
-    val oneLine: String,
-    val tooltip: String,
-) {
-    Tyranny(
-        label = "Tyranny",
-        sub = "Single admin",
-        oneLine = "You control membership and settings.",
-        tooltip = "Only the admin can manage this group.",
-    ),
-    OneOnOne(
-        label = "1‑1on‑1",
-        sub = "Dialog",
-        oneLine = "A private two-person conversation.",
-        tooltip = "Exactly two people. No one else can join.",
-    ),
-    Anarchy(
-        label = "Anarchy",
-        sub = "Open control",
-        oneLine = "Every member has the same control.",
-        tooltip = "Anyone can add, remove, or change settings.",
-    ),
+enum class OnymUIGovernance {
+    Tyranny,
+    OneOnOne,
+    Anarchy,
     ;
 
     /** All three governance flavours are wired to the chain layer:
@@ -471,17 +457,6 @@ enum class OnymUIGovernance(
      *  Anarchy (#50/51/this-PR stack). Future flavours
      *  (Democracy, Oligarchy) flip on as they wire. */
     val isAvailable: Boolean get() = true
-
-    /** One-line addendum rendered in the Step-2 banner under the
-     *  governance label. Type-specific because the implications
-     *  differ — Tyranny mentions the admin role, 1-on-1 mentions the
-     *  exact-one-invitee constraint. */
-    val step2Hint: String
-        get() = when (this) {
-            Tyranny -> "You'll be the only admin."
-            OneOnOne -> "Pick exactly one person."
-            Anarchy -> "Everyone shares control."
-        }
 
     val sepGroupType: SepGroupType
         get() = when (this) {
@@ -498,6 +473,25 @@ enum class OnymUIGovernance(
             OneOnOne -> chat.onym.android.chain.GovernanceType.OneOnOne
             Anarchy -> chat.onym.android.chain.GovernanceType.Anarchy
         }
+}
+
+/**
+ * Structured label for the Step-2 primary "Create" CTA. Compose
+ * resolves to a `stringResource` so the visible text honours the
+ * device locale; tests assert on the variant identity directly. */
+sealed class CreateCtaLabel {
+    /** Tyranny / Anarchy / default — zero invitees. */
+    data object Empty : CreateCtaLabel()
+    /** Tyranny / Anarchy / default — one invitee. */
+    data object OnePerson : CreateCtaLabel()
+    /** Tyranny / Anarchy / default — two or more invitees. */
+    data class NPeople(val count: Int) : CreateCtaLabel()
+    /** 1-on-1 with no invitee — needs exactly one. */
+    data object OneOnOneAddOther : CreateCtaLabel()
+    /** 1-on-1 with one invitee — ready to start. */
+    data object OneOnOneStart : CreateCtaLabel()
+    /** 1-on-1 with more than one invitee — over-quota. */
+    data object OneOnOneTooMany : CreateCtaLabel()
 }
 
 private val WHITESPACE_REGEX = Regex("\\s+")

--- a/app/src/main/kotlin/chat/onym/android/group/JoinScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinScreen.kt
@@ -32,10 +32,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
 
 /**
  * Joiner-side post-deeplink screen. The user lands here after tapping
@@ -68,10 +70,13 @@ fun JoinScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Join chat") },
+                title = { Text(stringResource(R.string.join_screen_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
                     }
                 },
             )
@@ -86,14 +91,18 @@ fun JoinScreen(
         ) {
             Spacer(Modifier.height(24.dp))
             Text(
-                text = viewModel.capability.groupName ?: "Invite to join a chat",
+                text = viewModel.capability.groupName
+                    ?: stringResource(R.string.join_invite_fallback_title),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.Center,
             )
             Spacer(Modifier.height(6.dp))
             Text(
-                text = "from ${viewModel.capability.introPublicKey.toShortFingerprint()}",
+                text = stringResource(
+                    R.string.join_invite_from,
+                    viewModel.capability.introPublicKey.toShortFingerprint(),
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -105,7 +114,7 @@ fun JoinScreen(
                     OutlinedTextField(
                         value = displayLabel,
                         onValueChange = { displayLabel = it.take(64) },
-                        label = { Text("How should the inviter see you?") },
+                        label = { Text(stringResource(R.string.join_label_field_label)) },
                         singleLine = true,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -113,8 +122,7 @@ fun JoinScreen(
                     )
                     Spacer(Modifier.height(6.dp))
                     Text(
-                        text = "The inviter sees this name in their approval prompt. " +
-                            "They can decline if it doesn't match what they expect.",
+                        text = stringResource(R.string.join_label_field_helper),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -140,7 +148,12 @@ fun JoinScreen(
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.size(8.dp))
-                        Text(if (s is JoinViewModel.State.Failed) "Try again" else "Send join request")
+                        Text(
+                            stringResource(
+                                if (s is JoinViewModel.State.Failed) R.string.try_again
+                                else R.string.join_send_request,
+                            ),
+                        )
                     }
                 }
 
@@ -156,7 +169,10 @@ fun JoinScreen(
                         )
                     }
                     Spacer(Modifier.height(12.dp))
-                    Text("Sending request…", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        text = stringResource(R.string.join_sending_request),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
                 }
 
                 is JoinViewModel.State.AwaitingApproval -> {
@@ -172,15 +188,13 @@ fun JoinScreen(
                         )
                         Spacer(Modifier.height(8.dp))
                         Text(
-                            text = "Waiting for approval",
+                            text = stringResource(R.string.join_awaiting_title),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                         )
                         Spacer(Modifier.height(4.dp))
                         Text(
-                            text = "You'll see this chat appear in your list as soon as " +
-                                "the inviter taps Approve. You can close this screen — " +
-                                "we'll add it to Chats automatically.",
+                            text = stringResource(R.string.join_awaiting_body),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center,
@@ -190,7 +204,7 @@ fun JoinScreen(
                             onClick = onBackClick,
                             modifier = Modifier.fillMaxWidth(),
                         ) {
-                            Text("Back to chats")
+                            Text(stringResource(R.string.join_back_to_chats))
                         }
                     }
                 }
@@ -208,13 +222,13 @@ fun JoinScreen(
                         )
                         Spacer(Modifier.height(8.dp))
                         Text(
-                            text = "Joined!",
+                            text = stringResource(R.string.join_approved_title),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                         )
                         Spacer(Modifier.height(4.dp))
                         Text(
-                            text = "You're a member of ${s.group.name}.",
+                            text = stringResource(R.string.join_approved_body, s.group.name),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -223,7 +237,7 @@ fun JoinScreen(
                             onClick = { onOpenChat(s.group) },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
-                            Text("Open chat")
+                            Text(stringResource(R.string.join_open_chat))
                         }
                     }
                 }

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +42,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
+import chat.onym.android.group.CreateCtaLabel
 import chat.onym.android.group.CreateGroupProgress
 import chat.onym.android.group.CreateGroupRoute
 import chat.onym.android.group.CreateGroupViewModel
@@ -92,7 +96,10 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
-        OnymNavTitle(title = "New Group", subtitle = "Step 1 of 2")
+        OnymNavTitle(
+            title = stringResource(R.string.create_group_step1_title),
+            subtitle = stringResource(R.string.create_group_step1_subtitle),
+        )
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -110,6 +117,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
             // `nameFieldFocused()`; the empty placeholder text below
             // shows the same generated name dimmed so the user
             // remembers what would be submitted.
+            val namePlaceholder = stringResource(R.string.create_group_name_placeholder)
             OnymCard {
                 BasicTextField(
                     value = state.name,
@@ -124,7 +132,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                         Box(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)) {
                             if (state.name.isEmpty()) {
                                 Text(
-                                    text = state.generatedName.ifEmpty { "Group name" },
+                                    text = state.generatedName.ifEmpty { namePlaceholder },
                                     color = LocalOnymTokens.current.text3,
                                     style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.Medium),
                                 )
@@ -140,7 +148,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                 )
             }
             Text(
-                text = "Visible to members. You can change this anytime.",
+                text = stringResource(R.string.create_group_name_helper),
                 color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 11.5.sp),
                 modifier = Modifier
@@ -148,7 +156,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                     .padding(start = 4.dp, top = 6.dp),
             )
 
-            OnymSectionLabel("Accent color")
+            OnymSectionLabel(stringResource(R.string.create_group_accent_color))
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -180,7 +188,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                 }
             }
 
-            OnymSectionLabel("How it’s run")
+            OnymSectionLabel(stringResource(R.string.create_group_how_its_run))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -217,7 +225,8 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                     )
                     Column {
                         Text(
-                            text = "${state.governance.sub}. ${state.governance.tooltip}",
+                            text = "${stringResource(state.governance.subRes())}. " +
+                                stringResource(state.governance.tooltipRes()),
                             color = LocalOnymTokens.current.text2,
                             style = TextStyle(fontSize = 13.sp, lineHeight = 18.sp),
                         )
@@ -238,7 +247,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                         style = TextStyle(fontSize = 14.sp),
                     )
                     Text(
-                        text = "End-to-end encrypted · published on Stellar so anyone can verify it’s real.",
+                        text = stringResource(R.string.create_group_encrypted_footer),
                         color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                     )
@@ -254,13 +263,16 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                 // type is wired (Tyranny only in PR-C); name has a
                 // random placeholder default so there's no "fill in
                 // the blank" gating step.
-                title = "Next · Add people",
+                title = stringResource(R.string.create_group_next),
                 accent = accent,
                 enabled = state.canAdvanceToStep2,
                 onClick = viewModel::tappedNext,
             )
             Spacer(Modifier.height(4.dp))
-            OnymQuietButton(title = "Cancel", onClick = viewModel.onClose)
+            OnymQuietButton(
+                title = stringResource(R.string.cancel),
+                onClick = viewModel.onClose,
+            )
         }
     }
 }
@@ -301,7 +313,7 @@ private fun GovernanceCard(
             )
             if (!available) {
                 Text(
-                    text = "Soon",
+                    text = stringResource(R.string.create_group_soon_badge),
                     color = LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 9.sp, fontWeight = FontWeight.SemiBold, letterSpacing = 0.5.sp),
                     modifier = Modifier
@@ -313,12 +325,12 @@ private fun GovernanceCard(
         }
         Spacer(Modifier.height(8.dp))
         Text(
-            text = type.label,
+            text = stringResource(type.cardLabelRes()),
             color = labelColor,
             style = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-0.13).sp),
         )
         Text(
-            text = type.sub,
+            text = stringResource(type.subRes()),
             color = LocalOnymTokens.current.text2,
             style = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium),
         )
@@ -332,7 +344,10 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
-        OnymNavTitle(title = "Add People", subtitle = "Step 2 of 2")
+        OnymNavTitle(
+            title = stringResource(R.string.create_group_step2_title),
+            subtitle = stringResource(R.string.create_group_step2_subtitle),
+        )
         Column(
             modifier = Modifier
                 .weight(1f)
@@ -356,7 +371,8 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                 ) {
                     OnymGovIcon(type = state.governance, accent = accent, size = 28.dp)
                     Text(
-                        text = "${state.governance.label}. ${state.governance.step2Hint}",
+                        text = "${stringResource(state.governance.cardLabelRes())}. " +
+                            stringResource(state.governance.step2HintRes()),
                         color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp, lineHeight = 17.sp),
                         modifier = Modifier.weight(1f),
@@ -384,13 +400,13 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                 ) {
                     Spacer(Modifier.height(28.dp))
                     Text(
-                        text = "No invitees yet",
+                        text = stringResource(R.string.create_group_no_invitees_title),
                         color = LocalOnymTokens.current.text,
                         style = TextStyle(fontSize = 15.sp, fontWeight = FontWeight.SemiBold),
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "Use “Invite by inbox key” below to add someone.",
+                        text = stringResource(R.string.create_group_no_invitees_body),
                         color = LocalOnymTokens.current.text2,
                         style = TextStyle(fontSize = 12.5.sp),
                         textAlign = TextAlign.Center,
@@ -431,12 +447,15 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                                 }
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        text = "Inbox ${invitee.displayLabel}",
+                                        text = stringResource(
+                                            R.string.create_group_invitee_inbox_label,
+                                            invitee.displayLabel,
+                                        ),
                                         color = LocalOnymTokens.current.text,
                                         style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
                                     )
                                     Text(
-                                        text = "Direct inbox key",
+                                        text = stringResource(R.string.create_group_invitee_inbox_subtitle),
                                         color = LocalOnymTokens.current.text2,
                                         style = TextStyle(fontSize = 12.sp),
                                     )
@@ -487,12 +506,12 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
                     }
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = "Invite by inbox key",
+                            text = stringResource(R.string.create_group_invite_by_key_row_title),
                             color = LocalOnymTokens.current.text,
                             style = TextStyle(fontSize = 13.5.sp, fontWeight = FontWeight.SemiBold),
                         )
                         Text(
-                            text = "Paste a 64-char key",
+                            text = stringResource(R.string.create_group_invite_by_key_row_subtitle),
                             color = LocalOnymTokens.current.text2,
                             style = TextStyle(fontSize = 11.5.sp),
                         )
@@ -506,12 +525,15 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
             }
             Spacer(Modifier.height(10.dp))
             OnymPrimaryButton(
-                title = state.createCtaLabel,
+                title = state.createCtaLabel.resolved(),
                 accent = accent,
                 enabled = state.canSubmit,
                 onClick = viewModel::tappedCreate,
             )
-            OnymQuietButton(title = "Back", onClick = viewModel::tappedBackFromStep2)
+            OnymQuietButton(
+                title = stringResource(R.string.back),
+                onClick = viewModel::tappedBackFromStep2,
+            )
         }
     }
 }
@@ -523,9 +545,15 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val accent = state.accent.color()
     Column(modifier = Modifier.fillMaxSize()) {
+        val groupLabel = state.name.ifEmpty {
+            stringResource(R.string.create_group_invite_by_key_default_group_label)
+        }
         OnymNavTitle(
-            title = "Invite by Inbox Key",
-            subtitle = "For ${if (state.name.isEmpty()) "group" else state.name}",
+            title = stringResource(R.string.create_group_invite_by_key_screen_title),
+            subtitle = stringResource(
+                R.string.create_group_invite_by_key_for_subtitle,
+                groupLabel,
+            ),
         )
         Column(
             modifier = Modifier
@@ -548,7 +576,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
                         Box(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)) {
                             if (state.inviteeInput.isEmpty()) {
                                 Text(
-                                    text = "Paste a 64-character hex key…",
+                                    text = stringResource(R.string.create_group_invite_by_key_placeholder),
                                     color = LocalOnymTokens.current.text3,
                                     style = TextStyle(fontSize = 14.sp),
                                 )
@@ -565,7 +593,10 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "(${state.inviteeInputCleanedLength}/64)",
+                    text = stringResource(
+                        R.string.create_group_invite_by_key_count,
+                        state.inviteeInputCleanedLength,
+                    ),
                     color = if (state.inviteeInputIsValid) accent else LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 11.5.sp, fontWeight = FontWeight.SemiBold),
                 )
@@ -579,7 +610,7 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
             }
             Spacer(Modifier.height(20.dp))
             Text(
-                text = "The recipient generates this key on their own device. They can find it in Settings → Identity → Inbox Key.",
+                text = stringResource(R.string.create_group_invite_by_key_helper),
                 color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
             )
@@ -587,12 +618,15 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
 
         FlowFooter {
             OnymPrimaryButton(
-                title = "Add invitee",
+                title = stringResource(R.string.create_group_invite_by_key_add),
                 accent = accent,
                 enabled = state.inviteeInputIsValid,
                 onClick = viewModel::tappedAddInvitee,
             )
-            OnymQuietButton(title = "Cancel", onClick = viewModel::tappedCancelInviteByKey)
+            OnymQuietButton(
+                title = stringResource(R.string.cancel),
+                onClick = viewModel::tappedCancelInviteByKey,
+            )
         }
     }
 }
@@ -610,8 +644,11 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(Modifier.height(20.dp))
+        val creatingName = state.name.ifEmpty {
+            stringResource(R.string.create_group_creating_default_name)
+        }
         Text(
-            text = "Creating ${state.name.ifEmpty { "Group" }}",
+            text = stringResource(R.string.create_group_creating_title, creatingName),
             color = LocalOnymTokens.current.text,
             style = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.SemiBold),
         )
@@ -621,7 +658,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
 
         OnymCard {
             Column {
-                val steps = creatingSteps(state.invitees.size)
+                val steps = creatingStepsLabels(state.invitees.size)
                 steps.forEachIndexed { index, step ->
                     if (index > 0) {
                         Box(
@@ -655,6 +692,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                     // readability; SelectionContainer lets the user
                     // long-press to copy into a bug report.
                     // Mirrors onym-ios PR #29.
+                    val fallbackError = stringResource(R.string.create_group_error_fallback)
                     SelectionContainer(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -662,7 +700,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                             .verticalScroll(rememberScrollState()),
                     ) {
                         Text(
-                            text = state.error?.message ?: "Couldn't create the group",
+                            text = state.error?.message ?: fallbackError,
                             color = LocalOnymTokens.current.red,
                             style = TextStyle(
                                 fontSize = 12.sp,
@@ -686,7 +724,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                                 .padding(horizontal = 18.dp, vertical = 8.dp),
                         ) {
                             Text(
-                                text = "Cancel",
+                                text = stringResource(R.string.cancel),
                                 color = LocalOnymTokens.current.text2,
                                 style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
                             )
@@ -699,7 +737,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
                                 .padding(horizontal = 18.dp, vertical = 8.dp),
                         ) {
                             Text(
-                                text = "Try again",
+                                text = stringResource(R.string.try_again),
                                 color = accent,
                                 style = TextStyle(fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold),
                             )
@@ -710,7 +748,7 @@ private fun CreatingScreen(viewModel: CreateGroupViewModel) {
         } else {
             Spacer(Modifier.height(14.dp))
             Text(
-                text = "This usually takes a few seconds. It’s safe to close this — we’ll finish in the background.",
+                text = stringResource(R.string.create_group_helpful_note),
                 color = LocalOnymTokens.current.text3,
                 style = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
                 textAlign = TextAlign.Center,
@@ -743,13 +781,24 @@ private fun stepStatus(
     }
 }
 
-private fun creatingSteps(inviteeCount: Int): List<Pair<String, String>> = buildList {
-    add("Setting up encrypted group" to "Generating keys on your device")
-    add("Setting up your admin keys" to "You’ll be the only admin")
-    repeat(inviteeCount) { i ->
-        add("Sending invitation #${i + 1}" to "Encrypted, end-to-end")
+@Composable
+private fun creatingStepsLabels(inviteeCount: Int): List<Pair<String, String>> {
+    val setup = stringResource(R.string.create_group_step_setup) to
+        stringResource(R.string.create_group_step_setup_sub)
+    val admin = stringResource(R.string.create_group_step_admin) to
+        stringResource(R.string.create_group_step_admin_sub)
+    val invitationSub = stringResource(R.string.create_group_step_invitation_sub)
+    val invitations = (1..inviteeCount).map { n ->
+        stringResource(R.string.create_group_step_invitation, n) to invitationSub
     }
-    add("Anchoring on Stellar" to "So anyone can verify this group is real")
+    val anchor = stringResource(R.string.create_group_step_anchor) to
+        stringResource(R.string.create_group_step_anchor_sub)
+    return buildList {
+        add(setup)
+        add(admin)
+        addAll(invitations)
+        add(anchor)
+    }
 }
 
 @Composable
@@ -831,7 +880,7 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
         )
         Spacer(Modifier.height(6.dp))
         Text(
-            text = "Anchored on Stellar testnet",
+            text = stringResource(R.string.create_group_anchored_testnet),
             color = LocalOnymTokens.current.text2,
             style = TextStyle(fontSize = 13.sp),
         )
@@ -840,20 +889,28 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
         OnymCard {
             Column(modifier = Modifier.padding(14.dp)) {
                 Text(
-                    text = "Members",
+                    text = stringResource(R.string.create_group_members_section),
                     color = LocalOnymTokens.current.text3,
                     style = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.SemiBold, letterSpacing = 0.88.sp),
                 )
                 Spacer(Modifier.height(8.dp))
+                val memberCount = group?.members?.size ?: 1
                 Text(
-                    text = "${(group?.members?.size ?: 1)} member" + if ((group?.members?.size ?: 1) == 1) "" else "s",
+                    text = pluralStringResource(
+                        R.plurals.create_group_members_count,
+                        memberCount,
+                        memberCount,
+                    ),
                     color = LocalOnymTokens.current.text,
                     style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
                 )
                 Spacer(Modifier.height(2.dp))
                 Text(
-                    text = "${state.invitees.size} invitation" +
-                        (if (state.invitees.size == 1) "" else "s") + " sent",
+                    text = pluralStringResource(
+                        R.plurals.create_group_invitations_sent,
+                        state.invitees.size,
+                        state.invitees.size,
+                    ),
                     color = LocalOnymTokens.current.text2,
                     style = TextStyle(fontSize = 12.5.sp),
                 )
@@ -863,17 +920,57 @@ private fun SuccessScreen(viewModel: CreateGroupViewModel) {
         Spacer(Modifier.weight(1f))
         FlowFooter {
             OnymPrimaryButton(
-                title = "Share invite link",
+                title = stringResource(R.string.share_invite_link_chooser),
                 accent = accent,
                 onClick = viewModel::tappedShareInvite,
             )
             Spacer(Modifier.height(6.dp))
             OnymQuietButton(
-                title = "Done",
+                title = stringResource(R.string.done),
                 onClick = viewModel::tappedDone,
             )
         }
     }
+}
+
+// ─── Localized resource lookups for governance + CTA enums ──────
+
+@androidx.annotation.StringRes
+private fun OnymUIGovernance.cardLabelRes(): Int = when (this) {
+    OnymUIGovernance.Tyranny -> R.string.governance_tyranny_card_label
+    OnymUIGovernance.OneOnOne -> R.string.governance_oneonone_card_label
+    OnymUIGovernance.Anarchy -> R.string.governance_anarchy_card_label
+}
+
+@androidx.annotation.StringRes
+private fun OnymUIGovernance.subRes(): Int = when (this) {
+    OnymUIGovernance.Tyranny -> R.string.governance_tyranny_sub
+    OnymUIGovernance.OneOnOne -> R.string.governance_oneonone_sub
+    OnymUIGovernance.Anarchy -> R.string.governance_anarchy_sub
+}
+
+@androidx.annotation.StringRes
+private fun OnymUIGovernance.tooltipRes(): Int = when (this) {
+    OnymUIGovernance.Tyranny -> R.string.governance_tyranny_tooltip
+    OnymUIGovernance.OneOnOne -> R.string.governance_oneonone_tooltip
+    OnymUIGovernance.Anarchy -> R.string.governance_anarchy_tooltip
+}
+
+@androidx.annotation.StringRes
+private fun OnymUIGovernance.step2HintRes(): Int = when (this) {
+    OnymUIGovernance.Tyranny -> R.string.governance_tyranny_step2hint
+    OnymUIGovernance.OneOnOne -> R.string.governance_oneonone_step2hint
+    OnymUIGovernance.Anarchy -> R.string.governance_anarchy_step2hint
+}
+
+@Composable
+private fun CreateCtaLabel.resolved(): String = when (this) {
+    CreateCtaLabel.Empty -> stringResource(R.string.create_group_cta_empty)
+    CreateCtaLabel.OnePerson -> stringResource(R.string.create_group_cta_one_person)
+    is CreateCtaLabel.NPeople -> stringResource(R.string.create_group_cta_n_people, count)
+    CreateCtaLabel.OneOnOneAddOther -> stringResource(R.string.create_group_cta_oneonone_add)
+    CreateCtaLabel.OneOnOneStart -> stringResource(R.string.create_group_cta_oneonone_start)
+    CreateCtaLabel.OneOnOneTooMany -> stringResource(R.string.create_group_cta_oneonone_too_many)
 }
 
 // ─── Sticky-bottom footer wrapper ───────────────────────────────

--- a/app/src/main/kotlin/chat/onym/android/group/creategroup/ShareInviteScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/creategroup/ShareInviteScreen.kt
@@ -35,10 +35,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
 import chat.onym.android.group.IntroCapability
 import chat.onym.android.group.ShareInviteViewModel
 
@@ -70,9 +72,9 @@ fun ShareInviteScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Invite") },
+                title = { Text(stringResource(R.string.share_invite_title)) },
                 actions = {
-                    TextButton(onClick = onDone) { Text("Done") }
+                    TextButton(onClick = onDone) { Text(stringResource(R.string.done)) }
                 },
             )
         },
@@ -93,14 +95,13 @@ fun ShareInviteScreen(
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "Your group is ready",
+                text = stringResource(R.string.share_invite_hero_title),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
             )
             Spacer(Modifier.height(4.dp))
             Text(
-                text = "Share this link with the people you want to invite. " +
-                    "You'll see and approve each request before they join.",
+                text = stringResource(R.string.share_invite_hero_body),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -118,6 +119,8 @@ fun ShareInviteScreen(
                 }
 
                 is ShareInviteViewModel.State.Ready -> {
+                    val chooserTitle = stringResource(R.string.share_invite_link_chooser)
+                    val clipboardLabel = stringResource(R.string.share_invite_clipboard_label)
                     Button(
                         onClick = {
                             val sendIntent = Intent().apply {
@@ -129,7 +132,7 @@ fun ShareInviteScreen(
                                 type = "text/plain"
                             }
                             context.startActivity(
-                                Intent.createChooser(sendIntent, "Share invite link"),
+                                Intent.createChooser(sendIntent, chooserTitle),
                             )
                         },
                         modifier = Modifier
@@ -142,32 +145,39 @@ fun ShareInviteScreen(
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.size(8.dp))
-                        Text("Share invite link")
+                        Text(stringResource(R.string.share_invite_link_chooser))
                     }
                     Spacer(Modifier.height(12.dp))
                     OutlinedButton(
                         onClick = {
                             val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
                                 as ClipboardManager
-                            clipboard.setPrimaryClip(ClipData.newPlainText("Invite link", s.link))
+                            clipboard.setPrimaryClip(ClipData.newPlainText(clipboardLabel, s.link))
                             copied = true
                         },
                         modifier = Modifier
                             .fillMaxWidth()
                             .testTag("share_invite.copy_button"),
                     ) {
-                        Text(if (copied) "Copied!" else "Copy invite link")
+                        Text(
+                            stringResource(
+                                if (copied) R.string.share_invite_copied
+                                else R.string.share_invite_copy,
+                            ),
+                        )
                     }
                 }
 
                 is ShareInviteViewModel.State.Failed -> {
                     Text(
-                        text = "Couldn't generate an invite: ${s.reason}",
+                        text = stringResource(R.string.share_invite_failed, s.reason),
                         color = MaterialTheme.colorScheme.error,
                         textAlign = TextAlign.Center,
                     )
                     Spacer(Modifier.height(12.dp))
-                    Button(onClick = { viewModel.mintFor(groupId) }) { Text("Retry") }
+                    Button(onClick = { viewModel.mintFor(groupId) }) {
+                        Text(stringResource(R.string.retry))
+                    }
                 }
             }
 
@@ -175,7 +185,7 @@ fun ShareInviteScreen(
 
             TextButton(onClick = onDone) {
                 Text(
-                    "I'll do this later",
+                    stringResource(R.string.share_invite_skip),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentitiesViewModel.kt
@@ -28,9 +28,9 @@ import kotlinx.coroutines.launch
  *    input is a silent no-op in the repository (matches the iOS
  *    inline-edit "blur with empty input keeps old name" pattern).
  *
- * Errors raised by the repository surface on [errorMessage]; UI
- * shows them as a Snackbar / inline banner and clears via
- * [clearError].
+ * Errors raised by the repository surface on [error]; UI shows them
+ * as a Snackbar / inline banner (resolving the structured value to a
+ * localized string) and clears via [clearError].
  */
 class IdentitiesViewModel(
     private val identity: IdentityRepository,
@@ -40,6 +40,18 @@ class IdentitiesViewModel(
      *  the currently-selected one. */
     data class Row(val summary: IdentitySummary, val isActive: Boolean)
 
+    /** Structured error so the UI can render a localized message.
+     *  [cause] carries the underlying exception's message (or class
+     *  name when null) — substituted into a `%1$s` placeholder. */
+    sealed class Error {
+        abstract val cause: String
+
+        data class Switch(override val cause: String) : Error()
+        data class Add(override val cause: String) : Error()
+        data class Remove(override val cause: String) : Error()
+        data class Rename(override val cause: String) : Error()
+    }
+
     val items: StateFlow<List<Row>> = combine(
         identity.identities,
         identity.currentIdentityId,
@@ -47,15 +59,15 @@ class IdentitiesViewModel(
         list.map { Row(summary = it, isActive = it.id == activeId) }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    private val _errorMessage = MutableStateFlow<String?>(null)
-    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+    private val _error = MutableStateFlow<Error?>(null)
+    val error: StateFlow<Error?> = _error.asStateFlow()
 
     fun select(id: IdentityId) {
         viewModelScope.launch {
             try {
                 identity.select(id)
             } catch (e: Throwable) {
-                _errorMessage.value = "Couldn't switch identity: ${e.message ?: e.javaClass.simpleName}"
+                _error.value = Error.Switch(e.causeText())
             }
         }
     }
@@ -65,7 +77,7 @@ class IdentitiesViewModel(
             try {
                 identity.add(name = name)
             } catch (e: Throwable) {
-                _errorMessage.value = "Couldn't add identity: ${e.message ?: e.javaClass.simpleName}"
+                _error.value = Error.Add(e.causeText())
             }
         }
     }
@@ -75,7 +87,7 @@ class IdentitiesViewModel(
             try {
                 identity.remove(id)
             } catch (e: Throwable) {
-                _errorMessage.value = "Couldn't remove identity: ${e.message ?: e.javaClass.simpleName}"
+                _error.value = Error.Remove(e.causeText())
             }
         }
     }
@@ -87,12 +99,14 @@ class IdentitiesViewModel(
             try {
                 identity.rename(id, newName)
             } catch (e: Throwable) {
-                _errorMessage.value = "Couldn't rename identity: ${e.message ?: e.javaClass.simpleName}"
+                _error.value = Error.Rename(e.causeText())
             }
         }
     }
 
     fun clearError() {
-        _errorMessage.value = null
+        _error.value = null
     }
+
+    private fun Throwable.causeText(): String = message ?: javaClass.simpleName
 }

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
@@ -69,10 +69,19 @@ fun IdentitiesScreen(
     onIdentityClick: (IdentityId) -> Unit,
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
-    val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
 
+    val errorMessage = error?.let { e ->
+        val keyId = when (e) {
+            is IdentitiesViewModel.Error.Switch -> R.string.identities_error_switch
+            is IdentitiesViewModel.Error.Add -> R.string.identities_error_add
+            is IdentitiesViewModel.Error.Remove -> R.string.identities_error_remove
+            is IdentitiesViewModel.Error.Rename -> R.string.identities_error_rename
+        }
+        stringResource(keyId, e.cause)
+    }
     LaunchedEffect(errorMessage) {
         errorMessage?.let {
             snackbarHostState.showSnackbar(it)

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -341,4 +341,124 @@
     <string name="governance_oneonone">Один на один</string>
     <string name="governance_tyranny">Тирания</string>
 
+    <!-- ─── Governance card copy (CreateGroup Step 1 / Step 2) ─── -->
+    <string name="governance_tyranny_card_label">Тирания</string>
+    <string name="governance_tyranny_sub">Один админ</string>
+    <string name="governance_tyranny_oneline">Вы управляете участниками и настройками.</string>
+    <string name="governance_tyranny_tooltip">Только админ может управлять группой.</string>
+    <string name="governance_tyranny_step2hint">Вы будете единственным админом.</string>
+    <string name="governance_oneonone_card_label">1-на-1</string>
+    <string name="governance_oneonone_sub">Диалог</string>
+    <string name="governance_oneonone_oneline">Приватный разговор на двоих.</string>
+    <string name="governance_oneonone_tooltip">Ровно два человека. Никто другой не сможет присоединиться.</string>
+    <string name="governance_oneonone_step2hint">Выберите ровно одного человека.</string>
+    <string name="governance_anarchy_card_label">Анархия</string>
+    <string name="governance_anarchy_sub">Открытое управление</string>
+    <string name="governance_anarchy_oneline">У каждого участника одинаковые права.</string>
+    <string name="governance_anarchy_tooltip">Любой может добавлять, удалять или менять настройки.</string>
+    <string name="governance_anarchy_step2hint">Управление общее.</string>
+
+    <!-- ─── Generic / shared CTAs ──────────────────────────────── -->
+    <string name="retry">Повторить</string>
+
+    <!-- ─── Join chat (deeplink landing) ───────────────────────── -->
+    <string name="join_screen_title">Присоединиться к чату</string>
+    <string name="join_invite_fallback_title">Приглашение в чат</string>
+    <string name="join_invite_from">от %1$s</string>
+    <string name="join_label_field_label">Как пригласившему вас видеть?</string>
+    <string name="join_label_field_helper">Пригласивший увидит это имя в запросе на подтверждение. Он может отклонить запрос, если имя не совпадает с ожидаемым.</string>
+    <string name="join_send_request">Отправить запрос</string>
+    <string name="join_sending_request">Отправка запроса…</string>
+    <string name="join_awaiting_title">Ожидание подтверждения</string>
+    <string name="join_awaiting_body">Чат появится в списке, как только пригласивший нажмёт «Подтвердить». Этот экран можно закрыть — мы добавим чат в список автоматически.</string>
+    <string name="join_back_to_chats">Назад к чатам</string>
+    <string name="join_approved_title">Готово!</string>
+    <string name="join_approved_body">Вы участник %1$s.</string>
+    <string name="join_open_chat">Открыть чат</string>
+
+    <!-- ─── Share invite (post-create) ─────────────────────────── -->
+    <string name="share_invite_title">Приглашение</string>
+    <string name="share_invite_hero_title">Ваша группа готова</string>
+    <string name="share_invite_hero_body">Поделитесь этой ссылкой с теми, кого хотите пригласить. Вы увидите и подтвердите каждый запрос до того, как человек присоединится.</string>
+    <string name="share_invite_link_chooser">Поделиться ссылкой-приглашением</string>
+    <string name="share_invite_clipboard_label">Ссылка-приглашение</string>
+    <string name="share_invite_copy">Скопировать ссылку</string>
+    <string name="share_invite_copied">Скопировано!</string>
+    <string name="share_invite_failed">Не удалось создать приглашение: %1$s</string>
+    <string name="share_invite_skip">Сделаю это позже</string>
+
+    <!-- ─── Create group — Step 1 ─────────────────────────────── -->
+    <string name="create_group_step1_title">Новая группа</string>
+    <string name="create_group_step1_subtitle">Шаг 1 из 2</string>
+    <string name="create_group_name_placeholder">Название группы</string>
+    <string name="create_group_name_helper">Видно участникам. Можно изменить в любое время.</string>
+    <string name="create_group_accent_color">Акцентный цвет</string>
+    <string name="create_group_how_its_run">Как устроена</string>
+    <string name="create_group_soon_badge">Скоро</string>
+    <string name="create_group_encrypted_footer">Сквозное шифрование · публикуется в Stellar — каждый может проверить подлинность.</string>
+    <string name="create_group_next">Далее · Добавить участников</string>
+
+    <!-- ─── Create group — Step 2 ─────────────────────────────── -->
+    <string name="create_group_step2_title">Добавить участников</string>
+    <string name="create_group_step2_subtitle">Шаг 2 из 2</string>
+    <string name="create_group_no_invitees_title">Приглашённых пока нет</string>
+    <string name="create_group_no_invitees_body">Используйте «Пригласить по ключу входящих» ниже, чтобы добавить участника.</string>
+    <string name="create_group_invitee_inbox_label">Входящие %1$s</string>
+    <string name="create_group_invitee_inbox_subtitle">Прямой ключ входящих</string>
+    <string name="create_group_invite_by_key_row_title">Пригласить по ключу входящих</string>
+    <string name="create_group_invite_by_key_row_subtitle">Вставьте ключ из 64 символов</string>
+
+    <!-- ─── Create group — InviteByKey screen ─────────────────── -->
+    <string name="create_group_invite_by_key_screen_title">Приглашение по ключу входящих</string>
+    <string name="create_group_invite_by_key_for_subtitle">Для %1$s</string>
+    <string name="create_group_invite_by_key_default_group_label">группы</string>
+    <string name="create_group_invite_by_key_placeholder">Вставьте hex-ключ из 64 символов…</string>
+    <string name="create_group_invite_by_key_count">(%1$d/64)</string>
+    <string name="create_group_invite_by_key_helper">Получатель создаёт этот ключ на своём устройстве. Найти его можно в Настройках → Личность → Ключ входящих.</string>
+    <string name="create_group_invite_by_key_add">Добавить участника</string>
+
+    <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
+    <string name="create_group_cta_empty">Создать пустую группу</string>
+    <string name="create_group_cta_one_person">Создать с одним участником</string>
+    <string name="create_group_cta_n_people">Создать с %1$d участниками</string>
+    <string name="create_group_cta_oneonone_add">Добавьте второго участника</string>
+    <string name="create_group_cta_oneonone_start">Начать 1-на-1</string>
+    <string name="create_group_cta_oneonone_too_many">Для 1-на-1 нужен ровно один</string>
+
+    <!-- ─── Create group — Creating ───────────────────────────── -->
+    <string name="create_group_creating_title">Создание «%1$s»</string>
+    <string name="create_group_creating_default_name">группы</string>
+    <string name="create_group_step_setup">Настройка зашифрованной группы</string>
+    <string name="create_group_step_setup_sub">Генерация ключей на устройстве</string>
+    <string name="create_group_step_admin">Настройка ключей администратора</string>
+    <string name="create_group_step_admin_sub">Вы будете единственным администратором</string>
+    <string name="create_group_step_invitation">Отправка приглашения №%1$d</string>
+    <string name="create_group_step_invitation_sub">Сквозное шифрование</string>
+    <string name="create_group_step_anchor">Закрепление в Stellar</string>
+    <string name="create_group_step_anchor_sub">Чтобы каждый мог проверить подлинность группы</string>
+    <string name="create_group_error_fallback">Не удалось создать группу</string>
+    <string name="create_group_helpful_note">Обычно занимает несколько секунд. Можно закрыть экран — мы завершим в фоне.</string>
+
+    <!-- ─── Create group — Success ────────────────────────────── -->
+    <string name="create_group_anchored_testnet">Закреплено в Stellar testnet</string>
+    <string name="create_group_members_section">Участники</string>
+    <plurals name="create_group_members_count">
+        <item quantity="one">%1$d участник</item>
+        <item quantity="few">%1$d участника</item>
+        <item quantity="many">%1$d участников</item>
+        <item quantity="other">%1$d участника</item>
+    </plurals>
+    <plurals name="create_group_invitations_sent">
+        <item quantity="one">Отправлено %1$d приглашение</item>
+        <item quantity="few">Отправлено %1$d приглашения</item>
+        <item quantity="many">Отправлено %1$d приглашений</item>
+        <item quantity="other">Отправлено %1$d приглашения</item>
+    </plurals>
+
+    <!-- ─── Identities errors (Snackbar) ──────────────────────── -->
+    <string name="identities_error_switch">Не удалось переключить личность: %1$s</string>
+    <string name="identities_error_add">Не удалось добавить личность: %1$s</string>
+    <string name="identities_error_remove">Не удалось удалить личность: %1$s</string>
+    <string name="identities_error_rename">Не удалось переименовать личность: %1$s</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,4 +346,123 @@
     <string name="governance_oneonone">One-on-one</string>
     <string name="governance_tyranny">Tyranny</string>
 
+    <!-- ─── Governance card copy (CreateGroup Step 1 / Step 2) ─────
+         Short pill labels for the picker cards plus the per-flavour
+         sub-line, tooltip blurb, and Step-2 banner hint that used
+         to live as hardcoded strings inside `OnymUIGovernance`. -->
+    <string name="governance_tyranny_card_label">Tyranny</string>
+    <string name="governance_tyranny_sub">Single admin</string>
+    <string name="governance_tyranny_oneline">You control membership and settings.</string>
+    <string name="governance_tyranny_tooltip">Only the admin can manage this group.</string>
+    <string name="governance_tyranny_step2hint">You\'ll be the only admin.</string>
+    <string name="governance_oneonone_card_label">1-on-1</string>
+    <string name="governance_oneonone_sub">Dialog</string>
+    <string name="governance_oneonone_oneline">A private two-person conversation.</string>
+    <string name="governance_oneonone_tooltip">Exactly two people. No one else can join.</string>
+    <string name="governance_oneonone_step2hint">Pick exactly one person.</string>
+    <string name="governance_anarchy_card_label">Anarchy</string>
+    <string name="governance_anarchy_sub">Open control</string>
+    <string name="governance_anarchy_oneline">Every member has the same control.</string>
+    <string name="governance_anarchy_tooltip">Anyone can add, remove, or change settings.</string>
+    <string name="governance_anarchy_step2hint">Everyone shares control.</string>
+
+    <!-- ─── Generic / shared CTAs ──────────────────────────────── -->
+    <string name="retry">Retry</string>
+
+    <!-- ─── Join chat (deeplink landing) ───────────────────────── -->
+    <string name="join_screen_title">Join chat</string>
+    <string name="join_invite_fallback_title">Invite to join a chat</string>
+    <string name="join_invite_from">from %1$s</string>
+    <string name="join_label_field_label">How should the inviter see you?</string>
+    <string name="join_label_field_helper">The inviter sees this name in their approval prompt. They can decline if it doesn\'t match what they expect.</string>
+    <string name="join_send_request">Send join request</string>
+    <string name="join_sending_request">Sending request…</string>
+    <string name="join_awaiting_title">Waiting for approval</string>
+    <string name="join_awaiting_body">You\'ll see this chat appear in your list as soon as the inviter taps Approve. You can close this screen — we\'ll add it to Chats automatically.</string>
+    <string name="join_back_to_chats">Back to chats</string>
+    <string name="join_approved_title">Joined!</string>
+    <string name="join_approved_body">You\'re a member of %1$s.</string>
+    <string name="join_open_chat">Open chat</string>
+
+    <!-- ─── Share invite (post-create) ─────────────────────────── -->
+    <string name="share_invite_title">Invite</string>
+    <string name="share_invite_hero_title">Your group is ready</string>
+    <string name="share_invite_hero_body">Share this link with the people you want to invite. You\'ll see and approve each request before they join.</string>
+    <string name="share_invite_link_chooser">Share invite link</string>
+    <string name="share_invite_clipboard_label">Invite link</string>
+    <string name="share_invite_copy">Copy invite link</string>
+    <string name="share_invite_copied">Copied!</string>
+    <string name="share_invite_failed">Couldn\'t generate an invite: %1$s</string>
+    <string name="share_invite_skip">I\'ll do this later</string>
+
+    <!-- ─── Create group — Step 1 ─────────────────────────────── -->
+    <string name="create_group_step1_title">New Group</string>
+    <string name="create_group_step1_subtitle">Step 1 of 2</string>
+    <string name="create_group_name_placeholder">Group name</string>
+    <string name="create_group_name_helper">Visible to members. You can change this anytime.</string>
+    <string name="create_group_accent_color">Accent color</string>
+    <string name="create_group_how_its_run">How it\'s run</string>
+    <string name="create_group_soon_badge">Soon</string>
+    <string name="create_group_encrypted_footer">End-to-end encrypted · published on Stellar so anyone can verify it\'s real.</string>
+    <string name="create_group_next">Next · Add people</string>
+
+    <!-- ─── Create group — Step 2 ─────────────────────────────── -->
+    <string name="create_group_step2_title">Add People</string>
+    <string name="create_group_step2_subtitle">Step 2 of 2</string>
+    <string name="create_group_no_invitees_title">No invitees yet</string>
+    <string name="create_group_no_invitees_body">Use \"Invite by inbox key\" below to add someone.</string>
+    <string name="create_group_invitee_inbox_label">Inbox %1$s</string>
+    <string name="create_group_invitee_inbox_subtitle">Direct inbox key</string>
+    <string name="create_group_invite_by_key_row_title">Invite by inbox key</string>
+    <string name="create_group_invite_by_key_row_subtitle">Paste a 64-char key</string>
+
+    <!-- ─── Create group — InviteByKey screen ─────────────────── -->
+    <string name="create_group_invite_by_key_screen_title">Invite by Inbox Key</string>
+    <string name="create_group_invite_by_key_for_subtitle">For %1$s</string>
+    <string name="create_group_invite_by_key_default_group_label">group</string>
+    <string name="create_group_invite_by_key_placeholder">Paste a 64-character hex key…</string>
+    <string name="create_group_invite_by_key_count">(%1$d/64)</string>
+    <string name="create_group_invite_by_key_helper">The recipient generates this key on their own device. They can find it in Settings → Identity → Inbox Key.</string>
+    <string name="create_group_invite_by_key_add">Add invitee</string>
+
+    <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
+    <string name="create_group_cta_empty">Create empty group</string>
+    <string name="create_group_cta_one_person">Create with 1 person</string>
+    <string name="create_group_cta_n_people">Create with %1$d people</string>
+    <string name="create_group_cta_oneonone_add">Add the other person</string>
+    <string name="create_group_cta_oneonone_start">Start 1-on-1</string>
+    <string name="create_group_cta_oneonone_too_many">1-on-1 needs exactly one</string>
+
+    <!-- ─── Create group — Creating ───────────────────────────── -->
+    <string name="create_group_creating_title">Creating %1$s</string>
+    <string name="create_group_creating_default_name">Group</string>
+    <string name="create_group_step_setup">Setting up encrypted group</string>
+    <string name="create_group_step_setup_sub">Generating keys on your device</string>
+    <string name="create_group_step_admin">Setting up your admin keys</string>
+    <string name="create_group_step_admin_sub">You\'ll be the only admin</string>
+    <string name="create_group_step_invitation">Sending invitation #%1$d</string>
+    <string name="create_group_step_invitation_sub">Encrypted, end-to-end</string>
+    <string name="create_group_step_anchor">Anchoring on Stellar</string>
+    <string name="create_group_step_anchor_sub">So anyone can verify this group is real</string>
+    <string name="create_group_error_fallback">Couldn\'t create the group</string>
+    <string name="create_group_helpful_note">This usually takes a few seconds. It\'s safe to close this — we\'ll finish in the background.</string>
+
+    <!-- ─── Create group — Success ────────────────────────────── -->
+    <string name="create_group_anchored_testnet">Anchored on Stellar testnet</string>
+    <string name="create_group_members_section">Members</string>
+    <plurals name="create_group_members_count">
+        <item quantity="one">%1$d member</item>
+        <item quantity="other">%1$d members</item>
+    </plurals>
+    <plurals name="create_group_invitations_sent">
+        <item quantity="one">%1$d invitation sent</item>
+        <item quantity="other">%1$d invitations sent</item>
+    </plurals>
+
+    <!-- ─── Identities errors (Snackbar) ──────────────────────── -->
+    <string name="identities_error_switch">Couldn\'t switch identity: %1$s</string>
+    <string name="identities_error_add">Couldn\'t add identity: %1$s</string>
+    <string name="identities_error_remove">Couldn\'t remove identity: %1$s</string>
+    <string name="identities_error_rename">Couldn\'t rename identity: %1$s</string>
+
 </resources>

--- a/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/CreateGroupViewModelTest.kt
@@ -248,14 +248,14 @@ class CreateGroupViewModelTest {
     @Test
     fun createCtaLabel_reflectsInviteeCount() = runTest {
         val vm = makeViewModel()
-        assertEquals("Create empty group", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.Empty, vm.state.value.createCtaLabel)
         vm.setInviteeInput("aa".repeat(32))
         vm.tappedAddInvitee()
-        assertEquals("Create with 1 person", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.OnePerson, vm.state.value.createCtaLabel)
         vm.tappedInviteByKey()
         vm.setInviteeInput("bb".repeat(32))
         vm.tappedAddInvitee()
-        assertEquals("Create with 2 people", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.NPeople(2), vm.state.value.createCtaLabel)
     }
 
     // ─── OneOnOne governance ──────────────────────────────────────
@@ -289,14 +289,14 @@ class CreateGroupViewModelTest {
     fun oneOnOne_ctaLabel_explainsTheGate() = runTest {
         val vm = makeViewModel()
         vm.setGovernance(OnymUIGovernance.OneOnOne)
-        assertEquals("Add the other person", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.OneOnOneAddOther, vm.state.value.createCtaLabel)
         vm.setInviteeInput("aa".repeat(32))
         vm.tappedAddInvitee()
-        assertEquals("Start 1-on-1", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.OneOnOneStart, vm.state.value.createCtaLabel)
         vm.tappedInviteByKey()
         vm.setInviteeInput("bb".repeat(32))
         vm.tappedAddInvitee()
-        assertEquals("1-on-1 needs exactly one", vm.state.value.createCtaLabel)
+        assertEquals(CreateCtaLabel.OneOnOneTooMany, vm.state.value.createCtaLabel)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Brings the last four screens that rendered hardcoded English — `JoinScreen`, `ShareInviteScreen`, `CreateGroupScreen` (Step 1 / 2 / InviteByKey / Creating / Success) — under the existing `values/` + `values-ru/` translation system. Russian plurals use the full `one/few/many/other` set for member and invitation counts.
- To keep VM layers locale-agnostic: `OnymUIGovernance` is now a pure enum (label/sub/tooltip/step2Hint move to `governance_*` resources), `createCtaLabel` becomes a `CreateCtaLabel` sealed class resolved in Compose, and `IdentitiesViewModel.errorMessage` becomes a structured `Error` (Switch / Add / Remove / Rename) that the screen formats via `stringResource(R.string.identities_error_*, cause)`.
- Drive-by fix: the `1‑1on‑1` typo on the OneOnOne governance card now reads `1-on-1` (`1-на-1` in ru).

## Test plan
- [x] `./gradlew :app:lintDebug :app:testDebugUnitTest` — passes (MissingTranslation gate green for new keys).
- [ ] Walk Create Group → Step 1 → Step 2 → InviteByKey → Creating → Success → Share Invite under both `en` and `ru` locales (Settings → Languages).
- [ ] Walk Join from a deeplink under both locales (Ready / Sending / Awaiting / Approved / Failed).
- [ ] Trigger an Identities switch/add/remove/rename failure and confirm the Snackbar text is localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)