### PR TITLE
feat(group): GroupInvitationPayload carries member_profiles

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -311,6 +311,11 @@ open class CreateGroupInteractor(
                     groupTypeRaw = groupType.wireValue,
                     adminPubkeyHex = adminPubkeyHex,
                     inviteeBlsSecretKey = secondaryBlsSecret,
+                    // Ship the creator's directory so the invitee
+                    // sees the inviter by alias from the moment the
+                    // group materializes (PR 83). takeIf-not-empty
+                    // matches iOS; pre-PR-82 senders shipped null.
+                    memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
                 )
                 val payloadBytes = try {
                     jsonFormat.encodeToString(

--- a/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupInvitationPayload.kt
@@ -72,6 +72,18 @@ data class GroupInvitationPayload(
     @SerialName("invitee_bls_secret_key")
     @Serializable(with = Base64ByteArraySerializer::class)
     val inviteeBlsSecretKey: ByteArray? = null,
+    /**
+     * Snapshot of the sender's [ChatGroup.memberProfiles] at send
+     * time. The joiner's receive-side materializer (PR 83) uses this
+     * to populate their local directory at the same time the group
+     * lands locally — no waiting for follow-up announcements just to
+     * render existing peers by name.
+     *
+     * Default null so older receivers / senders still round-trip.
+     * Map ordering is not load-bearing; the wire format is unordered.
+     */
+    @SerialName("member_profiles")
+    val memberProfiles: Map<String, MemberProfile>? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -88,7 +100,8 @@ data class GroupInvitationPayload(
             groupTypeRaw == other.groupTypeRaw &&
             adminPubkeyHex == other.adminPubkeyHex &&
             (inviteeBlsSecretKey?.contentEquals(other.inviteeBlsSecretKey)
-                ?: (other.inviteeBlsSecretKey == null))
+                ?: (other.inviteeBlsSecretKey == null)) &&
+            memberProfiles == other.memberProfiles
     }
 
     override fun hashCode(): Int {
@@ -104,6 +117,7 @@ data class GroupInvitationPayload(
         h = 31 * h + groupTypeRaw.hashCode()
         h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
         h = 31 * h + (inviteeBlsSecretKey?.contentHashCode() ?: 0)
+        h = 31 * h + (memberProfiles?.hashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -171,6 +171,11 @@ open class JoinRequestApprover(
             tierRaw = group.tier.rawValue,
             groupTypeRaw = group.groupType.wireValue,
             adminPubkeyHex = group.adminPubkeyHex,
+            // Ship the directory-as-known so the joiner sees existing
+            // peers + admin by name from the moment they land. The
+            // joiner's own profile gets backfilled by the receiver's
+            // materializer (PR 83) from their active identity.
+            memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
         )
         val payloadBytes = try {
             jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)

--- a/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/GroupInvitationPayloadTest.kt
@@ -56,6 +56,49 @@ class GroupInvitationPayloadTest {
     }
 
     @Test
+    fun roundtrip_memberProfilesField_preservesEntries() {
+        val profile = MemberProfile(alias = "Alice", inboxPublicKey = ByteArray(32) { 0xAB.toByte() })
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32),
+            groupSecret = ByteArray(32),
+            name = "G",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = ByteArray(32),
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            memberProfiles = mapOf("aa".repeat(48) to profile),
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        val obj = json.parseToJsonElement(encoded).jsonObject
+        assertNotNull(obj["member_profiles"])
+    }
+
+    @Test
+    fun roundtrip_decode_pre_pr82_payload_without_member_profiles() {
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32),
+            groupSecret = ByteArray(32),
+            name = "G",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = null,
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            memberProfiles = null,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertNull(decoded.memberProfiles)
+    }
+
+    @Test
     fun roundtrip_oneOnOneShape_carriesInviteeBlsSecretAsBase64() {
         val sk1 = ByteArray(32) { 0x99.toByte() }
         val original = GroupInvitationPayload(


### PR DESCRIPTION
## Summary

- Add nullable `member_profiles` field to `GroupInvitationPayload`. Sender-side: `CreateGroupInteractor` + `JoinRequestApprover` populate it via `takeIf { isNotEmpty() }`.
- Pre-PR-82 invitations still decode (default null).
- Joiner-side materializer in PR 83 will consume this so existing peers + admin show up by alias from the moment the group lands locally.

Stacked on `chats/members-view` (PR #101). Mirrors onym-ios PR #82.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `GroupInvitationPayloadTest.roundtrip_memberProfilesField_preservesEntries` round-trips a populated map
- [ ] `GroupInvitationPayloadTest.roundtrip_decode_pre_pr82_payload_without_member_profiles` confirms backward-compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)