### PR TITLE
feat(group): persist member alias + inbox key per group member

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -22,6 +22,7 @@ import chat.onym.android.chain.relayerFetchErrorMessageResolver
 import chat.onym.android.group.CreateGroupInteractor
 import chat.onym.android.group.CreateGroupViewModel
 import chat.onym.android.group.GroupDatabase
+import chat.onym.android.group.GroupDatabaseMigrations
 import chat.onym.android.group.GroupRepository
 import chat.onym.android.group.RoomGroupStore
 import chat.onym.android.identity.IdentityRepository
@@ -273,6 +274,11 @@ class OnymApplication : Application() {
                 // no production data to preserve — drop the table on
                 // the version mismatch instead of authoring a one-shot
                 // CASE migration.
+                //
+                // PR 75 (member-profiles) added a non-destructive v3→v4
+                // migration that introduces the nullable
+                // `encryptedMemberProfilesJson` column.
+                .addMigrations(GroupDatabaseMigrations.MIGRATION_3_4)
                 .fallbackToDestructiveMigration()
                 .build()
         } catch (e: Throwable) {

--- a/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
@@ -40,6 +40,22 @@ data class ChatGroup(
     val createdAtMillis: Long,
 
     val members: List<GovernanceMember>,
+    /**
+     * View-facing directory of people the local user has interacted
+     * with through this group, keyed by lowercase BLS pubkey hex
+     * (96 chars). Populated for the creator at group-create time and
+     * extended as joiners are admitted (post-PR fanout).
+     *
+     * Independent of [members]: V1 group rosters are static on-chain
+     * (`update_commitment` is post-V1 in the SEP contracts), so a
+     * joiner is "in the group" at the app level — receiving messages,
+     * listed in the chat detail — without yet being a
+     * [GovernanceMember] in the cryptographic Merkle tree.
+     * [members] is the on-chain truth; [memberProfiles] is the
+     * app-level "who am I talking to" directory. They may diverge.
+     */
+    @SerialName("member_profiles")
+    val memberProfiles: Map<String, MemberProfile> = emptyMap(),
     val epoch: ULong,
     @Serializable(with = Base64ByteArraySerializer::class)
     val salt: ByteArray,
@@ -98,6 +114,7 @@ data class ChatGroup(
             groupSecret.contentEquals(other.groupSecret) &&
             createdAtMillis == other.createdAtMillis &&
             members == other.members &&
+            memberProfiles == other.memberProfiles &&
             epoch == other.epoch &&
             salt.contentEquals(other.salt) &&
             (commitment?.contentEquals(other.commitment) ?: (other.commitment == null)) &&
@@ -114,6 +131,7 @@ data class ChatGroup(
         h = 31 * h + groupSecret.contentHashCode()
         h = 31 * h + createdAtMillis.hashCode()
         h = 31 * h + members.hashCode()
+        h = 31 * h + memberProfiles.hashCode()
         h = 31 * h + epoch.hashCode()
         h = 31 * h + salt.contentHashCode()
         h = 31 * h + (commitment?.contentHashCode() ?: 0)

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -20,6 +20,7 @@ import chat.onym.android.chain.SepContractTransport
 import chat.onym.android.chain.SepGroupType
 import chat.onym.android.chain.SepTier
 import chat.onym.android.chain.TyrannyCreateGroupPayload
+import chat.onym.android.identity.Identity
 import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.transport.InboxTransport
 import chat.onym.android.transport.TransportInboxId
@@ -264,12 +265,17 @@ open class CreateGroupInteractor(
         // step above would have thrown `MissingIdentity`).
         val ownerId = identity.currentIdentityId.value
             ?: throw CreateGroupError.MissingIdentity
+        val creatorAlias = identity.identities.value
+            .firstOrNull { it.id == ownerId }
+            ?.name
+            .orEmpty()
         val group = ChatGroup(
             id = groupIdHex,
             name = trimmedName,
             groupSecret = groupSecret,
             createdAtMillis = System.currentTimeMillis(),
             members = members,
+            memberProfiles = creatorProfiles(identitySnapshot, creatorAlias),
             epoch = 0uL,
             salt = salt,
             commitment = proof.commitment,
@@ -350,6 +356,29 @@ open class CreateGroupInteractor(
 
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true }
+
+        /**
+         * Single-entry seed for [ChatGroup.memberProfiles] at create
+         * time. Maps the creator's lowercase BLS pubkey hex (96 chars)
+         * to a [MemberProfile] carrying their current display name +
+         * inbox public key. Mirrors `creatorProfiles(...)` in
+         * `CreateGroupInteractor.swift`. Applied to all governance
+         * paths (Tyranny / OneOnOne / Anarchy).
+         */
+        fun creatorProfiles(
+            identitySnapshot: Identity,
+            alias: String,
+        ): Map<String, MemberProfile> {
+            val key = identitySnapshot.blsPublicKey.toHex()
+            // [Identity] has no display name field on Android — alias
+            // is read once from the per-identity [IdentitySummary] at
+            // create time. A later identity rename doesn't backfill
+            // historical groups.
+            return mapOf(key to MemberProfile(
+                alias = alias,
+                inboxPublicKey = identitySnapshot.inboxPublicKey,
+            ))
+        }
 
         /** Same derivation as `Identity.inboxTag` — duplicated here
          *  because the helper is tied to a specific identity, and we

--- a/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
@@ -17,14 +17,32 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [PersistedGroup::class],
-    // v3 (multi-identity, PR-3): adds `ownerIdentityId` column so the
-    // per-identity chats filter can `WHERE ownerIdentityId = :id`.
-    // Greenfield licence per the multi-identity spec — the Application
-    // builder uses `fallbackToDestructiveMigrationFrom(1, 2)` so dev
-    // installs lose any local groups on next launch.
-    version = 3,
+    // v4 (member-profiles): adds nullable `encryptedMemberProfilesJson`
+    // column. v3→v4 migration is non-destructive (the column is
+    // nullable and decodes to an empty map at the store boundary), so
+    // existing rows survive — see [GroupDatabaseMigrations.MIGRATION_3_4].
+    version = 4,
     exportSchema = false,
 )
 abstract class GroupDatabase : RoomDatabase() {
     abstract fun groupDao(): GroupDao
+}
+
+/**
+ * Hand-rolled migrations for [GroupDatabase]. Wired into the production
+ * builder in [chat.onym.android.OnymApplication]; the in-memory test
+ * builder skips them entirely (each test starts on the latest schema).
+ */
+object GroupDatabaseMigrations {
+    /**
+     * v3 → v4: introduce `encryptedMemberProfilesJson` (nullable BLOB).
+     * Existing rows decode to an empty map; the column is filled in
+     * the next time the row is rewritten via
+     * [RoomGroupStore.insertOrUpdate].
+     */
+    val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
+        override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE groups ADD COLUMN encryptedMemberProfilesJson BLOB")
+        }
+    }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/MemberProfile.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/MemberProfile.kt
@@ -1,0 +1,45 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * View-facing directory entry for one peer the local user has
+ * interacted with through a group. Carries what the UI needs to
+ * render "X joined" / "you are talking to Y" without crossing into
+ * secret material. Stored on [ChatGroup.memberProfiles] keyed by
+ * the peer's lowercase BLS pubkey hex.
+ *
+ * Distinct from [GovernanceMember]: that's the on-chain Merkle-tree
+ * roster (V1: creator only, static). [MemberProfile] covers the
+ * app-level "who's in this conversation" set, which V1 grows as
+ * joiners are admitted even though the on-chain roster doesn't
+ * change.
+ *
+ * Trust: [alias] is self-asserted by its owner — never load-bearing.
+ * Surfaces should always offer the member's BLS-pubkey fingerprint
+ * alongside (matches the inviter-approval pattern documented on
+ * [JoinRequestPayload]).
+ *
+ * [inboxPublicKey] is the 32-byte X25519 raw pub. Persisted so the
+ * admin (or any authorized fanout sender, in future governance
+ * models) can reach every member's inbox to announce roster changes
+ * without re-deriving from the join request each time.
+ *
+ * Mirrors `MemberProfile.swift` from onym-ios.
+ */
+@Serializable
+data class MemberProfile(
+    val alias: String,
+    @SerialName("inbox_public_key")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val inboxPublicKey: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean = this === other ||
+        (other is MemberProfile &&
+            alias == other.alias &&
+            inboxPublicKey.contentEquals(other.inboxPublicKey))
+
+    override fun hashCode(): Int = 31 * alias.hashCode() + inboxPublicKey.contentHashCode()
+}

--- a/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
@@ -58,6 +58,13 @@ data class PersistedGroup(
     val encryptedSalt: ByteArray,
     val encryptedCommitment: ByteArray? = null,
     val encryptedAdminPubkeyHex: ByteArray? = null,
+    /**
+     * Optional so Room's auto-migration can land an extra column on
+     * existing rows without a wipe. `null` decodes to an empty map at
+     * the [RoomGroupStore] boundary. Stores the encrypted JSON of
+     * `Map<String, MemberProfile>` keyed by lowercase BLS pubkey hex.
+     */
+    val encryptedMemberProfilesJson: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -74,7 +81,8 @@ data class PersistedGroup(
             encryptedMembersJson.contentEquals(other.encryptedMembersJson) &&
             encryptedSalt.contentEquals(other.encryptedSalt) &&
             (encryptedCommitment?.contentEquals(other.encryptedCommitment) ?: (other.encryptedCommitment == null)) &&
-            (encryptedAdminPubkeyHex?.contentEquals(other.encryptedAdminPubkeyHex) ?: (other.encryptedAdminPubkeyHex == null))
+            (encryptedAdminPubkeyHex?.contentEquals(other.encryptedAdminPubkeyHex) ?: (other.encryptedAdminPubkeyHex == null)) &&
+            (encryptedMemberProfilesJson?.contentEquals(other.encryptedMemberProfilesJson) ?: (other.encryptedMemberProfilesJson == null))
     }
 
     override fun hashCode(): Int {
@@ -91,6 +99,7 @@ data class PersistedGroup(
         h = 31 * h + encryptedSalt.contentHashCode()
         h = 31 * h + (encryptedCommitment?.contentHashCode() ?: 0)
         h = 31 * h + (encryptedAdminPubkeyHex?.contentHashCode() ?: 0)
+        h = 31 * h + (encryptedMemberProfilesJson?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 
 /**
@@ -79,6 +81,12 @@ class RoomGroupStore(
 
     private fun encode(group: ChatGroup): PersistedGroup {
         val membersJson = jsonFormat.encodeToString(membersSerializer, group.members)
+        val memberProfilesEncrypted: ByteArray? = if (group.memberProfiles.isEmpty()) {
+            null
+        } else {
+            val json = jsonFormat.encodeToString(memberProfilesSerializer, group.memberProfiles)
+            encryption.encrypt(json.toByteArray(Charsets.UTF_8))
+        }
         return PersistedGroup(
             id = group.id,
             createdAt = group.createdAtMillis,
@@ -95,6 +103,7 @@ class RoomGroupStore(
             encryptedSalt = encryption.encrypt(group.salt),
             encryptedCommitment = group.commitment?.let(encryption::encrypt),
             encryptedAdminPubkeyHex = group.adminPubkeyHex?.let(encryption::encrypt),
+            encryptedMemberProfilesJson = memberProfilesEncrypted,
         )
     }
 
@@ -119,6 +128,19 @@ class RoomGroupStore(
         val groupType = SepGroupType.fromWire(row.groupTypeRaw) ?: return null
         val commitment = row.encryptedCommitment?.let { tryDecrypt(it) }
         val adminPubkeyHex = row.encryptedAdminPubkeyHex?.let { tryDecryptString(it) }
+        val memberProfiles: Map<String, MemberProfile> = row.encryptedMemberProfilesJson
+            ?.let { tryDecrypt(it) }
+            ?.let { bytes ->
+                try {
+                    jsonFormat.decodeFromString(
+                        memberProfilesSerializer,
+                        bytes.toString(Charsets.UTF_8),
+                    )
+                } catch (_: SerializationException) {
+                    emptyMap()
+                }
+            }
+            ?: emptyMap()
 
         return ChatGroup(
             id = row.id,
@@ -126,6 +148,7 @@ class RoomGroupStore(
             groupSecret = groupSecret,
             createdAtMillis = row.createdAt,
             members = members,
+            memberProfiles = memberProfiles,
             // Long → ULong via bit pattern recovers the original
             // 64-bit value. Serializer on SepPublicInputs uses ULong
             // when this round-trips back to JSON.
@@ -151,5 +174,9 @@ class RoomGroupStore(
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true; ignoreUnknownKeys = true }
         private val membersSerializer = ListSerializer(GovernanceMember.serializer())
+        private val memberProfilesSerializer = MapSerializer(
+            String.serializer(),
+            MemberProfile.serializer(),
+        )
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/group/ChatGroupMemberProfilesTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ChatGroupMemberProfilesTest.kt
@@ -1,0 +1,51 @@
+package chat.onym.android.group
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Equality / default-empty contract for [ChatGroup.memberProfiles].
+ *
+ * Mirrors `ChatGroupMemberProfilesTests.swift` from onym-ios.
+ */
+class ChatGroupMemberProfilesTest {
+
+    @Test
+    fun defaultEmptyMap() {
+        val group = makeGroup(memberProfiles = null)
+        assertEquals(emptyMap<String, MemberProfile>(), group.memberProfiles)
+    }
+
+    @Test
+    fun equalityConsidersMemberProfiles() {
+        val a = makeGroup(memberProfiles = mapOf("aa" to MemberProfile("X", ByteArray(32))))
+        val b = makeGroup(memberProfiles = mapOf("aa" to MemberProfile("Y", ByteArray(32))))
+        val c = makeGroup(memberProfiles = mapOf("aa" to MemberProfile("X", ByteArray(32))))
+        assertNotEquals(a, b)
+        assertEquals(a, c)
+        assertEquals(a.hashCode(), c.hashCode())
+    }
+
+    private fun makeGroup(memberProfiles: Map<String, MemberProfile>?): ChatGroup {
+        val args = mutableMapOf<String, Any?>()
+        return ChatGroup(
+            id = "00".repeat(32),
+            name = "g",
+            groupSecret = ByteArray(32),
+            createdAtMillis = 0L,
+            members = emptyList(),
+            memberProfiles = memberProfiles ?: emptyMap(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = null,
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = null,
+            isPublishedOnChain = false,
+            ownerIdentityId = "owner",
+        )
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/MemberProfileTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/MemberProfileTest.kt
@@ -1,0 +1,56 @@
+package chat.onym.android.group
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Round-trip vectors for [MemberProfile]. Cross-checks the snake_case
+ * JSON shape + base64 byte encoding so onym-ios receivers decode
+ * Android-emitted profiles bit-for-bit.
+ *
+ * Mirrors `MemberProfileTests.swift` from onym-ios.
+ */
+class MemberProfileTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun encode_emitsSnakeCaseAndBase64() {
+        val inboxPub = ByteArray(32) { 0xAB.toByte() }
+        val profile = MemberProfile(alias = "Alice", inboxPublicKey = inboxPub)
+
+        val text = json.encodeToString(MemberProfile.serializer(), profile)
+
+        assertTrue("alias literal", text.contains("\"alias\":\"Alice\""))
+        assertTrue(
+            "snake_case key",
+            text.contains("\"inbox_public_key\":\"${Base64.getEncoder().encodeToString(inboxPub)}\""),
+        )
+    }
+
+    @Test
+    fun decode_roundTripsRawBytes() {
+        val inboxPub = ByteArray(32) { (it * 7 and 0xFF).toByte() }
+        val original = MemberProfile(alias = "Bob", inboxPublicKey = inboxPub)
+
+        val text = json.encodeToString(MemberProfile.serializer(), original)
+        val decoded = json.decodeFromString(MemberProfile.serializer(), text)
+
+        assertEquals("Bob", decoded.alias)
+        assertArrayEquals(inboxPub, decoded.inboxPublicKey)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun emptyAlias_roundTrips() {
+        val profile = MemberProfile(alias = "", inboxPublicKey = ByteArray(32))
+        val text = json.encodeToString(MemberProfile.serializer(), profile)
+        val decoded = json.decodeFromString(MemberProfile.serializer(), text)
+        assertEquals("", decoded.alias)
+        assertArrayEquals(ByteArray(32), decoded.inboxPublicKey)
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/RoomGroupStoreTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/RoomGroupStoreTest.kt
@@ -209,6 +209,38 @@ class RoomGroupStoreTest {
         assertEquals(listOf(newer.id, older.id), store.list().map { it.id })
     }
 
+    // ─── memberProfiles ───────────────────────────────────────────
+
+    @Test
+    fun memberProfiles_roundTripsThroughEncryptedColumn() = runTest {
+        val profile = MemberProfile(
+            alias = "Alice",
+            inboxPublicKey = ByteArray(32) { 0x77 },
+        )
+        val group = makeGroup(
+            id = "fa".repeat(32),
+            name = "G",
+            memberProfiles = mapOf("aa".repeat(48) to profile),
+        )
+        store.insertOrUpdate(group)
+
+        val listed = store.list().single()
+        assertEquals(1, listed.memberProfiles.size)
+        val restored = listed.memberProfiles["aa".repeat(48)]!!
+        assertEquals("Alice", restored.alias)
+        assertArrayEquals(profile.inboxPublicKey, restored.inboxPublicKey)
+    }
+
+    @Test
+    fun memberProfiles_emptyMapPersistsAsNullColumn() = runTest {
+        val group = makeGroup(id = "fb".repeat(32), name = "G", memberProfiles = emptyMap())
+        store.insertOrUpdate(group)
+        val raw = db.groupDao().findById(group.id)!!
+        assertNull(raw.encryptedMemberProfilesJson)
+        // Decode side maps null → emptyMap.
+        assertEquals(emptyMap<String, MemberProfile>(), store.list().single().memberProfiles)
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private fun makeGroup(
@@ -216,6 +248,7 @@ class RoomGroupStoreTest {
         name: String,
         adminPubkeyHex: String? = null,
         createdAtMillis: Long = 1_700_000_000_000L,
+        memberProfiles: Map<String, MemberProfile> = emptyMap(),
     ): ChatGroup {
         val member = GovernanceMember(
             publicKeyCompressed = ByteArray(48) { 0x11 },
@@ -227,6 +260,7 @@ class RoomGroupStoreTest {
             groupSecret = ByteArray(32) { 0x33 },
             createdAtMillis = createdAtMillis,
             members = listOf(member),
+            memberProfiles = memberProfiles,
             epoch = 0uL,
             salt = ByteArray(32) { 0x44 },
             commitment = ByteArray(32) { 0x55 },


### PR DESCRIPTION
## Summary

- Add `MemberProfile` (alias + inbox X25519 pubkey) and a per-group `memberProfiles: Map<String, MemberProfile>` directory keyed by lowercase BLS pubkey hex. App-level "who am I talking to" set, distinct from the on-chain `members` Merkle roster.
- Persist the directory via a nullable encrypted column (`encryptedMemberProfilesJson`); v3 → v4 Room migration is non-destructive — existing rows decode to an empty map.
- Seed at create time with a single creator entry across all governance paths.

Foundation PR for the announcement-payload + chat-members-view stack. Mirrors onym-ios PR #75.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `MemberProfileTest` — JSON round-trip with snake_case `inbox_public_key` + base64 bytes
- [ ] `RoomGroupStoreTest.memberProfiles_*` — encrypt/decrypt + null column → empty map
- [ ] `ChatGroupMemberProfilesTest` — equality/hashCode include `memberProfiles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)