### PR TITLE
feat(group): admin records joiner profile + BLS pubkey on approve

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -64,6 +64,12 @@ open class JoinRequestApprover(
          *  as the dedupe key. */
         val id: String,
         val joinerInboxPublicKey: ByteArray,
+        /** 48-byte BLS pubkey when the joiner sent it (post-PR-78
+         *  builds always do). `null` when the request came from a
+         *  pre-PR-78 client; the approver still ships the invitation
+         *  back, but skips the local roster update because there's
+         *  no stable cross-device key to record under. */
+        val joinerBlsPublicKey: ByteArray?,
         val joinerDisplayLabel: String,
         val groupId: ByteArray,
         /** Looked up from the local [GroupRepository]. Null if the
@@ -76,6 +82,8 @@ open class JoinRequestApprover(
             (other is PendingRequest &&
                 id == other.id &&
                 joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
+                (joinerBlsPublicKey?.contentEquals(other.joinerBlsPublicKey)
+                    ?: (other.joinerBlsPublicKey == null)) &&
                 joinerDisplayLabel == other.joinerDisplayLabel &&
                 groupId.contentEquals(other.groupId) &&
                 groupName == other.groupName)
@@ -83,6 +91,7 @@ open class JoinRequestApprover(
         override fun hashCode(): Int {
             var h = id.hashCode()
             h = 31 * h + joinerInboxPublicKey.contentHashCode()
+            h = 31 * h + (joinerBlsPublicKey?.contentHashCode() ?: 0)
             h = 31 * h + joinerDisplayLabel.hashCode()
             h = 31 * h + groupId.contentHashCode()
             h = 31 * h + (groupName?.hashCode() ?: 0)
@@ -184,12 +193,47 @@ open class JoinRequestApprover(
             return@withLock ApproveOutcome.TransportFailed("no relay accepted the invitation")
         }
 
+        // Record the joiner in the local group's view-facing roster
+        // (alias / inbox-pub) so the admin sees them by alias in the
+        // UI. Skipped when the joiner shipped a pre-PR-78 request —
+        // no stable cross-device key under which to record.
+        val blsPub = req.joinerBlsPublicKey
+        if (blsPub != null) {
+            recordJoiner(
+                group = group,
+                blsPub = blsPub,
+                inboxPub = req.joinerInboxPublicKey,
+                alias = req.joinerDisplayLabel,
+            )
+        }
+
         // Best-effort cleanup. Both calls run regardless of failures
         // because the request is conceptually consumed at this point;
         // a leaked intro key is benign (sender ignores future
         // requests on it via UnknownGroup or just not approving).
         revokeAndConsume(introPub = findIntroPubFor(requestId), requestId = requestId)
         ApproveOutcome.Sent
+    }
+
+    /**
+     * Insert / update the joiner's [MemberProfile] on the local
+     * group. Idempotent — re-approving for the same `(blsPub, group)`
+     * overwrites the entry (alias, inbox-pub) rather than minting a
+     * duplicate. Goes through [GroupRepository.insert] which
+     * delegates to [RoomGroupStore.insertOrUpdate].
+     */
+    private suspend fun recordJoiner(
+        group: ChatGroup,
+        blsPub: ByteArray,
+        inboxPub: ByteArray,
+        alias: String,
+    ) {
+        val key = blsPub.toHexLowercase()
+        val updated = group.copy(
+            memberProfiles = group.memberProfiles +
+                (key to MemberProfile(alias = alias, inboxPublicKey = inboxPub)),
+        )
+        groupRepository.insert(updated)
     }
 
     /** Decline a pending request: drop it + revoke the intro slot.
@@ -243,6 +287,7 @@ open class JoinRequestApprover(
         return PendingRequest(
             id = raw.id,
             joinerInboxPublicKey = payload.joinerInboxPublicKey,
+            joinerBlsPublicKey = payload.joinerBlsPublicKey,
             joinerDisplayLabel = payload.joinerDisplayLabel,
             groupId = payload.groupId,
             groupName = groupName,
@@ -264,5 +309,13 @@ open class JoinRequestApprover(
 
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+        /** Lowercase hex of a [ByteArray]. Lives here so the
+         *  approver doesn't have to import the persistence /
+         *  transport layer's privates. Mirrors the
+         *  `String(format: "%02x", $0)` map used on iOS. */
+        fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+            for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+        }
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
@@ -30,6 +30,20 @@ data class JoinRequestPayload(
     @SerialName("joiner_inbox_pub")
     @Serializable(with = Base64ByteArraySerializer::class)
     val joinerInboxPublicKey: ByteArray,
+    /**
+     * 48-byte arkworks-compressed BLS12-381 G1 pubkey. Optional —
+     * pre-PR-78 joiners shipped requests without it. The admin uses
+     * this as the **stable cross-device key** under which to record
+     * the joiner in [ChatGroup.memberProfiles] (and, post-PR-88, as
+     * the joiner's on-chain Merkle leaf input).
+     *
+     * Default null so older joiners' wire payloads still decode. The
+     * approver short-circuits the local-roster mutation (and the
+     * Tyranny anchor flow, post-PR-88) when this is missing.
+     */
+    @SerialName("joiner_bls_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val joinerBlsPublicKey: ByteArray? = null,
     @SerialName("joiner_display_label")
     val joinerDisplayLabel: String,
     @SerialName("group_id")
@@ -40,6 +54,11 @@ data class JoinRequestPayload(
         require(joinerInboxPublicKey.size == 32) {
             "joinerInboxPublicKey: expected 32 bytes, got ${joinerInboxPublicKey.size}"
         }
+        joinerBlsPublicKey?.let {
+            require(it.size == 48) {
+                "joinerBlsPublicKey: expected 48 bytes, got ${it.size}"
+            }
+        }
         require(groupId.size == 32) {
             "groupId: expected 32 bytes, got ${groupId.size}"
         }
@@ -49,12 +68,15 @@ data class JoinRequestPayload(
         if (this === other) return true
         if (other !is JoinRequestPayload) return false
         return joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
+            (joinerBlsPublicKey?.contentEquals(other.joinerBlsPublicKey)
+                ?: (other.joinerBlsPublicKey == null)) &&
             joinerDisplayLabel == other.joinerDisplayLabel &&
             groupId.contentEquals(other.groupId)
     }
 
     override fun hashCode(): Int {
         var h = joinerInboxPublicKey.contentHashCode()
+        h = 31 * h + (joinerBlsPublicKey?.contentHashCode() ?: 0)
         h = 31 * h + joinerDisplayLabel.hashCode()
         h = 31 * h + groupId.contentHashCode()
         return h

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
@@ -49,6 +49,10 @@ class JoinRequestSender(
         val activeIdentity = identity.currentIdentity() ?: return@withContext Outcome.NoIdentityLoaded()
         val payload = JoinRequestPayload(
             joinerInboxPublicKey = activeIdentity.inboxPublicKey,
+            // Stable cross-device identifier — the admin keys the
+            // joiner into the local roster under this. Pre-PR-78
+            // joiners shipped without it; post-PR-78 ships it always.
+            joinerBlsPublicKey = activeIdentity.blsPublicKey,
             joinerDisplayLabel = joinerDisplayLabel,
             groupId = capability.groupId,
         )

--- a/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
@@ -119,6 +119,7 @@ class ApproveRequestsViewModelTest {
     private fun samplePending(id: String) = JoinRequestApprover.PendingRequest(
         id = id,
         joinerInboxPublicKey = ByteArray(32),
+        joinerBlsPublicKey = null,
         joinerDisplayLabel = "Bob",
         groupId = ByteArray(32),
         groupName = "Family",

--- a/app/src/test/kotlin/chat/onym/android/group/JoinRequestPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/JoinRequestPayloadTest.kt
@@ -45,6 +45,48 @@ class JoinRequestPayloadTest {
     }
 
     @Test
+    fun decodes_pre_pr78_payload_without_joiner_bls_pub() {
+        // Pre-PR-78 joiner — no joiner_bls_pub field. Must still decode.
+        val text = """
+            {
+              "joiner_inbox_pub": "${java.util.Base64.getEncoder().encodeToString(ByteArray(32))}",
+              "joiner_display_label": "Alice",
+              "group_id": "${java.util.Base64.getEncoder().encodeToString(ByteArray(32))}"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(JoinRequestPayload.serializer(), text)
+        assertEquals(null, decoded.joinerBlsPublicKey)
+        assertEquals("Alice", decoded.joinerDisplayLabel)
+    }
+
+    @Test
+    fun decodes_post_pr78_payload_with_joiner_bls_pub() {
+        val bls = ByteArray(48) { 0xBB.toByte() }
+        val text = """
+            {
+              "joiner_inbox_pub": "${java.util.Base64.getEncoder().encodeToString(ByteArray(32))}",
+              "joiner_bls_pub": "${java.util.Base64.getEncoder().encodeToString(bls)}",
+              "joiner_display_label": "Alice",
+              "group_id": "${java.util.Base64.getEncoder().encodeToString(ByteArray(32))}"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(JoinRequestPayload.serializer(), text)
+        assertEquals(48, decoded.joinerBlsPublicKey!!.size)
+    }
+
+    @Test
+    fun constructor_rejectsWrongSizedBlsKey() {
+        assertThrows(IllegalArgumentException::class.java) {
+            JoinRequestPayload(
+                joinerInboxPublicKey = ByteArray(32),
+                joinerBlsPublicKey = ByteArray(47),
+                joinerDisplayLabel = "x",
+                groupId = ByteArray(32),
+            )
+        }
+    }
+
+    @Test
     fun constructor_rejectsWrongSizedKeys() {
         assertThrows(IllegalArgumentException::class.java) {
             JoinRequestPayload(


### PR DESCRIPTION
## Summary

- Extend `JoinRequestPayload` with optional `joiner_bls_pub` (48 bytes, nullable so older joiners still decode).
- Sender now ships the active identity's BLS pub.
- `JoinRequestApprover.PendingRequest` carries it through; after a successful send the admin records `(blsHex → MemberProfile(alias, inboxPub))` in the local group's directory. Idempotent.

Stacked on `group/member-announcement-payload` (PR #97). Mirrors onym-ios PR #78.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `JoinRequestPayloadTest.decodes_pre_pr78_payload_without_joiner_bls_pub` — old wire format still decodes
- [ ] `JoinRequestPayloadTest.decodes_post_pr78_payload_with_joiner_bls_pub` — new wire format decodes
- [ ] Constructor validates 48-byte length

🤖 Generated with [Claude Code](https://claude.com/claude-code)