### PR TITLE
feat(group): approver UI for incoming join requests

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -53,4 +53,10 @@ class AppDependencies(
      *  Takes the decoded capability so the same factory works for
      *  both `https://onym.chat/join` and `onym://join` intents. */
     val makeJoinViewModel: (chat.onym.android.group.IntroCapability) -> chat.onym.android.group.JoinViewModel,
+    /** Approver UI for incoming join requests. Single shared
+     *  instance — the toolbar badge on the chats screen and the
+     *  modal screen both consume the same flow so a request that
+     *  lands on the relay shows up in the badge before the modal
+     *  is opened. */
+    val approveRequestsViewModel: chat.onym.android.group.ApproveRequestsViewModel,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -382,6 +382,25 @@ class OnymApplication : Application() {
             inboxTransport = inboxTransport,
         )
 
+        // Approver-side: turn raw IntroRequests into UI-renderable
+        // pending requests + ship sealed GroupInvitationPayloads on
+        // user approval. Single instance — the toolbar badge + the
+        // modal screen share state via [ApproveRequestsViewModel].
+        val joinRequestApprover = chat.onym.android.group.JoinRequestApprover(
+            identity = identityRepository,
+            introKeyStore = introKeyStore,
+            introRequestStore = introRequestStore,
+            groupRepository = groupRepository,
+            inboxTransport = inboxTransport,
+            scope = applicationScope,
+        )
+        val approveRequestsViewModel = chat.onym.android.group.ApproveRequestsViewModel(
+            approver = joinRequestApprover,
+        )
+        // Kick the collector at app start so requests landing while
+        // the chats screen isn't open still drive the badge count.
+        approveRequestsViewModel.start()
+
         // App-wide network preference (PR-C follow-up). Defaults to
         // testnet; the Settings → Network → "Use Mainnet" Switch
         // flips it. CreateGroupInteractor reads `current()` per call
@@ -455,6 +474,7 @@ class OnymApplication : Application() {
                     groupRepository = groupRepository,
                 )
             },
+            approveRequestsViewModel = approveRequestsViewModel,
             makeJoinViewModel = { capability ->
                 // Suggest the active identity's display name as the
                 // initial label. Falls back to a generic "Anonymous"

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -162,6 +162,14 @@ fun RootScreen(
                 ChatsScreen(
                     viewModel = vm,
                     onCreateGroup = { navController.navigate(ROUTE_CREATE_GROUP) },
+                    approveRequestsViewModel = dependencies.approveRequestsViewModel,
+                    onOpenApproveRequests = { navController.navigate(ROUTE_APPROVE_REQUESTS) },
+                )
+            }
+            composable(ROUTE_APPROVE_REQUESTS) {
+                chat.onym.android.group.ApproveRequestsScreen(
+                    viewModel = dependencies.approveRequestsViewModel,
+                    onClose = { navController.popBackStack() },
                 )
             }
             composable(Tab.Settings.route) {
@@ -469,4 +477,5 @@ private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
 private const val ROUTE_RUN_RELAYER = "run_relayer"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"
+private const val ROUTE_APPROVE_REQUESTS = "approve_requests"
 private val TAB_ROUTES = setOf(Tab.Chats.route, Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,8 +46,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.runtime.collectAsState
 import chat.onym.android.R
 import chat.onym.android.chain.SepGroupType
+import chat.onym.android.group.ApproveRequestsToolbarBadge
+import chat.onym.android.group.ApproveRequestsViewModel
 import chat.onym.android.group.ChatGroup
 import chat.onym.android.group.OnymAccent
 import chat.onym.android.group.OnymGroupAvatar
@@ -65,14 +73,43 @@ import chat.onym.android.group.OnymGroupAvatar
 fun ChatsScreen(
     viewModel: ChatsViewModel,
     onCreateGroup: () -> Unit,
+    approveRequestsViewModel: ApproveRequestsViewModel? = null,
+    onOpenApproveRequests: (() -> Unit)? = null,
 ) {
     val groups by viewModel.groups.collectAsStateWithLifecycle()
+    val pending by (approveRequestsViewModel?.pending?.collectAsStateWithLifecycle()
+        ?: remember { mutableStateOf(emptyList<chat.onym.android.group.JoinRequestApprover.PendingRequest>()) })
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.chats_title)) },
                 actions = {
+                    if (approveRequestsViewModel != null && onOpenApproveRequests != null) {
+                        Box(modifier = Modifier.padding(end = 4.dp)) {
+                            IconButton(
+                                onClick = onOpenApproveRequests,
+                                modifier = Modifier.testTag("approve_requests.toolbar_button"),
+                            ) {
+                                Icon(
+                                    Icons.Filled.PersonAdd,
+                                    contentDescription = "Join requests",
+                                )
+                            }
+                            // Numeric red-badge overlay anchored top-end
+                            // of the icon button. Mirrors the iOS
+                            // ZStack(.topTrailing) layout.
+                            if (pending.isNotEmpty()) {
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.TopEnd)
+                                        .offset(x = (-4).dp, y = 6.dp),
+                                ) {
+                                    ApproveRequestsToolbarBadge(pending.size)
+                                }
+                            }
+                        }
+                    }
                     // Plus button mirrors Mail / Messages — useful
                     // once the user has at least one chat. Hidden in
                     // the empty state because the central CTA already

