### PR TITLE
ux: restore identity from 12-word recovery phrase (closes #86)

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -47,6 +47,8 @@ class AppDependencies(
     val makeChatsViewModel: () -> ChatsViewModel,
     /** Settings → Identities — multi-identity management (PR-5). */
     val makeIdentitiesViewModel: () -> chat.onym.android.identity.IdentitiesViewModel,
+    /** Settings → Identities → Restore from recovery phrase. */
+    val makeRestoreIdentityViewModel: () -> chat.onym.android.identity.RestoreIdentityViewModel,
     /** Post-create deeplink invite share (deeplink-invite PR-5). */
     val makeShareInviteViewModel: () -> chat.onym.android.group.ShareInviteViewModel,
     /** Joiner-side post-deeplink-tap surface (deeplink-invite PR-7).

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -539,6 +539,9 @@ class OnymApplication : Application() {
             makeIdentitiesViewModel = {
                 chat.onym.android.identity.IdentitiesViewModel(identity = identityRepository)
             },
+            makeRestoreIdentityViewModel = {
+                chat.onym.android.identity.RestoreIdentityViewModel(identity = identityRepository)
+            },
             makeShareInviteViewModel = {
                 chat.onym.android.group.ShareInviteViewModel(
                     identity = identityRepository,

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -56,6 +56,7 @@ import chat.onym.android.settings.IdentityDetailScreen
 import chat.onym.android.settings.PrivacyEncryptionScreen
 import chat.onym.android.settings.RelayerSettingsScreen
 import chat.onym.android.settings.RelayerSettingsViewModel
+import chat.onym.android.settings.RestoreIdentityScreen
 import chat.onym.android.settings.RunRelayerScreen
 import chat.onym.android.settings.SettingsScreen
 import chat.onym.android.settings.UseExistingContractScreen
@@ -324,6 +325,19 @@ fun RootScreen(
                     onIdentityClick = { id ->
                         navController.navigate("identity_detail/${id.value}")
                     },
+                    onRestoreClick = { navController.navigate(ROUTE_RESTORE_IDENTITY) },
+                )
+            }
+            composable(ROUTE_RESTORE_IDENTITY) {
+                val vm: chat.onym.android.identity.RestoreIdentityViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeRestoreIdentityViewModel() }
+                    },
+                )
+                RestoreIdentityScreen(
+                    viewModel = vm,
+                    onBack = { navController.popBackStack() },
+                    onDone = { navController.popBackStack() },
                 )
             }
             composable("identity_detail/{identityId}") { entry ->
@@ -514,6 +528,7 @@ private enum class Tab(val route: String, val labelRes: Int) {
 
 private const val ROUTE_RECOVERY_BACKUP = "recovery_backup"
 private const val ROUTE_IDENTITIES = "identities"
+private const val ROUTE_RESTORE_IDENTITY = "restore_identity"
 private const val ROUTE_PRIVACY = "privacy"
 private const val ROUTE_ABOUT = "about_onym"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"

--- a/app/src/main/kotlin/chat/onym/android/identity/RestoreIdentityViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/RestoreIdentityViewModel.kt
@@ -1,0 +1,90 @@
+package chat.onym.android.identity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Screen-local ViewModel for Settings → Identities → Restore. Owns
+ * the recovery-phrase + alias input, derives a [Validation] off the
+ * phrase via [Bip39.entropyFromMnemonic], and on [submit] calls
+ * [IdentityRepository.add] with `restoreMnemonic` set so the restored
+ * identity lands alongside any existing ones (non-destructive) and
+ * becomes the active selection.
+ *
+ * The input-state lives here (not in [IdentitiesViewModel]) so popping
+ * the screen drops the typed phrase from memory; the shared
+ * IdentitiesViewModel doesn't have to track per-screen ephemera.
+ */
+class RestoreIdentityViewModel(
+    private val identity: IdentityRepository,
+) : ViewModel() {
+
+    /** Live validation tag. The screen disables Restore on anything but
+     *  [Valid] and shows an inline hint on [Invalid]. [Empty] is the
+     *  pristine state — no hint, button disabled. */
+    enum class Validation { Empty, Invalid, Valid }
+
+    /** Async submit lifecycle. [Done] is a one-shot terminal state the
+     *  screen consumes to pop back; the caller acks via [acknowledgeDone]. */
+    sealed class State {
+        object Idle : State()
+        object Restoring : State()
+        data class Error(val cause: String) : State()
+        object Done : State()
+    }
+
+    private val _phrase = MutableStateFlow("")
+    val phrase: StateFlow<String> = _phrase.asStateFlow()
+
+    private val _name = MutableStateFlow("")
+    val name: StateFlow<String> = _name.asStateFlow()
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    val validation: StateFlow<Validation> = _phrase
+        .map { raw ->
+            val trimmed = raw.trim()
+            when {
+                trimmed.isEmpty() -> Validation.Empty
+                Bip39.isValidMnemonic(trimmed) -> Validation.Valid
+                else -> Validation.Invalid
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, Validation.Empty)
+
+    fun setPhrase(value: String) { _phrase.value = value }
+    fun setName(value: String) { _name.value = value }
+
+    fun submit() {
+        if (_state.value is State.Restoring) return
+        val trimmed = _phrase.value.trim()
+        if (!Bip39.isValidMnemonic(trimmed)) return
+        _state.value = State.Restoring
+        viewModelScope.launch {
+            try {
+                identity.add(name = _name.value.trim(), restoreMnemonic = trimmed)
+                _state.value = State.Done
+            } catch (e: Throwable) {
+                _state.value = State.Error(e.message ?: e.javaClass.simpleName)
+            }
+        }
+    }
+
+    fun clearError() {
+        if (_state.value is State.Error) _state.value = State.Idle
+    }
+
+    /** Caller invokes after handling [State.Done] (typically a navigate-pop)
+     *  so the flow doesn't re-fire on recomposition. */
+    fun acknowledgeDone() {
+        if (_state.value is State.Done) _state.value = State.Idle
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/IdentitiesScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -67,6 +68,7 @@ fun IdentitiesScreen(
     viewModel: IdentitiesViewModel,
     onBack: () -> Unit,
     onIdentityClick: (IdentityId) -> Unit,
+    onRestoreClick: () -> Unit,
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
@@ -130,35 +132,25 @@ fun IdentitiesScreen(
             item {
                 Spacer(Modifier.height(12.dp))
                 SettingsCard(modifier = Modifier.testTag("identities.add_card")) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { viewModel.add() }
-                            .padding(horizontal = 16.dp, vertical = 13.dp)
-                            .testTag("identities.add"),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(22.dp)
-                                .clip(CircleShape)
-                                .background(SettingsTile.Blue),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Icon(
-                                Icons.Filled.Add,
-                                contentDescription = null,
-                                tint = Color.White,
-                                modifier = Modifier.size(14.dp),
-                            )
-                        }
-                        Text(
-                            text = stringResource(R.string.identities_add_button),
-                            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                            color = SettingsTile.Blue,
-                        )
-                    }
+                    IdentityActionRow(
+                        icon = Icons.Filled.Add,
+                        background = SettingsTile.Blue,
+                        label = stringResource(R.string.identities_add_button),
+                        onClick = { viewModel.add() },
+                        rowTestTag = "identities.add",
+                    )
+                }
+            }
+            item {
+                Spacer(Modifier.height(12.dp))
+                SettingsCard(modifier = Modifier.testTag("identities.restore_card")) {
+                    IdentityActionRow(
+                        icon = Icons.Filled.Restore,
+                        background = SettingsTile.Green,
+                        label = stringResource(R.string.identities_restore_button),
+                        onClick = onRestoreClick,
+                        rowTestTag = "identities.restore",
+                    )
                 }
             }
             item {
@@ -166,6 +158,45 @@ fun IdentitiesScreen(
             }
             item { Spacer(Modifier.height(40.dp)) }
         }
+    }
+}
+
+@Composable
+private fun IdentityActionRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    background: Color,
+    label: String,
+    onClick: () -> Unit,
+    rowTestTag: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 13.dp)
+            .testTag(rowTestTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(22.dp)
+                .clip(CircleShape)
+                .background(background),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+            color = background,
+        )
     }
 }
 

