### PR TITLE
feat(inbox): joiner-side group materialization from invitation

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -325,6 +325,7 @@ class OnymApplication : Application() {
             envelopeDecrypter = identityRepository,
             groupRepository = groupRepository,
             invitationsRepository = invitationsRepository,
+            identitiesFlow = identityRepository.identities,
         )
         val invitationsInteractor = chat.onym.android.inbox.IncomingInvitationsInteractor(
             inboxTransport = inboxTransport,

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -1,13 +1,17 @@
 package chat.onym.android.inbox
 
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.SepTier
 import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GroupInvitationPayload
 import chat.onym.android.group.GroupRepository
 import chat.onym.android.group.MemberAnnouncementPayload
 import chat.onym.android.group.MemberProfile
-import chat.onym.android.identity.ActiveIdentityProvider
 import chat.onym.android.identity.DecryptedEnvelope
 import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.IdentitySummary
 import chat.onym.android.identity.InvitationEnvelopeDecrypter
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 import java.time.Instant
 
@@ -40,6 +44,13 @@ class IncomingMessageDispatcher(
     private val envelopeDecrypter: InvitationEnvelopeDecrypter,
     private val groupRepository: GroupRepository,
     private val invitationsRepository: IncomingInvitationsRepository,
+    /** Receiver's own identities, keyed by [IdentityId]. The PR-83
+     *  invitation fast-path looks up the recipient's
+     *  [IdentitySummary] here to backfill their own
+     *  [MemberProfile] entry into the freshly-materialized group's
+     *  directory. Pass [chat.onym.android.identity.IdentityRepository.identities]
+     *  in production. */
+    private val identitiesFlow: StateFlow<List<IdentitySummary>>? = null,
 ) {
 
     suspend fun dispatch(
@@ -73,9 +84,94 @@ class IncomingMessageDispatcher(
             return
         }
 
-        // No invitation fast-path yet — that's PR 83. For now anything
-        // that isn't an announcement falls through to the legacy queue.
+        // Fast path: GroupInvitationPayload — materialize a local
+        // group under [ownerIdentityId]. Skips the invitations queue
+        // because the group is now visible directly in the chats list.
+        val invitation = tryDecodeInvitation(envelope.plaintext)
+        if (invitation != null) {
+            materializeGroup(invitation, ownerIdentityId, envelope.senderEd25519PublicKey)
+            return
+        }
+
+        // Plaintext didn't match any known payload — fall through.
         fallThrough(messageId, ownerIdentityId, payload, receivedAt)
+    }
+
+    /**
+     * Materialize a local [ChatGroup] from an inbound
+     * [GroupInvitationPayload]. Idempotent on `groupId` —
+     * [GroupRepository.insert] delegates to `insertOrUpdate`, so a
+     * re-delivery of the same invitation overwrites in place rather
+     * than minting a duplicate row.
+     *
+     * The `memberProfiles` directory is the union of:
+     *   - whatever the sender shipped on the wire (PR 82),
+     *   - the receiver's own profile (looked up from
+     *     [identitiesFlow]). The "self last" ordering means a
+     *     sender that mistakenly includes us under our own BLS key
+     *     gets overwritten by our locally-trusted alias + inbox pub.
+     *
+     * Skipped when `tier_raw` / `group_type_raw` don't decode (older
+     * or future wire versions) — better to drop the message than
+     * materialize a partial group.
+     */
+    private suspend fun materializeGroup(
+        invitation: GroupInvitationPayload,
+        ownerIdentityId: IdentityId,
+        @Suppress("UNUSED_PARAMETER") senderEd25519PublicKey: ByteArray?,
+    ) {
+        val tier = SepTier.entries.firstOrNull { it.rawValue == invitation.tierRaw } ?: return
+        val groupType = SepGroupType.fromWire(invitation.groupTypeRaw) ?: return
+
+        // Wire-shipped profiles first; receiver's own entry overwrites
+        // any same-keyed wire entry (sender shouldn't be able to
+        // assert our alias).
+        val profiles = (invitation.memberProfiles ?: emptyMap()).toMutableMap()
+        selfMemberProfileEntry(ownerIdentityId)?.let { (key, profile) ->
+            profiles[key] = profile
+        }
+
+        val groupIdHex = invitation.groupId.toHexLowercase()
+        val group = ChatGroup(
+            id = groupIdHex,
+            name = invitation.name,
+            groupSecret = invitation.groupSecret,
+            createdAtMillis = System.currentTimeMillis(),
+            members = invitation.members,
+            memberProfiles = profiles,
+            epoch = invitation.epoch,
+            salt = invitation.salt,
+            commitment = invitation.commitment,
+            tier = tier,
+            groupType = groupType,
+            adminPubkeyHex = invitation.adminPubkeyHex,
+            // Sender already anchored before sending the invite, so
+            // by the time it lands the group is on chain.
+            isPublishedOnChain = true,
+            ownerIdentityId = ownerIdentityId.value,
+        )
+        groupRepository.insert(group)
+    }
+
+    private fun selfMemberProfileEntry(
+        identityId: IdentityId,
+    ): Pair<String, MemberProfile>? {
+        val summaries = identitiesFlow?.value ?: return null
+        val me = summaries.firstOrNull { it.id == identityId } ?: return null
+        val key = me.blsPublicKey.toHexLowercase()
+        return key to MemberProfile(
+            alias = me.name,
+            inboxPublicKey = me.inboxPublicKey,
+        )
+    }
+
+    private fun tryDecodeInvitation(bytes: ByteArray): GroupInvitationPayload? = try {
+        permissiveJson.decodeFromString(
+            GroupInvitationPayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
     }
 
     private suspend fun fallThrough(

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
@@ -3,18 +3,24 @@ package chat.onym.android.inbox
 import chat.onym.android.chain.SepGroupType
 import chat.onym.android.chain.SepTier
 import chat.onym.android.group.ChatGroup
+import chat.onym.android.group.GovernanceMember
+import chat.onym.android.group.GroupInvitationPayload
 import chat.onym.android.group.GroupRepository
 import chat.onym.android.group.GroupStore
 import chat.onym.android.group.MemberAnnouncementPayload
+import chat.onym.android.group.MemberProfile
 import chat.onym.android.identity.ActiveIdentityProvider
 import chat.onym.android.identity.DecryptedEnvelope
 import chat.onym.android.identity.IdentityId
+import chat.onym.android.identity.IdentitySummary
 import chat.onym.android.identity.InvitationEnvelopeDecrypter
 import chat.onym.android.persistence.InMemoryInvitationStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Assert.assertNotNull
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -155,6 +161,110 @@ class IncomingMessageDispatcherTest {
         dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(0x01), Instant.EPOCH)
         invitationsRepository.bootstrap()
         assertEquals(1, invitationsRepository.invitations.value.size)
+    }
+
+    @Test
+    fun invitation_materializesGroupAndAddsSelfProfile() = runTest {
+        // Build an invitation with one wire-shipped profile (the
+        // inviter), targeting a group that's NOT yet on the device.
+        val newGroupId = ByteArray(32) { 0xEE.toByte() }
+        val inviterBls = ByteArray(48) { 0x11 }
+        val inviterInbox = ByteArray(32) { 0x22 }
+        val inviterKey = inviterBls.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        val invitation = GroupInvitationPayload(
+            version = 1,
+            groupId = newGroupId,
+            groupSecret = ByteArray(32) { 0x33 },
+            name = "From Wire",
+            members = listOf(
+                GovernanceMember(
+                    publicKeyCompressed = inviterBls,
+                    leafHash = ByteArray(32) { 0x44 },
+                ),
+            ),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x55 },
+            commitment = ByteArray(32) { 0x66 },
+            tierRaw = SepTier.SMALL.rawValue,
+            groupTypeRaw = SepGroupType.TYRANNY.wireValue,
+            adminPubkeyHex = inviterKey,
+            memberProfiles = mapOf(
+                inviterKey to MemberProfile(alias = "Alice", inboxPublicKey = inviterInbox),
+            ),
+        )
+        val plaintext = Json.encodeToString(GroupInvitationPayload.serializer(), invitation)
+            .toByteArray(Charsets.UTF_8)
+
+        // Mock identitiesFlow so the dispatcher can backfill self.
+        val selfBls = ByteArray(48) { 0xAA.toByte() }
+        val selfInbox = ByteArray(32) { 0xBB.toByte() }
+        val identitiesFlow = MutableStateFlow(
+            listOf(
+                IdentitySummary(
+                    id = ownerIdentity,
+                    name = "Bob",
+                    blsPublicKey = selfBls,
+                    inboxPublicKey = selfInbox,
+                ),
+            ),
+        )
+
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32)),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            identitiesFlow = identitiesFlow.asStateFlow(),
+        )
+
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        // Group materialized + listed under owner; legacy queue empty.
+        val group = groupRepository.snapshots.value.firstOrNull {
+            it.groupIdBytes.contentEquals(newGroupId)
+        }
+        assertNotNull("invitation must materialize a group row", group)
+        assertEquals("From Wire", group!!.name)
+        assertTrue(group.isPublishedOnChain)
+        // Wire-shipped inviter + self both present in the directory.
+        val selfKey = selfBls.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        assertEquals(2, group.memberProfiles.size)
+        assertEquals("Alice", group.memberProfiles[inviterKey]?.alias)
+        assertEquals("Bob", group.memberProfiles[selfKey]?.alias)
+        invitationsRepository.bootstrap()
+        assertTrue(
+            "invitation must NOT land in the legacy queue",
+            invitationsRepository.invitations.value.isEmpty(),
+        )
+    }
+
+    @Test
+    fun invitation_redeliveryIsIdempotent() = runTest {
+        val newGroupId = ByteArray(32) { 0xEE.toByte() }
+        val invitation = GroupInvitationPayload(
+            version = 1,
+            groupId = newGroupId,
+            groupSecret = ByteArray(32) { 0x33 },
+            name = "G",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x55 },
+            commitment = null,
+            tierRaw = SepTier.SMALL.rawValue,
+            groupTypeRaw = SepGroupType.TYRANNY.wireValue,
+        )
+        val plaintext = Json.encodeToString(GroupInvitationPayload.serializer(), invitation)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = null),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+        dispatcher.dispatch("m2", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+        val groups = groupRepository.snapshots.value.filter {
+            it.groupIdBytes.contentEquals(newGroupId)
+        }
+        assertEquals("re-delivery must not mint a duplicate", 1, groups.size)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Second fast-path on `IncomingMessageDispatcher`: a decoded `GroupInvitationPayload` materializes a `ChatGroup` row under the receiver identity. The chat now appears in the chats list without going through any "Accept invitation?" UI.
- Directory is the union of wire-shipped `member_profiles` (PR 82) + the receiver's own `MemberProfile` looked up from `IdentityRepository.identities`. Self-last so the sender can't assert our alias.
- Bad `tier_raw` / `group_type_raw` drops the message rather than materializing a partial group. Idempotent on `groupId`.

PR 84 will populate `adminEd25519PubkeyHex` from the envelope's sender pubkey at this point. PRs 89 / 91 will gate Tyranny invitations against the on-chain commitment.

Stacked on `group/invitation-member-profiles` (PR #102). Mirrors onym-ios PR #83.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `IncomingMessageDispatcherTest.invitation_materializesGroupAndAddsSelfProfile` — new group lands; directory has wire entries + self
- [ ] `IncomingMessageDispatcherTest.invitation_redeliveryIsIdempotent` — re-delivery doesn't mint duplicates
- [ ] Existing announcement / fall-through tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)