--- a/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsScreen.kt
@@ -1,0 +1,321 @@
+package chat.onym.android.group
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Modal surface listing pending join requests with Approve / Decline
+ * actions. Driven by a shared [ApproveRequestsViewModel]. Empty state
+ * is the steady state for users with no outstanding invite links.
+ *
+ * Trust framing: each row shows the joiner's self-asserted alias
+ * alongside the inbox-pubkey hex prefix as an out-of-band fingerprint,
+ * matching the guidance documented on [JoinRequestPayload]. Inviters
+ * who care about provenance can verify the prefix with the joiner over
+ * a side channel before approving.
+ *
+ * Mirrors `ApproveRequestsView.swift` from onym-ios.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApproveRequestsScreen(
+    viewModel: ApproveRequestsViewModel,
+    onClose: () -> Unit,
+) {
+    LaunchedEffect(viewModel) { viewModel.start() }
+
+    val pending by viewModel.pending.collectAsStateWithLifecycle()
+    val lastError by viewModel.lastError.collectAsStateWithLifecycle()
+    val lastSuccess by viewModel.lastSuccessMessage.collectAsStateWithLifecycle()
+    val inFlight by viewModel.inFlight.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Join requests") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onClose,
+                        modifier = Modifier.testTag("approve_requests.close_button"),
+                    ) {
+                        Icon(Icons.Filled.Close, contentDescription = "Close")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            lastSuccess?.let { SuccessBanner(it) }
+            lastError?.let {
+                ErrorBanner(message = it, onDismiss = viewModel::dismissError)
+            }
+            if (pending.isEmpty()) {
+                EmptyState()
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                ) {
+                    items(pending, key = { it.id }) { request ->
+                        RequestCard(
+                            request = request,
+                            inFlight = inFlight.contains(request.id),
+                            onApprove = { viewModel.approve(request.id) },
+                            onDecline = { viewModel.decline(request.id) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuccessBanner(message: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFFE6F7EE))
+            .padding(12.dp)
+            .testTag("approve_requests.success_banner"),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            Icons.Filled.CheckCircle,
+            contentDescription = null,
+            tint = Color(0xFF34C759),
+        )
+        Column {
+            Text("Approved on chain", fontWeight = FontWeight.SemiBold, fontSize = 13.sp)
+            Text(message, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFFFDECEC))
+            .padding(12.dp)
+            .testTag("approve_requests.error_banner"),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            Icons.Filled.Warning,
+            contentDescription = null,
+            tint = Color(0xFFD0011B),
+        )
+        Text(
+            text = message,
+            modifier = Modifier.weight(1f),
+            fontSize = 13.sp,
+        )
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier
+                .size(24.dp)
+                .testTag("approve_requests.error_dismiss"),
+        ) {
+            Icon(Icons.Filled.Close, contentDescription = "Dismiss", modifier = Modifier.size(14.dp))
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("approve_requests.empty"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Filled.Inbox,
+            contentDescription = null,
+            modifier = Modifier.size(44.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(14.dp))
+        Text(
+            "No pending requests",
+            fontSize = 16.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "People who tap one of your invite links show up here.",
+            fontSize = 13.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+    }
+}
+
+@Composable
+private fun RequestCard(
+    request: JoinRequestApprover.PendingRequest,
+    inFlight: Boolean,
+    onApprove: () -> Unit,
+    onDecline: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(14.dp)
+            .testTag("approve_requests.row.${request.id}"),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = displayAlias(request.joinerDisplayLabel),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+            )
+            val groupLabel = request.groupName ?: "Unknown group"
+            Text(
+                text = "wants to join “$groupLabel”",
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                "inbox",
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = hexPrefix(request.joinerInboxPublicKey) + "…",
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = onDecline,
+                enabled = request.groupName != null && !inFlight,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("approve_requests.decline_button.${request.id}"),
+            ) {
+                Text("Decline")
+            }
+            Button(
+                onClick = onApprove,
+                enabled = request.groupName != null && !inFlight,
+                colors = ButtonDefaults.buttonColors(),
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("approve_requests.approve_button.${request.id}"),
+            ) {
+                Text("Approve")
+            }
+        }
+        if (request.groupName == null) {
+            Text(
+                text = "This request is for a group that isn’t on this device. Decline to clear it.",
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun displayAlias(raw: String): String {
+    val trimmed = raw.trim()
+    return if (trimmed.isEmpty()) "(unnamed)" else trimmed
+}
+
+private fun hexPrefix(bytes: ByteArray, count: Int = 8): String {
+    val take = bytes.take(count)
+    val sb = StringBuilder(count * 2)
+    for (b in take) sb.append("%02x".format(b.toInt() and 0xFF))
+    return sb.toString()
+}
+
+/**
+ * Toolbar entry-point — a small icon with a numeric badge when there
+ * are pending requests. Always shown so the surface is discoverable.
+ *
+ * Pure composable; the chats screen owns the modal state.
+ */
+@Composable
+fun ApproveRequestsToolbarBadge(pendingCount: Int) {
+    if (pendingCount > 0) {
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .clip(RoundedCornerShape(50))
+                .background(Color(0xFFD0011B))
+                .testTag("approve_requests.toolbar_badge"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = pendingCount.toString(),
+                color = Color.White,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
@@ -1,0 +1,129 @@
+package chat.onym.android.group
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * View-model for the approver UI. Mirrors `ApproveRequestsFlow.swift`
+ * — one shared instance lives in [chat.onym.android.AppDependencies],
+ * the toolbar badge on the chats screen watches `pending.size`, and
+ * the modal [ApproveRequestsScreen] consumes the full list +
+ * dispatches Approve / Decline taps.
+ *
+ * Purely a thin wrapper over [JoinRequestApprover] — no UI logic
+ * beyond mapping outcomes to a user-facing reason string.
+ *
+ * [start] is idempotent so any composable's `LaunchedEffect` can
+ * call it without double-subscribing.
+ */
+class ApproveRequestsViewModel(
+    private val approver: JoinRequestApproving,
+) : ViewModel() {
+
+    private val _pending = MutableStateFlow<List<JoinRequestApprover.PendingRequest>>(emptyList())
+    val pending: StateFlow<List<JoinRequestApprover.PendingRequest>> = _pending.asStateFlow()
+
+    /** Last failed-approve reason, or null. Cleared on the next
+     *  successful Approve / Decline / dismiss. */
+    private val _lastError = MutableStateFlow<String?>(null)
+    val lastError: StateFlow<String?> = _lastError.asStateFlow()
+
+    /** Brief success banner copy after a `Sent` approval. PR 91 adds
+     *  the auto-dismiss timer + content; PR 76 just exposes the
+     *  field so the screen can render whatever lands here. */
+    private val _lastSuccessMessage = MutableStateFlow<String?>(null)
+    val lastSuccessMessage: StateFlow<String?> = _lastSuccessMessage.asStateFlow()
+
+    /** Request IDs whose Approve / Decline call is currently in
+     *  flight. PR 90 adds the per-row spinner UI; PR 76 maintains
+     *  the state (so debounce works) without rendering it. */
+    private val _inFlight = MutableStateFlow<Set<String>>(emptySet())
+    val inFlight: StateFlow<Set<String>> = _inFlight.asStateFlow()
+
+    private var streamJob: Job? = null
+
+    /** Subscribe to [JoinRequestApprover.pending]. Idempotent — a
+     *  second call replaces the prior collector. */
+    fun start() {
+        if (streamJob != null) return
+        approver.start()
+        streamJob = viewModelScope.launch {
+            approver.pending.collectLatest { snapshot ->
+                _pending.value = snapshot
+            }
+        }
+    }
+
+    fun stop() {
+        streamJob?.cancel()
+        streamJob = null
+    }
+
+    fun isInFlight(requestId: String): Boolean = _inFlight.value.contains(requestId)
+
+    /**
+     * Approve a pending request. Debounced on [_inFlight] so a
+     * rapid double-tap doesn't dispatch twice — entering the proof +
+     * chain submission path twice is wasted cycles + can confuse
+     * `lastError` ordering.
+     */
+    fun approve(requestId: String) {
+        if (_inFlight.value.contains(requestId)) return
+        val joinerAlias = _pending.value.firstOrNull { it.id == requestId }?.joinerDisplayLabel
+        _inFlight.value = _inFlight.value + requestId
+        viewModelScope.launch {
+            val outcome = approver.approve(requestId)
+            _inFlight.value = _inFlight.value - requestId
+            when (outcome) {
+                is JoinRequestApprover.ApproveOutcome.Sent -> {
+                    _lastError.value = null
+                    val trimmed = joinerAlias?.trim().orEmpty()
+                    val label = if (trimmed.isEmpty()) "this person" else trimmed
+                    _lastSuccessMessage.value = "$label is now in the group."
+                }
+                else -> {
+                    _lastSuccessMessage.value = null
+                    _lastError.value = failureReason(outcome)
+                }
+            }
+        }
+    }
+
+    fun decline(requestId: String) {
+        if (_inFlight.value.contains(requestId)) return
+        _inFlight.value = _inFlight.value + requestId
+        viewModelScope.launch {
+            approver.decline(requestId)
+            _inFlight.value = _inFlight.value - requestId
+            _lastError.value = null
+        }
+    }
+
+    fun dismissError() {
+        _lastError.value = null
+    }
+
+    private companion object {
+        /** Translate an approve [JoinRequestApprover.ApproveOutcome]
+         *  into a user-facing reason. PR 76 ships the V1 outcomes
+         *  only; later PRs add Tyranny-anchor branches. Keep the
+         *  mapping local so later prompts only add cases. */
+        fun failureReason(outcome: JoinRequestApprover.ApproveOutcome): String? = when (outcome) {
+            is JoinRequestApprover.ApproveOutcome.Sent -> null
+            is JoinRequestApprover.ApproveOutcome.UnknownGroup ->
+                "This invite isn’t for any group on this device."
+            is JoinRequestApprover.ApproveOutcome.UnknownRequest ->
+                "Request expired or was already handled."
+            is JoinRequestApprover.ApproveOutcome.NoIdentityLoaded ->
+                "Sign in first."
+            is JoinRequestApprover.ApproveOutcome.TransportFailed ->
+                "Couldn’t send: ${outcome.reason}"
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -36,14 +36,28 @@ import kotlinx.serialization.json.Json
  *  4. On Decline → drop the request, revoke the intro key. No
  *     NACK to the joiner; their JoinScreen times out gracefully.
  */
-class JoinRequestApprover(
+/**
+ * Test seam consumed by [ApproveRequestsViewModel]. The production
+ * conformer is [JoinRequestApprover] itself; tests inject a stub
+ * instead of standing up the full keychain + transport stack just to
+ * exercise the VM's bookkeeping. Mirrors `JoinRequestApproving.swift`
+ * from onym-ios.
+ */
+interface JoinRequestApproving {
+    val pending: StateFlow<List<JoinRequestApprover.PendingRequest>>
+    fun start()
+    suspend fun approve(requestId: String): JoinRequestApprover.ApproveOutcome
+    suspend fun decline(requestId: String)
+}
+
+open class JoinRequestApprover(
     private val identity: IdentityRepository,
     private val introKeyStore: IntroKeyStore,
     private val introRequestStore: IntroRequestStore,
     private val groupRepository: GroupRepository,
     private val inboxTransport: InboxTransport,
     private val scope: CoroutineScope,
-) {
+) : JoinRequestApproving {
     /** UI-renderable view of one decrypted, awaiting-action request. */
     data class PendingRequest(
         /** Stable id == [IntroRequest.id]. Approve / Decline use it
@@ -86,7 +100,7 @@ class JoinRequestApprover(
 
     private val mutex = Mutex()
     private val _pending = MutableStateFlow<List<PendingRequest>>(emptyList())
-    val pending: StateFlow<List<PendingRequest>> = _pending.asStateFlow()
+    override val pending: StateFlow<List<PendingRequest>> = _pending.asStateFlow()
 
     /** Internal counter for decrypt failures — drives a future
      *  diagnostic surface (e.g., Settings → Diagnostics shows
@@ -102,7 +116,7 @@ class JoinRequestApprover(
      * in sync. Idempotent — safe to call once at app start. The
      * collector lives for [scope]'s lifetime.
      */
-    fun start() {
+    override fun start() {
         scope.launch {
             introRequestStore.requests.collectLatest { raw ->
                 val decoded = raw.mapNotNull { decode(it) }
@@ -126,7 +140,7 @@ class JoinRequestApprover(
      * ship via Nostr, then revoke the intro slot + drop the
      * pending entry.
      */
-    suspend fun approve(requestId: String): ApproveOutcome = mutex.withLock {
+    override suspend fun approve(requestId: String): ApproveOutcome = mutex.withLock {
         val req = _pending.value.firstOrNull { it.id == requestId }
             ?: return@withLock ApproveOutcome.UnknownRequest
         val activeIdentity = identity.currentIdentity()
@@ -180,7 +194,7 @@ class JoinRequestApprover(
 
     /** Decline a pending request: drop it + revoke the intro slot.
      *  No NACK to the joiner — their JoinScreen times out. */
-    suspend fun decline(requestId: String) = mutex.withLock {
+    override suspend fun decline(requestId: String): Unit = mutex.withLock {
         revokeAndConsume(introPub = findIntroPubFor(requestId), requestId = requestId)
     }
 

--- a/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
@@ -1,0 +1,154 @@
+package chat.onym.android.group
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Behavioral tests for [ApproveRequestsViewModel]. Drives a fake
+ * [JoinRequestApproving] to assert the lifecycle / debounce / outcome
+ * mapping without standing up the keychain + transport stack.
+ *
+ * Mirrors `ApproveRequestsFlowTests.swift` from onym-ios.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ApproveRequestsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun pendingMirrorsApproverFlow() = runTest(dispatcher) {
+        val approver = FakeApprover()
+        val vm = ApproveRequestsViewModel(approver = approver)
+        vm.start()
+        approver.emit(listOf(samplePending("r1")))
+        advanceUntilIdle()
+        assertEquals(1, vm.pending.value.size)
+        assertEquals("r1", vm.pending.value[0].id)
+    }
+
+    @Test
+    fun approveDebouncesSecondCallWhileInFlight() = runTest(dispatcher) {
+        val approver = FakeApprover()
+        val vm = ApproveRequestsViewModel(approver = approver)
+        vm.start()
+        approver.emit(listOf(samplePending("r1")))
+        advanceUntilIdle()
+
+        vm.approve("r1")
+        advanceUntilIdle()
+        assertTrue("first call must be in-flight", vm.inFlight.value.contains("r1"))
+        assertEquals(1, approver.approveCallCount)
+
+        vm.approve("r1")
+        advanceUntilIdle()
+        assertEquals("debounce: still 1", 1, approver.approveCallCount)
+
+        approver.gate.complete(JoinRequestApprover.ApproveOutcome.Sent)
+        advanceUntilIdle()
+        assertTrue("inFlight cleared after completion", !vm.inFlight.value.contains("r1"))
+    }
+
+    @Test
+    fun sentClearsLastError() = runTest(dispatcher) {
+        val approver = FakeApprover()
+        val vm = ApproveRequestsViewModel(approver = approver)
+        vm.start()
+        approver.emit(listOf(samplePending("r1")))
+        advanceUntilIdle()
+
+        // First approve fails — produces an error.
+        approver.gate = CompletableDeferred()
+        vm.approve("r1")
+        advanceUntilIdle()
+        approver.gate.complete(JoinRequestApprover.ApproveOutcome.TransportFailed("boom"))
+        advanceUntilIdle()
+        assertEquals("Couldn’t send: boom", vm.lastError.value)
+
+        // Second approve succeeds — clears the error.
+        approver.gate = CompletableDeferred()
+        vm.approve("r1")
+        advanceUntilIdle()
+        approver.gate.complete(JoinRequestApprover.ApproveOutcome.Sent)
+        advanceUntilIdle()
+        assertNull(vm.lastError.value)
+        assertNotNull(vm.lastSuccessMessage.value)
+    }
+
+    @Test
+    fun transportFailedFormatsAsCouldntSend() = runTest(dispatcher) {
+        val approver = FakeApprover()
+        val vm = ApproveRequestsViewModel(approver = approver)
+        vm.start()
+        approver.emit(listOf(samplePending("r1")))
+        advanceUntilIdle()
+
+        approver.gate = CompletableDeferred()
+        vm.approve("r1")
+        advanceUntilIdle()
+        approver.gate.complete(JoinRequestApprover.ApproveOutcome.TransportFailed("relays down"))
+        advanceUntilIdle()
+        assertEquals("Couldn’t send: relays down", vm.lastError.value)
+    }
+
+    private fun samplePending(id: String) = JoinRequestApprover.PendingRequest(
+        id = id,
+        joinerInboxPublicKey = ByteArray(32),
+        joinerDisplayLabel = "Bob",
+        groupId = ByteArray(32),
+        groupName = "Family",
+    )
+}
+
+/**
+ * In-test [JoinRequestApproving] driver. Tests script the approver
+ * behavior via [emit] (drives the `pending` flow) and [gate] (controls
+ * when an approve call returns + with what outcome).
+ */
+private class FakeApprover : JoinRequestApproving {
+    private val pendingState = MutableStateFlow<List<JoinRequestApprover.PendingRequest>>(emptyList())
+    override val pending: StateFlow<List<JoinRequestApprover.PendingRequest>> =
+        pendingState.asStateFlow()
+
+    var approveCallCount: Int = 0
+        private set
+    var gate: CompletableDeferred<JoinRequestApprover.ApproveOutcome> = CompletableDeferred()
+
+    override fun start() { /* no-op — pending is driven by the test */ }
+
+    override suspend fun approve(requestId: String): JoinRequestApprover.ApproveOutcome {
+        approveCallCount += 1
+        return gate.await()
+    }
+
+    override suspend fun decline(requestId: String) { /* no-op */ }
+
+    fun emit(snapshot: List<JoinRequestApprover.PendingRequest>) {
+        pendingState.value = snapshot
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ApproveRequestsViewModel` + `ApproveRequestsScreen` (modal). Driven by a new `JoinRequestApproving` seam so tests can inject a fake.
- Toolbar entry-point on the chats screen with a numeric red-badge when there are pending requests. Always shown for discoverability.
- Wire a single shared `ApproveRequestsViewModel` instance through `AppDependencies` so the badge + modal share state.
- Maintain `inFlight: Set<String>` and a `failureReason(...)` mapper so later PRs (90 / 91) can render the spinner UI + auto-dismiss success banner without refactoring.

Stacked on `group/member-profile` (PR #95). Mirrors onym-ios PR #76.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `ApproveRequestsViewModelTest` covers debounce, Sent clears lastError, TransportFailed → "Couldn’t send: …"
- [ ] testTags reachable: `approve_requests.toolbar_button`, `approve_requests.toolbar_badge`, `approve_requests.row.{id}`, `approve_requests.approve_button.{id}`, `approve_requests.decline_button.{id}`, `approve_requests.empty`, `approve_requests.error_banner`, `approve_requests.error_dismiss`, `approve_requests.success_banner`, `approve_requests.close_button`

🤖 Generated with [Claude Code](https://claude.com/claude-code)