### PR TITLE
fix: drop tap-to-reveal overlay from recovery-phrase screen (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,8 +528,7 @@ in shape, ported to Compose + StateFlow + AndroidX BiometricPrompt.
 .intro
   │ tappedContinueFromIntro → authenticate()
   ├─► .authFailed(reason) ── dismissedAuthError → .intro
-  └─► .reveal(phrase, revealed: false)
-        │ tappedReveal     → revealed: true
+  └─► .reveal(phrase)
         │ tappedCopyPhrase → clipboard write + 60s auto-clear
         │ tappedContinueFromReveal
         ▼

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreenTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreenTest.kt
@@ -5,8 +5,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -124,36 +122,20 @@ class RecoveryPhraseBackupScreenTest {
     // ─── Reveal ────────────────────────────────────────────────────
 
     @Test
-    fun reveal_unrevealed_shows_tap_to_reveal_overlay() {
+    fun reveal_shows_words_and_enables_actions_immediately() {
         setContent()
         runBlocking { advanceToReveal() }
-        composeRule.onNodeWithText(string(R.string.tap_to_reveal))
-            .assertIsDisplayed()
-        // Continue + Copy disabled until the user taps to reveal.
-        composeRule.onNodeWithText(string(R.string.ive_written_it_down))
-            .assertIsNotEnabled()
-        composeRule.onNodeWithText(string(R.string.copy))
-            .assertIsNotEnabled()
-    }
 
-    @Test
-    fun reveal_tap_shows_words_and_enables_actions() {
-        setContent()
-        runBlocking { advanceToReveal() }
-        composeRule.onNodeWithText(string(R.string.tap_to_reveal)).performClick()
-
-        // Tap-to-reveal overlay disappears + at least one early + late
-        // word is now visible to the user. The test mnemonic repeats
-        // "legal" / "winner" / "thank" by design (BIP39 spec vector),
-        // so the assertion targets the first / last positions that are
-        // unique in the phrase — `onNodeWithText` (singular) requires
-        // a unique match.
-        composeRule.onNodeWithText(string(R.string.tap_to_reveal))
-            .assertIsNotDisplayed()
+        // Words rendered immediately — no tap-to-reveal gate after the
+        // biometric step (issue #82). The test mnemonic repeats "legal"
+        // / "winner" / "thank" by design (BIP39 spec vector), so the
+        // assertion targets the first / last positions that are unique
+        // in the phrase — `onNodeWithText` (singular) requires a unique
+        // match.
         composeRule.onNodeWithText(testWords[3], substring = true).assertExists()  // "year"
         composeRule.onNodeWithText(testWords.last(), substring = true).assertExists()  // "yellow"
 
-        // Actions enabled.
+        // Actions enabled from the start.
         composeRule.onNodeWithText(string(R.string.ive_written_it_down))
             .assertIsEnabled()
         composeRule.onNodeWithText(string(R.string.copy))
@@ -164,7 +146,6 @@ class RecoveryPhraseBackupScreenTest {
     fun reveal_copy_writes_to_clipboard_and_shows_dialog() {
         setContent()
         runBlocking { advanceToReveal() }
-        composeRule.onNodeWithText(string(R.string.tap_to_reveal)).performClick()
         composeRule.onNodeWithText(string(R.string.copy)).performClick()
 
         // Confirmation dialog visible.
@@ -179,7 +160,6 @@ class RecoveryPhraseBackupScreenTest {
     fun reveal_continue_advances_to_verify_step() {
         setContent()
         runBlocking { advanceToReveal() }
-        composeRule.onNodeWithText(string(R.string.tap_to_reveal)).performClick()
         composeRule.onNodeWithText(string(R.string.ive_written_it_down)).performClick()
 
         // Verify step prompt visible.
@@ -308,7 +288,6 @@ class RecoveryPhraseBackupScreenTest {
 
     private suspend fun advanceToVerify() {
         advanceToReveal()
-        viewModel.tappedReveal()
         viewModel.tappedContinueFromReveal()
         composeRule.waitUntil(timeoutMillis = 1_000) {
             viewModel.step.value is RecoveryPhraseBackupViewModel.Step.Verify

--- a/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModelTest.kt
@@ -109,7 +109,7 @@ class RecoveryPhraseBackupViewModelTest {
     }
 
     @Test
-    fun authSuccess_transitionsToReveal_unrevealed() = runBlocking {
+    fun authSuccess_transitionsToReveal() = runBlocking {
         authenticator.outcome = FakeAuthenticator.Outcome.Success
         viewModel.authenticate()
 
@@ -118,7 +118,6 @@ class RecoveryPhraseBackupViewModelTest {
             fail("expected Reveal, got $step"); return@runBlocking
         }
         assertEquals(testMnemonic, step.phrase)
-        assertEquals(false, step.revealed)
     }
 
     @Test
@@ -148,21 +147,8 @@ class RecoveryPhraseBackupViewModelTest {
     // ─── Reveal ─────────────────────────────────────────────────────
 
     @Test
-    fun tappedReveal_flipsRevealedTrue() = runBlocking {
-        advanceToReveal()
-        viewModel.tappedReveal()
-
-        val step = viewModel.step.value
-        if (step !is RecoveryPhraseBackupViewModel.Step.Reveal) {
-            fail("expected Reveal, got $step"); return@runBlocking
-        }
-        assertTrue(step.revealed)
-    }
-
-    @Test
     fun tappedCopyPhrase_writesToClipboard_thenClearsAfterDelay() = runBlocking {
         advanceToReveal()
-        viewModel.tappedReveal()
 
         viewModel.tappedCopyPhrase()
         assertEquals(testMnemonic, clipboard.lastWritten)
@@ -174,9 +160,8 @@ class RecoveryPhraseBackupViewModelTest {
     }
 
     @Test
-    fun tappedCopyPhrase_isNoop_beforeReveal() = runBlocking {
-        advanceToReveal()
-        // Don't tap reveal — phrase still hidden.
+    fun tappedCopyPhrase_isNoop_outsideReveal() = runBlocking {
+        // Still on Intro — no Reveal step yet, so copy must not write.
         viewModel.tappedCopyPhrase()
         assertNull(clipboard.lastWritten)
     }
@@ -184,7 +169,6 @@ class RecoveryPhraseBackupViewModelTest {
     @Test
     fun tappedContinueFromReveal_movesToVerify_withThreeRounds() = runBlocking {
         advanceToReveal()
-        viewModel.tappedReveal()
         viewModel.tappedContinueFromReveal()
 
         val step = viewModel.step.value
@@ -296,7 +280,6 @@ class RecoveryPhraseBackupViewModelTest {
 
     private suspend fun advanceToVerify() {
         advanceToReveal()
-        viewModel.tappedReveal()
         viewModel.tappedContinueFromReveal()
     }
 

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -448,11 +448,13 @@ private fun PhraseCard(
             .padding(16.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // 2-column grid of indexed words. Slight blur when hidden.
+        // 2-column grid of indexed words. Hidden via alpha = 0 when
+        // not revealed — Modifier.blur is a no-op below API 31 and
+        // would leak the secret on Android 8–11.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .blur(if (revealed) 0.dp else 10.dp),
+                .alpha(if (revealed) 1f else 0f),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             words.chunked(2).forEachIndexed { rowIdx, pair ->
@@ -490,7 +492,7 @@ private fun PhraseCard(
         }
 
         if (!revealed) {
-            // Tap target overlaying the blurred phrase
+            // Tap target covering the hidden phrase
             Column(
                 modifier = Modifier
                     .matchParentSize()

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Key
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Shield
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.AlertDialog
@@ -40,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -129,8 +127,6 @@ fun RecoveryPhraseBackupScreen(
                 is RecoveryPhraseBackupViewModel.Step.Reveal -> {
                     RevealScreen(
                         phrase = s.phrase,
-                        revealed = s.revealed,
-                        onReveal = viewModel::tappedReveal,
                         onCopy = viewModel::tappedCopyPhrase,
                         onContinue = viewModel::tappedContinueFromReveal,
                     )
@@ -331,8 +327,6 @@ private fun IntroRow(
 @Composable
 private fun RevealScreen(
     phrase: String,
-    revealed: Boolean,
-    onReveal: () -> Unit,
     onCopy: () -> Unit,
     onContinue: () -> Unit,
 ) {
@@ -361,8 +355,6 @@ private fun RevealScreen(
 
         PhraseCard(
             words = words,
-            revealed = revealed,
-            onReveal = onReveal,
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 12.dp),
@@ -380,7 +372,6 @@ private fun RevealScreen(
                     onCopy()
                     copyConfirmShown = true
                 },
-                enabled = revealed,
                 modifier = Modifier.weight(1f),
                 shape = RoundedCornerShape(14.dp),
                 colors = ButtonDefaults.buttonColors(
@@ -397,7 +388,6 @@ private fun RevealScreen(
 
         Button(
             onClick = onContinue,
-            enabled = revealed,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
@@ -436,8 +426,6 @@ private fun RevealScreen(
 @Composable
 private fun PhraseCard(
     words: List<String>,
-    revealed: Boolean,
-    onReveal: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -448,13 +436,16 @@ private fun PhraseCard(
             .padding(16.dp),
         contentAlignment = Alignment.Center,
     ) {
-        // 2-column grid of indexed words. Hidden via alpha = 0 when
-        // not revealed — Modifier.blur is a no-op below API 31 and
-        // would leak the secret on Android 8–11.
+        // 2-column grid of indexed words. Visible immediately — the
+        // biometric gate in [authenticate] + FLAG_SECURE on the window
+        // (set in MainActivity) is the protection. The previous attempt
+        // (blur-then-tap-to-reveal, then alpha-then-tap-to-reveal) kept
+        // a tap-to-reveal overlay that confused users when the words
+        // were already plainly visible (issue #82). Since the user has
+        // just authenticated with biometrics, the extra gate adds no
+        // real protection and was visually broken on its broken paths.
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .alpha(if (revealed) 1f else 0f),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             words.chunked(2).forEachIndexed { rowIdx, pair ->
@@ -488,36 +479,6 @@ private fun PhraseCard(
                     // Pad-cell when chunked left an odd word out
                     if (pair.size == 1) Spacer(Modifier.weight(1f))
                 }
-            }
-        }
-
-        if (!revealed) {
-            // Tap target covering the hidden phrase
-            Column(
-                modifier = Modifier
-                    .matchParentSize()
-                    .clickable { onReveal() },
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(44.dp)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        Icons.Filled.VisibilityOff,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
-                Spacer(Modifier.height(10.dp))
-                Text(
-                    stringResource(R.string.tap_to_reveal),
-                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
-                )
             }
         }
     }

--- a/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/recovery/RecoveryPhraseBackupViewModel.kt
@@ -49,7 +49,7 @@ class RecoveryPhraseBackupViewModel(
     sealed class Step {
         data object Intro : Step()
         data class AuthFailed(val reason: String) : Step()
-        data class Reveal(val phrase: String, val revealed: Boolean) : Step()
+        data class Reveal(val phrase: String) : Step()
         data class Verify(
             val phrase: String,
             val rounds: List<VerifyRound>,
@@ -144,16 +144,9 @@ class RecoveryPhraseBackupViewModel(
         if (_step.value is Step.AuthFailed) _step.value = Step.Intro
     }
 
-    fun tappedReveal() {
-        val current = _step.value
-        if (current is Step.Reveal) {
-            _step.value = current.copy(revealed = true)
-        }
-    }
-
     fun tappedCopyPhrase() {
         val current = _step.value
-        if (current !is Step.Reveal || !current.revealed) return
+        if (current !is Step.Reveal) return
         // onym:allow-secret-read: copy is the explicit user intent on the
         // reveal screen; auto-clears after `clipboardClearDelay` so the
         // value doesn't sit on the system clipboard indefinitely.
@@ -168,7 +161,7 @@ class RecoveryPhraseBackupViewModel(
 
     fun tappedContinueFromReveal() {
         val current = _step.value
-        if (current is Step.Reveal && current.revealed) {
+        if (current is Step.Reveal) {
             _step.value = Step.Verify(
                 phrase = current.phrase,
                 rounds = makeRounds(current.phrase),
@@ -241,7 +234,7 @@ class RecoveryPhraseBackupViewModel(
             )
             return
         }
-        _step.value = Step.Reveal(phrase = phrase, revealed = false)
+        _step.value = Step.Reveal(phrase = phrase)
     }
 
     companion object {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -45,7 +45,6 @@
     <string name="copied">Скопировано</string>
     <string name="ok">ОК</string>
     <string name="recovery_phrase_copied_message">Фраза восстановления скопирована. Через 60 секунд она будет удалена из буфера обмена. Сохраните её сейчас в надёжном месте.</string>
-    <string name="tap_to_reveal">Нажмите, чтобы показать</string>
 
     <!-- ─── Verify screen ────────────────────────────────────────── -->
     <string name="select_word_number">Выберите слово номер</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,7 +48,6 @@
     <string name="copied">Copied</string>
     <string name="ok">OK</string>
     <string name="recovery_phrase_copied_message">Recovery phrase copied. It will be cleared from clipboard in 60 seconds. Store it securely now.</string>
-    <string name="tap_to_reveal">Tap to reveal</string>
 
     <!-- ─── Verify screen ────────────────────────────────────────── -->
     <string name="select_word_number">Select word number</string>


### PR DESCRIPTION
Closes #82.

## Summary

- Recovery-phrase reveal screen no longer draws a "Tap to reveal" overlay over the 12-word grid.
- Words are visible immediately after the biometric authentication; Copy + Continue are enabled from the start.
- `Step.Reveal` no longer carries a `revealed` flag, and `tappedReveal()` is gone.

## Why

Per #82, the previous overlay floated over an apparently-visible 12-word grid, confusing users.

Root cause: the screen used `Modifier.blur(...)` to hide the words pre-reveal, but `Modifier.blur` is a no-op below API 31 (Android 12). On Android 8–11, the words rendered fully readable behind a half-translated overlay reading "...нажмите чтобы показать..." — exactly the screenshot.

The previous attempt on this branch (`65cec7d`) swapped `blur` for `alpha = 0f` so the API < 31 path actually hid the words. That fixed the leak, but kept the tap-to-reveal gate — a second hurdle right after a biometric auth that already passed. The issue body's "Expected Behavior" explicitly calls out that with biometric + FLAG_SECURE already in place, the overlay adds no value.

This PR completes the fix by removing the gate entirely:
- `BiometricAuthenticator` (gates `authenticate()`) + `FLAG_SECURE` on the window (set in `MainActivity`) remain the access controls.
- The phrase appears on entering the Reveal step — same UX as iOS post-auth biometrics flows.
- Drops the `tap_to_reveal` string in en + ru.

## Test plan

- [x] `./gradlew compileDebugKotlin compileDebugAndroidTestKotlin` (clean)
- [x] `./gradlew lintDebug` (clean)
- [x] `./gradlew testDebugUnitTest` — 363/363 of the affected suites pass; 16 pre-existing `Room*StoreTest` failures (SQLite JNI in JVM) are unrelated and reproduce on `main`.
- [ ] Instrumented `RecoveryPhraseBackupScreenTest` + `RecoveryPhraseBackupViewModelTest` updated for the new flow — needs an emulator run in CI.
- [ ] Manual: Settings → Active profile → Backup → Show 12-word recovery phrase → biometrics → words visible immediately, no overlay; Copy + Continue enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)