### PR TITLE
feat(inbox): receive-side dispatcher for member announcements

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -317,9 +317,19 @@ class OnymApplication : Application() {
             scope = applicationScope,
         )
         invitationsRepository.start()
+        // PR 80: receive-side dispatcher routes MemberAnnouncementPayload
+        // straight into local group state instead of queueing it as a
+        // raw invitation. Falls through to the legacy queue for anything
+        // else.
+        val incomingDispatcher = chat.onym.android.inbox.IncomingMessageDispatcher(
+            envelopeDecrypter = identityRepository,
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
         val invitationsInteractor = chat.onym.android.inbox.IncomingInvitationsInteractor(
             inboxTransport = inboxTransport,
             repository = invitationsRepository,
+            dispatcher = incomingDispatcher,
         )
         applicationScope.launch {
             invitationsInteractor.runFanout(

--- a/app/src/main/kotlin/chat/onym/android/identity/DecryptedEnvelope.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/DecryptedEnvelope.kt
@@ -1,0 +1,36 @@
+package chat.onym.android.identity
+
+/**
+ * Output of [InvitationEnvelopeDecrypter.decryptInvitationWithSender].
+ * Bundles the inner plaintext with the Ed25519 pubkey that signed
+ * the outer [SealedEnvelope] — receivers that need to authenticate
+ * the sender (e.g. the admin-Ed25519 trust check on a
+ * `MemberAnnouncementPayload`) read both at the same time without
+ * re-decoding the envelope.
+ *
+ * [senderEd25519PublicKey] is `null` when the envelope shipped
+ * without a `sender_ed25519_public_key` block. That's allowed by
+ * the wire format (the signature block is optional), so callers
+ * that require provenance MUST treat `null` as "no proof of sender"
+ * and refuse to act on the plaintext as if it were authenticated.
+ *
+ * Mirrors `DecryptedEnvelope.swift` from onym-ios.
+ */
+data class DecryptedEnvelope(
+    val plaintext: ByteArray,
+    /** 32-byte raw Ed25519 pubkey, or `null` when the envelope
+     *  didn't include a signature block. */
+    val senderEd25519PublicKey: ByteArray?,
+) {
+    override fun equals(other: Any?): Boolean = this === other ||
+        (other is DecryptedEnvelope &&
+            plaintext.contentEquals(other.plaintext) &&
+            (senderEd25519PublicKey?.contentEquals(other.senderEd25519PublicKey)
+                ?: (other.senderEd25519PublicKey == null)))
+
+    override fun hashCode(): Int {
+        var h = plaintext.contentHashCode()
+        h = 31 * h + (senderEd25519PublicKey?.contentHashCode() ?: 0)
+        return h
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/IdentityRepository.kt
@@ -377,6 +377,17 @@ class IdentityRepository(
         decryptInvitationLocked(snapshot, envelopeBytes)
     }
 
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = withContext(ioDispatcher) {
+        val snapshot = store.load(asIdentity) ?: throw InvitationDecryptError.IdentityNotLoaded
+        decryptSealedEnvelopeWithKeyAndSender(
+            envelopeBytes = envelopeBytes,
+            recipientX25519PrivateKey = inboxKeyAgreementPrivateKey(snapshot.nostrSecretKey).encoded,
+        )
+    }
+
     private fun decryptInvitationLocked(
         snapshot: StoredSnapshot,
         envelopeBytes: ByteArray,
@@ -588,6 +599,29 @@ class IdentityRepository(
          * Throws [InvitationDecryptError]; never raw `javax.crypto`
          * / `kotlinx.serialization` exceptions.
          */
+        /**
+         * Same as [decryptSealedEnvelopeWithKey] but returns both
+         * the plaintext and the envelope's sender Ed25519 pubkey
+         * (when present). Used by the inbox dispatcher (PR 80) so
+         * the admin-Ed25519 trust check on
+         * `MemberAnnouncementPayload` can authenticate the sender
+         * without re-parsing the envelope.
+         */
+        fun decryptSealedEnvelopeWithKeyAndSender(
+            envelopeBytes: ByteArray,
+            recipientX25519PrivateKey: ByteArray,
+        ): DecryptedEnvelope {
+            require(recipientX25519PrivateKey.size == 32) {
+                "recipient X25519 priv: expected 32 bytes, got ${recipientX25519PrivateKey.size}"
+            }
+            val envelope = parseEnvelope(envelopeBytes)
+            val plaintext = openEnvelope(envelope, recipientX25519PrivateKey)
+            return DecryptedEnvelope(
+                plaintext = plaintext,
+                senderEd25519PublicKey = envelope.senderEd25519PublicKey,
+            )
+        }
+
         fun decryptSealedEnvelopeWithKey(
             envelopeBytes: ByteArray,
             recipientX25519PrivateKey: ByteArray,
@@ -595,6 +629,11 @@ class IdentityRepository(
             require(recipientX25519PrivateKey.size == 32) {
                 "recipient X25519 priv: expected 32 bytes, got ${recipientX25519PrivateKey.size}"
             }
+            val envelope = parseEnvelope(envelopeBytes)
+            return openEnvelope(envelope, recipientX25519PrivateKey)
+        }
+
+        private fun parseEnvelope(envelopeBytes: ByteArray): SealedEnvelope {
             val envelope = try {
                 envelopeJsonFormat.decodeFromString<SealedEnvelope>(
                     envelopeBytes.toString(Charsets.UTF_8)
@@ -625,6 +664,15 @@ class IdentityRepository(
                     throw InvitationDecryptError.SignatureFailed
                 }
             }
+            return envelope
+        }
+
+        private fun openEnvelope(
+            envelope: SealedEnvelope,
+            recipientX25519PrivateKey: ByteArray,
+        ): ByteArray {
+            val ephemeralPub = envelope.ephemeralPublicKey
+                ?: throw InvitationDecryptError.MissingEphemeralKey
 
             // ECDH against the recipient's X25519 private.
             val recipientPriv = X25519PrivateKeyParameters(recipientX25519PrivateKey, 0)

--- a/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
+++ b/app/src/main/kotlin/chat/onym/android/identity/InvitationEnvelopeDecrypter.kt
@@ -43,6 +43,25 @@ interface InvitationEnvelopeDecrypter {
      *         classify with a `when (e: InvitationDecryptError)`.
      */
     suspend fun decryptInvitation(envelopeBytes: ByteArray, asIdentity: IdentityId): ByteArray
+
+    /**
+     * Same as [decryptInvitation] but also surfaces the sealed
+     * envelope's `sender_ed25519_public_key` block so callers that
+     * need provenance can authenticate the sender without re-parsing.
+     *
+     * The receive-side dispatcher (PR 80) reads both at the same
+     * hop: the plaintext routes to the right fast-path decoder, the
+     * sender pubkey gates `MemberAnnouncementPayload` against the
+     * group's stored admin Ed25519 (PR 84).
+     *
+     * `senderEd25519PublicKey == null` is allowed by the wire format
+     * — callers that require authenticated provenance MUST refuse
+     * to act on the plaintext when it's null.
+     */
+    suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope
 }
 
 /**

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingInvitationsInteractor.kt
@@ -32,13 +32,26 @@ import kotlinx.coroutines.launch
 class IncomingInvitationsInteractor(
     private val inboxTransport: InboxTransport,
     private val repository: IncomingInvitationsRepository,
+    /**
+     * Optional receive-side dispatcher (PR 80+). When set, every
+     * inbound message is handed to the dispatcher before falling
+     * back to the legacy invitations queue. The dispatcher decrypts
+     * once at receive time + routes:
+     *  - `MemberAnnouncementPayload` → applied to the local group.
+     *  - `GroupInvitationPayload` → materialized into a new group (PR 83).
+     *  - Anything else → falls through into [repository.recordIncoming].
+     *
+     * Null preserves pre-PR-80 behavior (always queue).
+     */
+    private val dispatcher: IncomingMessageDispatcher? = null,
 ) {
 
     /**
      * Subscribe to [inbox] and forward each delivered message into
-     * the repository, stamping each record with [ownerIdentityId]
-     * so PR-6's per-identity decrypt path can route to the right
-     * X25519 private key.
+     * the dispatcher (when wired) or directly into the repository.
+     * Each record is stamped with [ownerIdentityId] so the
+     * per-identity decrypt path can route to the right X25519
+     * private key.
      *
      * Suspends for the lifetime of the subscription; cancellation
      * of the calling scope unsubscribes upstream (production
@@ -47,12 +60,21 @@ class IncomingInvitationsInteractor(
      */
     suspend fun run(inbox: TransportInboxId, ownerIdentityId: IdentityId) {
         inboxTransport.subscribe(inbox).collect { inbound ->
-            repository.recordIncoming(
-                id = inbound.messageId,
-                payload = inbound.payload,
-                receivedAt = inbound.receivedAt,
-                ownerIdentityId = ownerIdentityId,
-            )
+            if (dispatcher != null) {
+                dispatcher.dispatch(
+                    messageId = inbound.messageId,
+                    ownerIdentityId = ownerIdentityId,
+                    payload = inbound.payload,
+                    receivedAt = inbound.receivedAt,
+                )
+            } else {
+                repository.recordIncoming(
+                    id = inbound.messageId,
+                    payload = inbound.payload,
+                    receivedAt = inbound.receivedAt,
+                    ownerIdentityId = ownerIdentityId,
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -1,0 +1,146 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GroupRepository
+import chat.onym.android.group.MemberAnnouncementPayload
+import chat.onym.android.group.MemberProfile
+import chat.onym.android.identity.ActiveIdentityProvider
+import chat.onym.android.identity.DecryptedEnvelope
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.InvitationEnvelopeDecrypter
+import kotlinx.serialization.json.Json
+import java.time.Instant
+
+/**
+ * Receive-side fan-out target for the inbox pump. Inspects every
+ * inbound message after decryption and routes it to the right
+ * destination:
+ *
+ *   - [MemberAnnouncementPayload] → applied directly to the matching
+ *     local [ChatGroup.memberProfiles]. Never lands in the
+ *     invitations queue.
+ *   - PR 83 will add: [chat.onym.android.group.GroupInvitationPayload]
+ *     → materializes a local [ChatGroup] under the recipient identity.
+ *   - Anything else (unknown / undecryptable plaintext) → persisted
+ *     as an opaque [IncomingInvitation] for the legacy display
+ *     pipeline. Safety-net: ciphertext we can't open at receive time
+ *     (wrong recipient, corrupted envelope) still gets a chance via
+ *     [InvitationDecryptor] later.
+ *
+ * ## Cost
+ *
+ * Every inbound message is decrypted at receive time (one extra
+ * X25519/AES-GCM op per message). For the low-volume Onym inbox
+ * this is negligible; the simplification gain — never leaking an
+ * announcement or a stale invitation into the queue — is worth it.
+ *
+ * Mirrors `IncomingMessageDispatcher.swift` from onym-ios PR #80.
+ */
+class IncomingMessageDispatcher(
+    private val envelopeDecrypter: InvitationEnvelopeDecrypter,
+    private val groupRepository: GroupRepository,
+    private val invitationsRepository: IncomingInvitationsRepository,
+) {
+
+    suspend fun dispatch(
+        messageId: String,
+        ownerIdentityId: IdentityId,
+        payload: ByteArray,
+        receivedAt: Instant,
+    ) {
+        // Decrypt once at receive time and grab the sender's Ed25519
+        // pubkey at the same hop — fast paths use it for provenance
+        // (announcement: verify against stored admin in PR 84;
+        // invitation: stamp into the materialized group in PR 83+84).
+        val envelope: DecryptedEnvelope = try {
+            envelopeDecrypter.decryptInvitationWithSender(
+                envelopeBytes = payload,
+                asIdentity = ownerIdentityId,
+            )
+        } catch (_: Throwable) {
+            // Couldn't decrypt — fall through to the legacy queue
+            // (ciphertext might be addressed to a different identity
+            // and decryptable later).
+            fallThrough(messageId, ownerIdentityId, payload, receivedAt)
+            return
+        }
+
+        // Fast path: MemberAnnouncementPayload — incremental roster
+        // delta for an existing local group.
+        val announcement = tryDecodeAnnouncement(envelope.plaintext)
+        if (announcement != null) {
+            applyAnnouncement(announcement, envelope.senderEd25519PublicKey)
+            return
+        }
+
+        // No invitation fast-path yet — that's PR 83. For now anything
+        // that isn't an announcement falls through to the legacy queue.
+        fallThrough(messageId, ownerIdentityId, payload, receivedAt)
+    }
+
+    private suspend fun fallThrough(
+        messageId: String,
+        ownerIdentityId: IdentityId,
+        payload: ByteArray,
+        receivedAt: Instant,
+    ) {
+        invitationsRepository.recordIncoming(
+            id = messageId,
+            payload = payload,
+            receivedAt = receivedAt,
+            ownerIdentityId = ownerIdentityId,
+        )
+    }
+
+    /**
+     * Idempotent merge of one announced member into the matching
+     * local group's [ChatGroup.memberProfiles]. No-op when:
+     *
+     *   - The group isn't on this device (joiner whose local
+     *     materialization hasn't shipped, or stale announcement for
+     *     an unrelated group).
+     *   - The member is already known under the same BLS pubkey hex
+     *     (re-delivery, or the admin's own approve loop
+     *     re-broadcasting).
+     *
+     * PR 84 adds the admin-Ed25519 trust check. Until then the only
+     * provenance gate is the outer envelope's signature (verified by
+     * [InvitationEnvelopeDecrypter]).
+     */
+    private suspend fun applyAnnouncement(
+        payload: MemberAnnouncementPayload,
+        @Suppress("UNUSED_PARAMETER") senderEd25519PublicKey: ByteArray?,
+    ) {
+        val groups = groupRepository.snapshots.value
+        val group = groups.firstOrNull {
+            it.groupIdBytes.contentEquals(payload.groupId)
+        } ?: return
+
+        val key = payload.newMember.blsPub.toHexLowercase()
+        if (group.memberProfiles[key] != null) return  // dedup
+        val updated = group.copy(
+            memberProfiles = group.memberProfiles + (key to MemberProfile(
+                alias = payload.newMember.alias,
+                inboxPublicKey = payload.newMember.inboxPub,
+            )),
+        )
+        groupRepository.insert(updated)
+    }
+
+    private fun tryDecodeAnnouncement(bytes: ByteArray): MemberAnnouncementPayload? = try {
+        permissiveJson.decodeFromString(
+            MemberAnnouncementPayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    private companion object {
+        private val permissiveJson = Json { ignoreUnknownKeys = true }
+
+        private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+            for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+        }
+    }
+}

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/FakeInvitationEnvelopeDecrypter.kt
@@ -1,5 +1,6 @@
 package chat.onym.android.support
 
+import chat.onym.android.identity.DecryptedEnvelope
 import chat.onym.android.identity.IdentityId
 import chat.onym.android.identity.InvitationDecryptError
 import chat.onym.android.identity.InvitationEnvelopeDecrypter
@@ -70,4 +71,12 @@ class FakeInvitationEnvelopeDecrypter(var mode: Mode) : InvitationEnvelopeDecryp
             is Mode.Failing -> throw m.error
         }
     }
+
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = DecryptedEnvelope(
+        plaintext = decryptInvitation(envelopeBytes, asIdentity),
+        senderEd25519PublicKey = null,
+    )
 }

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
@@ -1,0 +1,258 @@
+package chat.onym.android.inbox
+
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GroupRepository
+import chat.onym.android.group.GroupStore
+import chat.onym.android.group.MemberAnnouncementPayload
+import chat.onym.android.identity.ActiveIdentityProvider
+import chat.onym.android.identity.DecryptedEnvelope
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.InvitationEnvelopeDecrypter
+import chat.onym.android.persistence.InMemoryInvitationStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Behavioral tests for [IncomingMessageDispatcher]. Drives the
+ * dispatcher with a fake decrypter that returns a pre-baked
+ * [DecryptedEnvelope]; verifies the announcement fast-path mutates
+ * group state (and only group state — never the legacy invitations
+ * queue).
+ *
+ * Mirrors `IncomingMessageDispatcherTests.swift` from onym-ios.
+ */
+class IncomingMessageDispatcherTest {
+
+    private val groupId = ByteArray(32) { 0xAA.toByte() }
+    private val newMemberBlsPub = ByteArray(48) { 0xBB.toByte() }
+    private val newMemberInbox = ByteArray(32) { 0xCC.toByte() }
+    private val ownerIdentity = IdentityId("owner")
+
+    private lateinit var groupStore: InMemoryGroupStore
+    private lateinit var groupRepository: GroupRepository
+    private lateinit var invitationsRepository: IncomingInvitationsRepository
+
+    @Before
+    fun setUp() = runTest {
+        groupStore = InMemoryGroupStore()
+        groupRepository = GroupRepository(
+            store = groupStore,
+            identity = ConstantIdentity(ownerIdentity),
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        // Seed a group with the owner so the announcement fast-path
+        // can find it. memberProfiles starts empty.
+        groupRepository.insert(makeGroup(groupId))
+        groupRepository.reload()
+        invitationsRepository = IncomingInvitationsRepository(
+            store = InMemoryInvitationStore(),
+            identity = ConstantIdentity(ownerIdentity),
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+    }
+
+    @Test
+    fun announcement_appendsToLocalGroupAndDoesNotQueue() = runTest {
+        val payload = announcementPayload()
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32)),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+
+        dispatcher.dispatch(
+            messageId = "m1",
+            ownerIdentityId = ownerIdentity,
+            payload = byteArrayOf(),
+            receivedAt = Instant.EPOCH,
+        )
+
+        val updated = groupRepository.snapshots.value.single()
+        assertEquals(1, updated.memberProfiles.size)
+        val key = newMemberBlsPub.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        assertNotNull(updated.memberProfiles[key])
+        assertEquals("Bob", updated.memberProfiles[key]!!.alias)
+
+        // Legacy queue MUST be untouched for an announcement.
+        invitationsRepository.bootstrap()
+        assertTrue(invitationsRepository.invitations.value.isEmpty())
+    }
+
+    @Test
+    fun announcement_unknownGroupIsDroppedNotQueued() = runTest {
+        val foreignPayload = MemberAnnouncementPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0xFF.toByte() },  // not on this device
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = newMemberBlsPub, inboxPub = newMemberInbox, alias = "Bob",
+            ),
+            adminAlias = "Alice",
+        )
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), foreignPayload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32)),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+
+        dispatcher.dispatch(
+            messageId = "m1",
+            ownerIdentityId = ownerIdentity,
+            payload = byteArrayOf(),
+            receivedAt = Instant.EPOCH,
+        )
+
+        // Local group untouched.
+        val unchanged = groupRepository.snapshots.value.single()
+        assertTrue(unchanged.memberProfiles.isEmpty())
+        // No queue side-effect either.
+        invitationsRepository.bootstrap()
+        assertTrue(invitationsRepository.invitations.value.isEmpty())
+    }
+
+    @Test
+    fun announcement_idempotentOnRedelivery() = runTest {
+        val payload = announcementPayload()
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32)),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+        dispatcher.dispatch("m2", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        val final = groupRepository.snapshots.value.single()
+        assertEquals(1, final.memberProfiles.size)
+    }
+
+    @Test
+    fun decryptFailure_fallsThroughToInvitationsQueue() = runTest {
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = ThrowingDecrypter(),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(0x01), Instant.EPOCH)
+        invitationsRepository.bootstrap()
+        assertEquals(1, invitationsRepository.invitations.value.size)
+    }
+
+    @Test
+    fun unrecognizedPlaintext_fallsThroughToQueue() = runTest {
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(
+                plaintext = "{\"some\":\"random\"}".toByteArray(Charsets.UTF_8),
+                senderPub = null,
+            ),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(0x02), Instant.EPOCH)
+        invitationsRepository.bootstrap()
+        assertEquals(1, invitationsRepository.invitations.value.size)
+    }
+
+    private fun announcementPayload() = MemberAnnouncementPayload(
+        version = 1,
+        groupId = groupId,
+        newMember = MemberAnnouncementPayload.AnnouncedMember(
+            blsPub = newMemberBlsPub, inboxPub = newMemberInbox, alias = "Bob",
+        ),
+        adminAlias = "Alice",
+    )
+
+    private fun makeGroup(id: ByteArray): ChatGroup {
+        val hex = id.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        return ChatGroup(
+            id = hex,
+            name = "Family",
+            groupSecret = ByteArray(32),
+            createdAtMillis = 0L,
+            members = emptyList(),
+            memberProfiles = emptyMap(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = null,
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = null,
+            isPublishedOnChain = true,
+            ownerIdentityId = ownerIdentity.value,
+        )
+    }
+}
+
+private class StubDecrypter(
+    private val plaintext: ByteArray,
+    private val senderPub: ByteArray?,
+) : InvitationEnvelopeDecrypter {
+    override suspend fun decryptInvitation(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): ByteArray = plaintext
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = DecryptedEnvelope(plaintext, senderPub)
+}
+
+private class ThrowingDecrypter : InvitationEnvelopeDecrypter {
+    override suspend fun decryptInvitation(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): ByteArray = throw IllegalStateException("decrypt failed")
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = throw IllegalStateException("decrypt failed")
+}
+
+private class InMemoryGroupStore : GroupStore {
+    private val rows = mutableMapOf<String, ChatGroup>()
+    override suspend fun list(): List<ChatGroup> = rows.values.toList()
+    override suspend fun listForOwner(ownerIdentityId: String): List<ChatGroup> =
+        rows.values.filter { it.ownerIdentityId == ownerIdentityId }
+    override suspend fun deleteForOwner(ownerIdentityId: String): Int {
+        val before = rows.size
+        rows.entries.removeAll { it.value.ownerIdentityId == ownerIdentityId }
+        return before - rows.size
+    }
+    override suspend fun insertOrUpdate(group: ChatGroup): Boolean {
+        val isNew = !rows.containsKey(group.id)
+        rows[group.id] = group
+        return isNew
+    }
+    override suspend fun markPublished(id: String, commitment: ByteArray?) {
+        val existing = rows[id] ?: return
+        rows[id] = existing.copy(
+            isPublishedOnChain = true,
+            commitment = commitment ?: existing.commitment,
+        )
+    }
+    override suspend fun delete(id: String) { rows.remove(id) }
+}
+
+private class ConstantIdentity(private val id: IdentityId) : ActiveIdentityProvider {
+    override val currentIdentityId: StateFlow<IdentityId?> = MutableStateFlow(id)
+    override fun registerRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {}
+}


### PR DESCRIPTION
## Summary

- New `IncomingMessageDispatcher` lives between the inbox transport pump and the legacy invitations queue. Decrypts once at receive time, routes by plaintext shape:
  - `MemberAnnouncementPayload` → applied to the matching local `ChatGroup.memberProfiles`. Never lands in the queue.
  - Anything else → falls through to `IncomingInvitationsRepository.recordIncoming` (safety net for ciphertext we can't open under the current identity, or future payload shapes).
- `DecryptedEnvelope` + `InvitationEnvelopeDecrypter.decryptInvitationWithSender` surface the envelope's sender Ed25519 pubkey alongside the plaintext so PR 84 can wire the admin-trust check.
- `IncomingInvitationsInteractor` accepts an optional dispatcher and falls back to the pre-PR-80 queue path when null.

Stacked on `group/broadcast-joiner` (PR #99). Mirrors onym-ios PR #80.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `IncomingMessageDispatcherTest` covers: announcement applied + queue untouched, unknown groupId silently dropped, idempotent re-delivery, decrypt failure falls through, unrecognized plaintext falls through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)