### PR TITLE
feat(chats): chat-members view + member-count subtitle

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -164,6 +164,28 @@ fun RootScreen(
                     onCreateGroup = { navController.navigate(ROUTE_CREATE_GROUP) },
                     approveRequestsViewModel = dependencies.approveRequestsViewModel,
                     onOpenApproveRequests = { navController.navigate(ROUTE_APPROVE_REQUESTS) },
+                    onOpenChat = { groupId ->
+                        navController.navigate("chat_members/$groupId")
+                    },
+                )
+            }
+            composable("chat_members/{groupId}") { entry ->
+                val groupId = entry.arguments?.getString("groupId") ?: return@composable
+                val chatsVm: ChatsViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeChatsViewModel() }
+                    },
+                )
+                val identitiesVm: IdentitiesViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeIdentitiesViewModel() }
+                    },
+                )
+                chat.onym.android.chats.ChatMembersScreen(
+                    groupId = groupId,
+                    chatsViewModel = chatsVm,
+                    identityViewModel = identitiesVm,
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable(ROUTE_APPROVE_REQUESTS) {

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatMembersScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatMembersScreen.kt
@@ -1,0 +1,298 @@
+package chat.onym.android.chats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.PersonOutline
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.MemberProfile
+import chat.onym.android.identity.IdentitiesViewModel
+
+/**
+ * Roster screen drilled into from a chat row. Renders one row per
+ * entry in [ChatGroup.memberProfiles], sorted by alias, with the
+ * active identity badged "(you)".
+ *
+ * Reads the latest [ChatGroup] by ID from [chatsViewModel.groups] so
+ * the view re-renders when an admin's PR-79 fanout lands a new entry
+ * via the PR-80 dispatcher.
+ *
+ * Mirrors `ChatMembersView.swift` from onym-ios.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatMembersScreen(
+    groupId: String,
+    chatsViewModel: ChatsViewModel,
+    identityViewModel: IdentitiesViewModel,
+    onBack: () -> Unit,
+    onShareInviteClick: (() -> Unit)? = null,
+) {
+    val groups by chatsViewModel.groups.collectAsStateWithLifecycle()
+    val identityRows by identityViewModel.items.collectAsStateWithLifecycle()
+    val activeBlsHex: String? = identityRows.firstOrNull { it.isActive }
+        ?.summary
+        ?.blsPublicKey
+        ?.toHexLowercase()
+
+    val group = groups.firstOrNull { it.id == groupId }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(group?.name ?: "Group") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    // PR 86 wires the share-invite toolbar into this slot.
+                    if (onShareInviteClick != null) {
+                        IconButton(
+                            onClick = onShareInviteClick,
+                            modifier = Modifier.testTag("members.share_invite_button"),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Share,
+                                contentDescription = "Share invite",
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        if (group == null) {
+            MissingGroupState(modifier = Modifier.padding(padding).fillMaxSize())
+        } else {
+            ChatMembersBody(
+                group = group,
+                activeBlsHex = activeBlsHex,
+                modifier = Modifier.padding(padding).fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChatMembersBody(
+    group: ChatGroup,
+    activeBlsHex: String?,
+    modifier: Modifier = Modifier,
+) {
+    val rows = remember(group.memberProfiles, activeBlsHex) {
+        group.memberProfiles.map { (key, profile) ->
+            MemberRow(
+                blsHex = key,
+                blsPrefix = key.take(12),
+                displayAlias = profile.alias.ifEmpty { "(unnamed)" },
+                isSelf = activeBlsHex != null &&
+                    key.equals(activeBlsHex, ignoreCase = true),
+            )
+        }.sortedWith(compareBy({ !it.isSelf }, { it.displayAlias.lowercase() }))
+    }
+
+    Column(modifier = modifier) {
+        if (rows.isEmpty()) {
+            EmptyState(modifier = Modifier.fillMaxSize())
+        } else {
+            MembersCard(rows = rows)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = if (rows.size == 1) "${rows.size} member" else "${rows.size} members",
+                modifier = Modifier.padding(horizontal = 24.dp),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MembersCard(rows: List<MemberRow>) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        rows.forEachIndexed { idx, row ->
+            MemberRowView(row = row)
+            if (idx != rows.lastIndex) {
+                HorizontalDivider(thickness = 0.5.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemberRowView(row: MemberRow) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 14.dp, vertical = 12.dp)
+            .testTag("members.row.${row.blsHex}"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AvatarCircle(letter = row.displayAlias.firstOrNull()?.uppercase().orEmpty(), self = row.isSelf)
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = row.displayAlias,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 15.sp,
+                )
+                if (row.isSelf) {
+                    Spacer(Modifier.size(6.dp))
+                    SelfPill()
+                }
+            }
+            Text(
+                text = "BLS ${row.blsPrefix}…",
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvatarCircle(letter: String, self: Boolean) {
+    val accent = if (self) Color(0xFF34C759) else MaterialTheme.colorScheme.primary
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(accent.copy(alpha = if (self) 0.25f else 0.15f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (letter.isNotEmpty()) {
+            Text(
+                text = letter,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                color = accent,
+            )
+        } else {
+            Icon(
+                Icons.Filled.PersonOutline,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = accent,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelfPill() {
+    Text(
+        text = "(you)",
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
+            .padding(horizontal = 6.dp, vertical = 1.dp),
+        fontSize = 10.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.testTag("members.empty"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Filled.PersonOutline,
+            contentDescription = null,
+            modifier = Modifier.size(44.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(14.dp))
+        Text("No members yet", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "Invite people from the chat to see them here.",
+            fontSize = 13.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+    }
+}
+
+@Composable
+private fun MissingGroupState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.testTag("members.missing"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text("Group not found", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "It may have been removed or it belongs to a different identity.",
+            fontSize = 13.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+    }
+}
+
+internal data class MemberRow(
+    val blsHex: String,
+    val blsPrefix: String,
+    val displayAlias: String,
+    val isSelf: Boolean,
+)
+
+private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+    for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+}

--- a/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/chats/ChatsScreen.kt
@@ -75,6 +75,7 @@ fun ChatsScreen(
     onCreateGroup: () -> Unit,
     approveRequestsViewModel: ApproveRequestsViewModel? = null,
     onOpenApproveRequests: (() -> Unit)? = null,
+    onOpenChat: (groupId: String) -> Unit = {},
 ) {
     val groups by viewModel.groups.collectAsStateWithLifecycle()
     val pending by (approveRequestsViewModel?.pending?.collectAsStateWithLifecycle()
@@ -139,7 +140,7 @@ fun ChatsScreen(
                     .fillMaxSize(),
             ) {
                 items(groups, key = { it.id }) { group ->
-                    ChatsRow(group = group, onClick = { /* TODO: chat screen */ })
+                    ChatsRow(group = group, onClick = { onOpenChat(group.id) })
                     HorizontalDivider(thickness = 0.5.dp)
                 }
             }