--- a/app/src/main/kotlin/chat/onym/android/settings/RestoreIdentityScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RestoreIdentityScreen.kt
@@ -1,0 +1,247 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.R
+import chat.onym.android.identity.RestoreIdentityViewModel
+
+/**
+ * Settings → Identities → Restore. Paste/type a 12- or 24-word BIP39
+ * recovery phrase + an optional alias, then tap Restore. The repository
+ * derives keys from the phrase and adds the identity alongside any
+ * existing ones (non-destructive — see [chat.onym.android.identity.IdentityRepository.add]).
+ *
+ * Validation is live: the BIP39 checksum check from
+ * [chat.onym.android.identity.Bip39.isValidMnemonic] gates the Restore
+ * button and drives an inline hint that turns red on invalid input.
+ *
+ * The screen is intentionally bare — no biometric gate, no multi-step
+ * verify — restore IS the verify (a wrong phrase yields a different
+ * identity; the user notices on first chat). Mirrors how every other
+ * BIP39 wallet treats restore.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RestoreIdentityScreen(
+    viewModel: RestoreIdentityViewModel,
+    onBack: () -> Unit,
+    onDone: () -> Unit,
+) {
+    val phrase by viewModel.phrase.collectAsStateWithLifecycle()
+    val name by viewModel.name.collectAsStateWithLifecycle()
+    val validation by viewModel.validation.collectAsStateWithLifecycle()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val errorTemplate = stringResource(R.string.identities_error_add)
+    LaunchedEffect(state) {
+        val s = state
+        if (s is RestoreIdentityViewModel.State.Error) {
+            snackbarHostState.showSnackbar(errorTemplate.format(s.cause))
+            viewModel.clearError()
+        } else if (s is RestoreIdentityViewModel.State.Done) {
+            viewModel.acknowledgeDone()
+            onDone()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.restore_identity_screen_title)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("restore_identity.back"),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back),
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 28.dp)
+                .testTag("restore_identity.screen"),
+        ) {
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.restore_identity_intro),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(R.string.restore_identity_phrase_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+            )
+
+            val isInvalid = validation == RestoreIdentityViewModel.Validation.Invalid
+            OutlinedTextField(
+                value = phrase,
+                onValueChange = viewModel::setPhrase,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 120.dp)
+                    .testTag("restore_identity.phrase"),
+                placeholder = {
+                    Text(stringResource(R.string.restore_identity_phrase_placeholder))
+                },
+                isError = isInvalid,
+                singleLine = false,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrect = false,
+                    imeAction = ImeAction.Next,
+                ),
+            )
+
+            Spacer(Modifier.height(6.dp))
+
+            // Validation hint slot. Stable height so the layout doesn't
+            // jump when the user finishes typing the 12th word.
+            Box(modifier = Modifier.heightIn(min = 18.dp)) {
+                val hint = when (validation) {
+                    RestoreIdentityViewModel.Validation.Invalid ->
+                        stringResource(R.string.restore_identity_invalid)
+                    RestoreIdentityViewModel.Validation.Valid ->
+                        stringResource(R.string.restore_identity_valid)
+                    RestoreIdentityViewModel.Validation.Empty ->
+                        stringResource(R.string.restore_identity_word_count_hint)
+                }
+                val color = when (validation) {
+                    RestoreIdentityViewModel.Validation.Invalid -> MaterialTheme.colorScheme.error
+                    RestoreIdentityViewModel.Validation.Valid -> SettingsTile.Green
+                    RestoreIdentityViewModel.Validation.Empty -> MaterialTheme.colorScheme.onSurfaceVariant
+                }
+                Text(
+                    text = hint,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .testTag("restore_identity.hint"),
+                )
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(R.string.restore_identity_name_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 4.dp, bottom = 6.dp),
+            )
+            OutlinedTextField(
+                value = name,
+                onValueChange = viewModel::setName,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("restore_identity.name"),
+                placeholder = {
+                    Text(stringResource(R.string.restore_identity_name_placeholder))
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                    imeAction = ImeAction.Done,
+                ),
+            )
+
+            Spacer(Modifier.height(28.dp))
+
+            val canSubmit = validation == RestoreIdentityViewModel.Validation.Valid &&
+                state !is RestoreIdentityViewModel.State.Restoring
+            Button(
+                onClick = viewModel::submit,
+                enabled = canSubmit,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("restore_identity.submit"),
+                shape = RoundedCornerShape(14.dp),
+                contentPadding = PaddingValues(vertical = 14.dp),
+            ) {
+                Text(
+                    text = if (state is RestoreIdentityViewModel.State.Restoring) {
+                        stringResource(R.string.restore_identity_restoring)
+                    } else {
+                        stringResource(R.string.restore_identity_action)
+                    },
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(R.string.restore_identity_footnote),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/RestoreIdentityScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/RestoreIdentityScreen.kt
@@ -151,7 +151,7 @@ fun RestoreIdentityScreen(
                 singleLine = false,
                 keyboardOptions = KeyboardOptions(
                     capitalization = KeyboardCapitalization.None,
-                    autoCorrect = false,
+                    autoCorrectEnabled = false,
                     imeAction = ImeAction.Next,
                 ),
             )

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -158,7 +158,22 @@
     <string name="identities_screen_footer">Видимы только чаты активной личности. Переключайтесь между личностями, чтобы увидеть разные входящие.</string>
     <string name="identities_section_your">Ваши личности</string>
     <string name="identities_add_button">Добавить личность</string>
+    <string name="identities_restore_button">Восстановить из фразы восстановления</string>
     <string name="identity_unnamed">Безымянная личность</string>
+
+    <!-- ─── Restore identity (Настройки → Личности → Восстановить) ─── -->
+    <string name="restore_identity_screen_title">Восстановить личность</string>
+    <string name="restore_identity_intro">Введите фразу восстановления из 12 слов, чтобы восстановить личность на этом устройстве. Существующие личности не будут затронуты.</string>
+    <string name="restore_identity_phrase_label">Фраза восстановления</string>
+    <string name="restore_identity_phrase_placeholder">Введите 12 слов через пробел</string>
+    <string name="restore_identity_word_count_hint">12 или 24 слова, разделённых пробелами.</string>
+    <string name="restore_identity_invalid">Неверная фраза. Проверьте написание и порядок слов.</string>
+    <string name="restore_identity_valid">Фраза корректна.</string>
+    <string name="restore_identity_name_label">Имя (необязательно)</string>
+    <string name="restore_identity_name_placeholder">например, Личное</string>
+    <string name="restore_identity_action">Восстановить личность</string>
+    <string name="restore_identity_restoring">Восстановление…</string>
+    <string name="restore_identity_footnote">Восстановление воссоздаёт те же ключи из вашей фразы. Восстановленная личность станет активной.</string>
 
     <!-- ─── Identity detail ──────────────────────────────────────── -->
     <string name="identity_detail_title">Личность</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,7 +162,22 @@
     <string name="identities_screen_footer">Only the active identity\'s chats are visible. Switch between identities to see different inboxes.</string>
     <string name="identities_section_your">Your identities</string>
     <string name="identities_add_button">Add Identity</string>
+    <string name="identities_restore_button">Restore from recovery phrase</string>
     <string name="identity_unnamed">Unnamed identity</string>
+
+    <!-- ─── Restore identity (Settings → Identities → Restore) ─── -->
+    <string name="restore_identity_screen_title">Restore identity</string>
+    <string name="restore_identity_intro">Enter your 12-word recovery phrase to restore an identity on this device. Your existing identities are not affected.</string>
+    <string name="restore_identity_phrase_label">Recovery phrase</string>
+    <string name="restore_identity_phrase_placeholder">Enter your 12 words separated by spaces</string>
+    <string name="restore_identity_word_count_hint">12 or 24 words, separated by spaces.</string>
+    <string name="restore_identity_invalid">Invalid phrase. Check the spelling and order of your words.</string>
+    <string name="restore_identity_valid">Phrase looks good.</string>
+    <string name="restore_identity_name_label">Name (optional)</string>
+    <string name="restore_identity_name_placeholder">e.g. Personal</string>
+    <string name="restore_identity_action">Restore identity</string>
+    <string name="restore_identity_restoring">Restoring…</string>
+    <string name="restore_identity_footnote">Restoring derives the same keys from your phrase. The restored identity becomes active.</string>
 
     <!-- ─── Identity detail ──────────────────────────────────────── -->
     <string name="identity_detail_title">Identity</string>


### PR DESCRIPTION
## Summary

Closes #86. Users can now restore an existing identity from its 12-word BIP39 recovery phrase.

**UX decision.** Restore lives in **Settings → Identities** as a sibling card to "Add Identity" (rather than wedged into Privacy & Encryption, which is documented as a read-only explainer of the cryptographic primitives — not an actions surface). Single-tap "create fresh" stays unchanged; restore gets its own clearly-labeled top-level affordance — matches the wallet/keyring convention of separate "Create new" / "Import existing" entries.

**Flow:**
1. Tap "Restore from recovery phrase" → new `RestoreIdentityScreen`.
2. Paste/type 12 (or 24) words + optional alias. Live BIP39-checksum validation gates the Restore button and drives an inline hint.
3. Submit calls the existing non-destructive `IdentityRepository.add(name, restoreMnemonic = ...)`. The restored identity lands alongside any existing ones and becomes the active selection.

All cryptographic primitives, storage, and the `add(restoreMnemonic = …)` API already existed — this PR is wiring + UI.

## Notes

- Strings localized for **en** and **ru** (matches commit fd344d7's parity contract; `StringsCompletenessTest` passes).
- No biometric gate on restore — wrong phrase yields a different identity, the user notices on first chat. Mirrors how every other BIP39 wallet treats restore.
- The Privacy & Encryption "Your Keys" block stays read-only by design (out of scope for this issue).

## Test plan

- [ ] Settings → Identities shows two action cards: "Add Identity" (blue +) and "Restore from recovery phrase" (green Restore icon).
- [ ] Tapping Restore opens the screen with a multi-line phrase input.
- [ ] Typing a partial / invalid phrase shows the red "Invalid phrase" hint and disables the Restore button.
- [ ] Pasting a valid 12-word phrase flips the hint green and enables Restore.
- [ ] Tapping Restore creates a new identity, switches to it, and pops back to Identities.
- [ ] Restoring with the same phrase that's already on the device produces the same key material (so the BLS public key matches the original identity's).
- [ ] System back from RestoreIdentityScreen returns to Identities without committing anything.
- [ ] Russian locale: every new string is translated; layout doesn't truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)