### PR TITLE
feat(group): add MemberAnnouncementPayload wire format

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/MemberAnnouncementPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/MemberAnnouncementPayload.kt
@@ -1,0 +1,155 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Plaintext payload that the admin seals (via
+ * `IdentityRepository.sealInvitation`, X25519 + AES-GCM, signed by
+ * the admin's Ed25519 stellar key) and ships to every existing
+ * member's inbox after they Approve a join request. Tells receivers
+ * "this person just joined the group — append them to your local
+ * roster".
+ *
+ * Sits alongside [GroupInvitationPayload]:
+ *   - [GroupInvitationPayload] is the joiner's first taste of a
+ *     group — full state needed to render messages.
+ *   - [MemberAnnouncementPayload] is incremental — existing members
+ *     already know the group, they just need to learn about one new
+ *     entry in the roster.
+ *
+ * ## Trust
+ *
+ * `newMember.alias` and [adminAlias] are self-asserted. Receivers
+ * that care about provenance should display the BLS-pubkey
+ * fingerprint alongside (matches the inviter-approval guidance on
+ * [JoinRequestPayload]). The OUTER `SealedEnvelope` carries the
+ * admin's Ed25519 signature over the ephemeral key — receivers MUST
+ * cross-check `senderEd25519PublicKey` against the group's stored
+ * `adminEd25519PubkeyHex` (PR 84) before mutating local state. That
+ * signature check lives in the dispatcher, not here — this type is
+ * a pure value carrier.
+ *
+ * ## Versioning
+ *
+ * `version = 1` is the only shape receivers handle today. Future
+ * fields land via nullable defaults so older builds round-trip
+ * unknown announcements as best-effort.
+ *
+ * ## Cross-platform parity
+ *
+ * Wire format authored on iOS first; this Kotlin twin mirrors the
+ * snake_case keys + base64 [ByteArray] encoding (Swift `JSONEncoder`'s
+ * `.base64` default + Kotlin's `Base64.getEncoder()` produce the
+ * same bytes).
+ *
+ * Mirrors `MemberAnnouncementPayload.swift` from onym-ios PR #77.
+ */
+@Serializable
+data class MemberAnnouncementPayload(
+    val version: Int,
+    /** 32-byte group ID — receivers cross-check against their
+     *  local [ChatGroup.groupIdBytes] to refuse announcements for
+     *  groups they don't know about. */
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    @SerialName("new_member")
+    val newMember: AnnouncedMember,
+    /** Admin's user-visible alias at send time. Carried alongside
+     *  the announcement so the receiver can render "Y admitted X"
+     *  without needing a prior alias map keyed by admin pubkey. */
+    @SerialName("admin_alias")
+    val adminAlias: String,
+    /**
+     * 32-byte Poseidon commitment of the new tree (post-admit).
+     * PR 88 (admin side) fills this; PR 89 (receiver side) verifies
+     * it against the on-chain commitment. Optional on the wire —
+     * pre-PR-88 senders ship without it. Receivers running PR 89+
+     * MUST reject Tyranny announcements missing this field.
+     */
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val commitment: ByteArray? = null,
+    /** New epoch number after the on-chain `update_commitment`
+     *  (i.e. `epoch_old + 1`). Optional for the same reason as
+     *  [commitment]. */
+    val epoch: ULong? = null,
+) {
+    /**
+     * One member's directory entry. App-level only — the
+     * cryptographic Poseidon leaf hash is intentionally absent.
+     * V1 group rosters are static on-chain (the joiner is not yet
+     * a member of the Merkle tree), so the leaf hash is meaningless
+     * to ship today. When on-chain joiner ceremonies land, a
+     * `leaf_hash` field can return via a nullable default without
+     * breaking older receivers.
+     *
+     * [blsPub] is still carried as the **stable cross-device
+     * identifier**: HKDF-derived from the joiner's identity secret,
+     * persisted across recovery-phrase restores, and forms the
+     * dedup key in [ChatGroup.memberProfiles].
+     */
+    @Serializable
+    data class AnnouncedMember(
+        @SerialName("bls_pub")
+        @Serializable(with = Base64ByteArraySerializer::class)
+        val blsPub: ByteArray,
+        @SerialName("inbox_pub")
+        @Serializable(with = Base64ByteArraySerializer::class)
+        val inboxPub: ByteArray,
+        val alias: String,
+    ) {
+        init {
+            require(blsPub.size == 48) {
+                "blsPub: expected 48 bytes, got ${blsPub.size}"
+            }
+            require(inboxPub.size == 32) {
+                "inboxPub: expected 32 bytes, got ${inboxPub.size}"
+            }
+        }
+
+        override fun equals(other: Any?): Boolean = this === other ||
+            (other is AnnouncedMember &&
+                blsPub.contentEquals(other.blsPub) &&
+                inboxPub.contentEquals(other.inboxPub) &&
+                alias == other.alias)
+
+        override fun hashCode(): Int {
+            var h = blsPub.contentHashCode()
+            h = 31 * h + inboxPub.contentHashCode()
+            h = 31 * h + alias.hashCode()
+            return h
+        }
+    }
+
+    init {
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+        commitment?.let {
+            require(it.size == 32) {
+                "commitment: expected 32 bytes, got ${it.size}"
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other ||
+        (other is MemberAnnouncementPayload &&
+            version == other.version &&
+            groupId.contentEquals(other.groupId) &&
+            newMember == other.newMember &&
+            adminAlias == other.adminAlias &&
+            (commitment?.contentEquals(other.commitment) ?: (other.commitment == null)) &&
+            epoch == other.epoch)
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + newMember.hashCode()
+        h = 31 * h + adminAlias.hashCode()
+        h = 31 * h + (commitment?.contentHashCode() ?: 0)
+        h = 31 * h + (epoch?.hashCode() ?: 0)
+        return h
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/group/MemberAnnouncementPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/MemberAnnouncementPayloadTest.kt
@@ -1,0 +1,157 @@
+package chat.onym.android.group
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Round-trip vectors for [MemberAnnouncementPayload]. Cross-checks
+ * the snake_case JSON shape + base64 byte encoding so the iOS
+ * receiver decodes Android-emitted announcements bit-for-bit.
+ *
+ * Mirrors `MemberAnnouncementPayloadTests.swift` from onym-ios.
+ */
+class MemberAnnouncementPayloadTest {
+
+    private val json = Json { encodeDefaults = false; ignoreUnknownKeys = true }
+
+    private val groupId = ByteArray(32) { 0xAA.toByte() }
+    private val blsPub = ByteArray(48) { 0xBB.toByte() }
+    private val inboxPub = ByteArray(32) { 0xCC.toByte() }
+
+    @Test
+    fun decode_v1WithoutCommitment() {
+        val text = """
+            {
+              "version": 1,
+              "group_id": "${b64(groupId)}",
+              "new_member": {
+                "bls_pub": "${b64(blsPub)}",
+                "inbox_pub": "${b64(inboxPub)}",
+                "alias": "Bob"
+              },
+              "admin_alias": "Alice"
+            }
+        """.trimIndent()
+
+        val decoded = json.decodeFromString(MemberAnnouncementPayload.serializer(), text)
+
+        assertEquals(1, decoded.version)
+        assertArrayEquals(groupId, decoded.groupId)
+        assertArrayEquals(blsPub, decoded.newMember.blsPub)
+        assertArrayEquals(inboxPub, decoded.newMember.inboxPub)
+        assertEquals("Bob", decoded.newMember.alias)
+        assertEquals("Alice", decoded.adminAlias)
+        assertNull(decoded.commitment)
+        assertNull(decoded.epoch)
+    }
+
+    @Test
+    fun decode_v1WithCommitmentAndEpoch() {
+        val commitment = ByteArray(32) { 0xDD.toByte() }
+        val text = """
+            {
+              "version": 1,
+              "group_id": "${b64(groupId)}",
+              "new_member": {
+                "bls_pub": "${b64(blsPub)}",
+                "inbox_pub": "${b64(inboxPub)}",
+                "alias": "Bob"
+              },
+              "admin_alias": "Alice",
+              "commitment": "${b64(commitment)}",
+              "epoch": 7
+            }
+        """.trimIndent()
+
+        val decoded = json.decodeFromString(MemberAnnouncementPayload.serializer(), text)
+        assertArrayEquals(commitment, decoded.commitment)
+        assertEquals(7uL, decoded.epoch)
+    }
+
+    @Test
+    fun encode_omitsNullOptionalsWhenNotSet() {
+        val payload = MemberAnnouncementPayload(
+            version = 1,
+            groupId = groupId,
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = blsPub, inboxPub = inboxPub, alias = "Bob",
+            ),
+            adminAlias = "Alice",
+        )
+        val text = json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+        assertTrue("snake_case key", text.contains("\"group_id\":"))
+        assertTrue("snake_case bls", text.contains("\"bls_pub\":"))
+        assertTrue("commitment omitted", !text.contains("\"commitment\""))
+        assertTrue("epoch omitted", !text.contains("\"epoch\""))
+    }
+
+    @Test
+    fun roundTrip_preservesAllFields() {
+        val commitment = ByteArray(32) { 0xEE.toByte() }
+        val original = MemberAnnouncementPayload(
+            version = 1,
+            groupId = groupId,
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = blsPub, inboxPub = inboxPub, alias = "Bob",
+            ),
+            adminAlias = "Alice",
+            commitment = commitment,
+            epoch = 42uL,
+        )
+        val text = json.encodeToString(MemberAnnouncementPayload.serializer(), original)
+        val decoded = json.decodeFromString(MemberAnnouncementPayload.serializer(), text)
+        assertEquals(original, decoded)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsGroupIdOfWrongLength() {
+        MemberAnnouncementPayload(
+            version = 1,
+            groupId = ByteArray(31),
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = blsPub, inboxPub = inboxPub, alias = "Bob",
+            ),
+            adminAlias = "",
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsBlsPubOfWrongLength() {
+        MemberAnnouncementPayload.AnnouncedMember(
+            blsPub = ByteArray(47), inboxPub = inboxPub, alias = "Bob",
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsInboxPubOfWrongLength() {
+        MemberAnnouncementPayload.AnnouncedMember(
+            blsPub = blsPub, inboxPub = ByteArray(33), alias = "Bob",
+        )
+    }
+
+    @Test
+    fun ignoresUnknownFields() {
+        val text = """
+            {
+              "version": 1,
+              "group_id": "${b64(groupId)}",
+              "new_member": {
+                "bls_pub": "${b64(blsPub)}",
+                "inbox_pub": "${b64(inboxPub)}",
+                "alias": "Bob"
+              },
+              "admin_alias": "Alice",
+              "future_field_we_do_not_know": 99
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(MemberAnnouncementPayload.serializer(), text)
+        assertEquals("Alice", decoded.adminAlias)
+    }
+
+    private fun b64(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
+}


### PR DESCRIPTION
## Summary

- New `@Serializable data class MemberAnnouncementPayload` plus nested `AnnouncedMember`. Snake_case JSON keys + base64 ByteArrays so it's byte-equivalent with onym-ios.
- `commitment` + `epoch` are optional today; PRs 88 / 89 fill them in for the on-chain anchor flow. Pre-PR-88 senders ship without them and receivers stay best-effort until PR 89.
- `init` validation throws on malformed byte lengths.

Stacked on `group/approver-ui` (PR #96). Mirrors onym-ios PR #77.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `MemberAnnouncementPayloadTest` covers decode-with/without optionals, encode omits nulls, byte-length validation throws, unknown fields are tolerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)