@@ -262,6 +263,12 @@ private fun subtitleFor(group: ChatGroup): String {
         SepGroupType.DEMOCRACY -> "Democracy"
         SepGroupType.OLIGARCHY -> "Oligarchy"
     }
+    val memberCount = group.memberProfiles.size
+    val membersLabel = when (memberCount) {
+        0 -> ""
+        1 -> "1 member"
+        else -> "$memberCount members"
+    }
     val now = System.currentTimeMillis()
     val relative = DateUtils.getRelativeTimeSpanString(
         group.createdAtMillis,
@@ -269,5 +276,6 @@ private fun subtitleFor(group: ChatGroup): String {
         DateUtils.MINUTE_IN_MILLIS,
         DateUtils.FORMAT_ABBREV_RELATIVE,
     ).toString()
-    return "$label · $relative"
+    return if (membersLabel.isEmpty()) "$label · $relative"
+    else "$label · $membersLabel · $relative"
 }

--- a/app/src/test/kotlin/chat/onym/android/chats/ChatMembersSortTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/chats/ChatMembersSortTest.kt
@@ -1,0 +1,45 @@
+package chat.onym.android.chats
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Sort + label-derivation rules used by [ChatMembersScreen].
+ * Replicates the iOS behavioral test for cross-platform parity.
+ *
+ * Mirrors `ChatMembersViewSortTests.swift` from onym-ios.
+ */
+class ChatMembersSortTest {
+
+    @Test
+    fun selfAlwaysFirst_thenAlphabeticCaseInsensitive() {
+        val rows = listOf(
+            row("alice", "alice", isSelf = false),
+            row("zoe", "Zoe", isSelf = false),
+            row("self", "Self", isSelf = true),
+            row("bob", "Bob", isSelf = false),
+        )
+        val sorted = rows.sortedWith(compareBy({ !it.isSelf }, { it.displayAlias.lowercase() }))
+        assertEquals(listOf("self", "alice", "bob", "zoe"), sorted.map { it.blsHex })
+    }
+
+    @Test
+    fun unnamedAliasUsesFallbackLabel() {
+        val raw = ""
+        val displayed = raw.ifEmpty { "(unnamed)" }
+        assertEquals("(unnamed)", displayed)
+    }
+
+    @Test
+    fun blsPrefixIsFirst12Chars() {
+        val key = "abcdef0123456789".repeat(6)  // long enough for 96 chars
+        assertEquals("abcdef012345", key.take(12))
+    }
+
+    private fun row(blsHex: String, displayAlias: String, isSelf: Boolean) = MemberRow(
+        blsHex = blsHex,
+        blsPrefix = blsHex.take(12),
+        displayAlias = displayAlias,
+        isSelf = isSelf,
+    )
+}


### PR DESCRIPTION
## Summary

- New `ChatMembersScreen` drilled into from a chats-list row tap. Renders one row per `ChatGroup.memberProfiles` entry; self always first, then alphabetic case-insensitive, with `(you)` badge + BLS hex prefix as monospaced fingerprint.
- Empty / missing-group fallbacks. testTags: `members.row.{blsHex}`, `members.empty`, `members.missing`, `members.share_invite_button` (slot for PR 86).
- ChatsScreen subtitle now includes `"{n} members"` derived from `memberProfiles.size` so PR 80's announcement-driven mutations show up immediately.

Stacked on `inbox/dispatcher` (PR #100). Mirrors onym-ios PR #81.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `ChatMembersSortTest` covers self-first sort, case-insensitive alphabetic order, `(unnamed)` fallback, 12-char BLS prefix
- [ ] Manual smoke: open a chat row → see members list with self badged

🤖 Generated with [Claude Code](https://claude.com/claude-code)