### PR TITLE
feat(inbox): verify member announcements against group's admin Ed25519

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -278,7 +278,10 @@ class OnymApplication : Application() {
                 // PR 75 (member-profiles) added a non-destructive v3→v4
                 // migration that introduces the nullable
                 // `encryptedMemberProfilesJson` column.
-                .addMigrations(GroupDatabaseMigrations.MIGRATION_3_4)
+                .addMigrations(
+                    GroupDatabaseMigrations.MIGRATION_3_4,
+                    GroupDatabaseMigrations.MIGRATION_4_5,
+                )
                 .fallbackToDestructiveMigration()
                 .build()
         } catch (e: Throwable) {

--- a/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ChatGroup.kt
@@ -77,6 +77,24 @@ data class ChatGroup(
     @SerialName("admin_pubkey_hex")
     val adminPubkeyHex: String? = null,
     /**
+     * Hex (lowercase, 64 chars) Ed25519 pubkey of the admin —
+     * HKDF-derived from their nostr secret on the admin's device.
+     * Captured at materialize time from the inviting envelope's
+     * `senderEd25519PublicKey`, or stamped at create time from the
+     * creator's own [chat.onym.android.identity.Identity.stellarPublicKey].
+     * Used by the receive-side dispatcher to verify that an inbound
+     * [MemberAnnouncementPayload] was actually signed by the known
+     * admin (and not a peer who happens to know the recipient's
+     * inbox pubkey).
+     *
+     * `null` for [SepGroupType.ANARCHY] / [SepGroupType.ONE_ON_ONE]
+     * (no admin) or when a pre-PR-84 group materialized before the
+     * field existed — announcements for such groups fall back to V1
+     * best-effort (decrypt-only verification).
+     */
+    @SerialName("admin_ed25519_pubkey_hex")
+    val adminEd25519PubkeyHex: String? = null,
+    /**
      * Flips to `true` once the relayer's `create_group_v2` returns
      * `accepted = true`. Persisted-but-not-anchored groups can be
      * retried.
@@ -121,6 +139,7 @@ data class ChatGroup(
             tier == other.tier &&
             groupType == other.groupType &&
             adminPubkeyHex == other.adminPubkeyHex &&
+            adminEd25519PubkeyHex == other.adminEd25519PubkeyHex &&
             isPublishedOnChain == other.isPublishedOnChain &&
             ownerIdentityId == other.ownerIdentityId
     }
@@ -138,6 +157,7 @@ data class ChatGroup(
         h = 31 * h + tier.hashCode()
         h = 31 * h + groupType.hashCode()
         h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
+        h = 31 * h + (adminEd25519PubkeyHex?.hashCode() ?: 0)
         h = 31 * h + isPublishedOnChain.hashCode()
         h = 31 * h + ownerIdentityId.hashCode()
         return h

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -262,6 +262,15 @@ open class CreateGroupInteractor(
         } else {
             null
         }
+        // PR 84: stamp the admin's Ed25519 pubkey at create time. The
+        // receive-side dispatcher cross-checks `MemberAnnouncement`s
+        // against this. `null` for governance models without a
+        // privileged member.
+        val adminEd25519PubkeyHex: String? = if (groupType == SepGroupType.TYRANNY) {
+            identitySnapshot.stellarPublicKey.toHex()
+        } else {
+            null
+        }
         // Stamp the active identity at create time so the per-identity
         // chats filter in `GroupRepository.snapshots` includes it
         // automatically. There MUST be a current identity (we already
@@ -286,6 +295,7 @@ open class CreateGroupInteractor(
             tier = tier,
             groupType = groupType,
             adminPubkeyHex = adminPubkeyHex,
+            adminEd25519PubkeyHex = adminEd25519PubkeyHex,
             isPublishedOnChain = false,
             ownerIdentityId = ownerId.value,
         )

--- a/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/GroupDatabase.kt
@@ -17,11 +17,11 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [PersistedGroup::class],
-    // v4 (member-profiles): adds nullable `encryptedMemberProfilesJson`
-    // column. v3→v4 migration is non-destructive (the column is
-    // nullable and decodes to an empty map at the store boundary), so
-    // existing rows survive — see [GroupDatabaseMigrations.MIGRATION_3_4].
-    version = 4,
+    // v5 (admin Ed25519): adds nullable `encryptedAdminEd25519PubkeyHex`
+    // column on top of v4's `encryptedMemberProfilesJson`. Both
+    // migrations are non-destructive — existing rows decode to null
+    // at the store boundary.
+    version = 5,
     exportSchema = false,
 )
 abstract class GroupDatabase : RoomDatabase() {
@@ -43,6 +43,17 @@ object GroupDatabaseMigrations {
     val MIGRATION_3_4 = object : androidx.room.migration.Migration(3, 4) {
         override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
             db.execSQL("ALTER TABLE groups ADD COLUMN encryptedMemberProfilesJson BLOB")
+        }
+    }
+
+    /**
+     * v4 → v5: introduce `encryptedAdminEd25519PubkeyHex` (nullable
+     * BLOB). Existing rows decode to null (best-effort fallback for
+     * pre-PR-84 announcements).
+     */
+    val MIGRATION_4_5 = object : androidx.room.migration.Migration(4, 5) {
+        override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE groups ADD COLUMN encryptedAdminEd25519PubkeyHex BLOB")
         }
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/PersistedGroup.kt
@@ -65,6 +65,12 @@ data class PersistedGroup(
      * `Map<String, MemberProfile>` keyed by lowercase BLS pubkey hex.
      */
     val encryptedMemberProfilesJson: ByteArray? = null,
+    /**
+     * Optional Ed25519 pubkey of the admin (PR 84). `null` on rows
+     * migrated from the pre-PR-84 schema, or for governance models
+     * without an admin (Anarchy / OneOnOne).
+     */
+    val encryptedAdminEd25519PubkeyHex: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -82,7 +88,8 @@ data class PersistedGroup(
             encryptedSalt.contentEquals(other.encryptedSalt) &&
             (encryptedCommitment?.contentEquals(other.encryptedCommitment) ?: (other.encryptedCommitment == null)) &&
             (encryptedAdminPubkeyHex?.contentEquals(other.encryptedAdminPubkeyHex) ?: (other.encryptedAdminPubkeyHex == null)) &&
-            (encryptedMemberProfilesJson?.contentEquals(other.encryptedMemberProfilesJson) ?: (other.encryptedMemberProfilesJson == null))
+            (encryptedMemberProfilesJson?.contentEquals(other.encryptedMemberProfilesJson) ?: (other.encryptedMemberProfilesJson == null)) &&
+            (encryptedAdminEd25519PubkeyHex?.contentEquals(other.encryptedAdminEd25519PubkeyHex) ?: (other.encryptedAdminEd25519PubkeyHex == null))
     }
 
     override fun hashCode(): Int {
@@ -100,6 +107,7 @@ data class PersistedGroup(
         h = 31 * h + (encryptedCommitment?.contentHashCode() ?: 0)
         h = 31 * h + (encryptedAdminPubkeyHex?.contentHashCode() ?: 0)
         h = 31 * h + (encryptedMemberProfilesJson?.contentHashCode() ?: 0)
+        h = 31 * h + (encryptedAdminEd25519PubkeyHex?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/RoomGroupStore.kt
@@ -104,6 +104,7 @@ class RoomGroupStore(
             encryptedCommitment = group.commitment?.let(encryption::encrypt),
             encryptedAdminPubkeyHex = group.adminPubkeyHex?.let(encryption::encrypt),
             encryptedMemberProfilesJson = memberProfilesEncrypted,
+            encryptedAdminEd25519PubkeyHex = group.adminEd25519PubkeyHex?.let(encryption::encrypt),
         )
     }
 
@@ -128,6 +129,7 @@ class RoomGroupStore(
         val groupType = SepGroupType.fromWire(row.groupTypeRaw) ?: return null
         val commitment = row.encryptedCommitment?.let { tryDecrypt(it) }
         val adminPubkeyHex = row.encryptedAdminPubkeyHex?.let { tryDecryptString(it) }
+        val adminEd25519PubkeyHex = row.encryptedAdminEd25519PubkeyHex?.let { tryDecryptString(it) }
         val memberProfiles: Map<String, MemberProfile> = row.encryptedMemberProfilesJson
             ?.let { tryDecrypt(it) }
             ?.let { bytes ->
@@ -158,6 +160,7 @@ class RoomGroupStore(
             tier = tier,
             groupType = groupType,
             adminPubkeyHex = adminPubkeyHex,
+            adminEd25519PubkeyHex = adminEd25519PubkeyHex,
             isPublishedOnChain = row.isPublishedOnChain,
             ownerIdentityId = row.ownerIdentityId,
         )

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -118,7 +118,7 @@ class IncomingMessageDispatcher(
     private suspend fun materializeGroup(
         invitation: GroupInvitationPayload,
         ownerIdentityId: IdentityId,
-        @Suppress("UNUSED_PARAMETER") senderEd25519PublicKey: ByteArray?,
+        senderEd25519PublicKey: ByteArray?,
     ) {
         val tier = SepTier.entries.firstOrNull { it.rawValue == invitation.tierRaw } ?: return
         val groupType = SepGroupType.fromWire(invitation.groupTypeRaw) ?: return
@@ -129,6 +129,16 @@ class IncomingMessageDispatcher(
         val profiles = (invitation.memberProfiles ?: emptyMap()).toMutableMap()
         selfMemberProfileEntry(ownerIdentityId)?.let { (key, profile) ->
             profiles[key] = profile
+        }
+
+        // PR 84: stamp the inviting envelope's Ed25519 pubkey as the
+        // group's admin signing key. Subsequent
+        // `MemberAnnouncementPayload` apply paths verify the sender
+        // matches. `null` for Anarchy / OneOnOne (no admin), or when
+        // the envelope shipped without a signature block.
+        val adminEd25519PubkeyHex: String? = when (groupType) {
+            SepGroupType.ANARCHY, SepGroupType.ONE_ON_ONE -> null
+            else -> senderEd25519PublicKey?.toHexLowercase()
         }
 
         val groupIdHex = invitation.groupId.toHexLowercase()
@@ -145,6 +155,7 @@ class IncomingMessageDispatcher(
             tier = tier,
             groupType = groupType,
             adminPubkeyHex = invitation.adminPubkeyHex,
+            adminEd25519PubkeyHex = adminEd25519PubkeyHex,
             // Sender already anchored before sending the invite, so
             // by the time it lands the group is on chain.
             isPublishedOnChain = true,
@@ -205,12 +216,24 @@ class IncomingMessageDispatcher(
      */
     private suspend fun applyAnnouncement(
         payload: MemberAnnouncementPayload,
-        @Suppress("UNUSED_PARAMETER") senderEd25519PublicKey: ByteArray?,
+        senderEd25519PublicKey: ByteArray?,
     ) {
         val groups = groupRepository.snapshots.value
         val group = groups.firstOrNull {
             it.groupIdBytes.contentEquals(payload.groupId)
         } ?: return
+
+        // PR 84 trust check: announcement must be signed by the
+        // group's known admin. Skipped (best-effort) when the group
+        // has no stored admin Ed25519 — happens for governance
+        // models without an admin (Anarchy / OneOnOne) or pre-PR-84
+        // rows that materialized before the field existed.
+        val storedAdmin = group.adminEd25519PubkeyHex
+        if (storedAdmin != null) {
+            val sender = senderEd25519PublicKey ?: return
+            val senderHex = sender.toHexLowercase()
+            if (senderHex != storedAdmin.lowercase()) return
+        }
 
         val key = payload.newMember.blsPub.toHexLowercase()
         if (group.memberProfiles[key] != null) return  // dedup

--- a/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/inbox/IncomingMessageDispatcherTest.kt
@@ -268,6 +268,48 @@ class IncomingMessageDispatcherTest {
     }
 
     @Test
+    fun announcement_droppedWhenSenderDoesNotMatchStoredAdmin() = runTest {
+        // Seed a group whose adminEd25519PubkeyHex is set.
+        val storedAdmin = ByteArray(32) { 0x10 }
+        val storedAdminHex = storedAdmin.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        groupStore.replaceForTest(makeGroup(groupId).copy(adminEd25519PubkeyHex = storedAdminHex))
+        groupRepository.reload()
+
+        val payload = announcementPayload()
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        // Forged announcement — different sender pubkey.
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32) { 0x99.toByte() }),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        // Forged announcement must NOT mutate the group.
+        assertTrue(groupRepository.snapshots.value.single().memberProfiles.isEmpty())
+    }
+
+    @Test
+    fun announcement_acceptedWhenSenderMatchesStoredAdmin() = runTest {
+        val storedAdmin = ByteArray(32) { 0x10 }
+        val storedAdminHex = storedAdmin.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        groupStore.replaceForTest(makeGroup(groupId).copy(adminEd25519PubkeyHex = storedAdminHex))
+        groupRepository.reload()
+
+        val payload = announcementPayload()
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = storedAdmin),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+        assertEquals(1, groupRepository.snapshots.value.single().memberProfiles.size)
+    }
+
+    @Test
     fun unrecognizedPlaintext_fallsThroughToQueue() = runTest {
         val dispatcher = IncomingMessageDispatcher(
             envelopeDecrypter = StubDecrypter(
@@ -360,6 +402,12 @@ private class InMemoryGroupStore : GroupStore {
         )
     }
     override suspend fun delete(id: String) { rows.remove(id) }
+
+    /** Test-only helper — replace a row by id without going through
+     *  insertOrUpdate's "preserve createdAt" branch. */
+    fun replaceForTest(group: ChatGroup) {
+        rows[group.id] = group
+    }
 }
 
 private class ConstantIdentity(private val id: IdentityId) : ActiveIdentityProvider {


### PR DESCRIPTION
## Summary

Closes a trust gap: anyone who knows a member's inbox pubkey could encrypt a forged `MemberAnnouncementPayload`. The outer `SealedEnvelope`'s Ed25519 signature is already verified; this PR cross-checks the signer matches the group's stored admin Ed25519.

- `ChatGroup` grows nullable `adminEd25519PubkeyHex` (lowercase 64 hex chars). Encrypted on disk via a v4 → v5 non-destructive migration.
- `CreateGroupInteractor` stamps it from the creator's Stellar pubkey (Tyranny only).
- `IncomingMessageDispatcher.materializeGroup` stamps it from the inviting envelope's `senderEd25519PublicKey` (Tyranny only).
- `applyAnnouncement` drops messages where the sender doesn't match. Null `adminEd25519PubkeyHex` (pre-PR-84 row, or non-admin governance) falls back to V1 best-effort.

Stacked on `inbox/joiner-materialization` (PR #103). Mirrors onym-ios PR #84.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `IncomingMessageDispatcherTest.announcement_droppedWhenSenderDoesNotMatchStoredAdmin`
- [ ] `IncomingMessageDispatcherTest.announcement_acceptedWhenSenderMatchesStoredAdmin`
- [ ] Pre-PR-84 best-effort path still covered by the original announcement-applied test (group has no `adminEd25519PubkeyHex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)