### PR TITLE
feat(chats): share invite link from chat-members view

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -186,6 +186,13 @@ fun RootScreen(
                     chatsViewModel = chatsVm,
                     identityViewModel = identitiesVm,
                     onBack = { navController.popBackStack() },
+                    onShareInviteClick = {
+                        // Reuse the existing share-invite surface —
+                        // ShareInviteScreen + ShareInviteViewModel
+                        // already know how to mint a fresh
+                        // IntroCapability + render the deeplink URL.
+                        navController.navigate("share_invite/$groupId")
+                    },
                 )
             }
             composable(ROUTE_APPROVE_REQUESTS) {


### PR DESCRIPTION
## Summary

Wire the Share Invite toolbar slot on `ChatMembersScreen` (added as a slot in PR 81) to navigate to the existing `share_invite/{groupId}` destination. Admin can now share a fresh invite for an existing group, not just at create time.

PR 94 will hide the button for non-admins. Until then, the same admin-only enforcement that already exists on chain (sep-tyranny rejects `update_commitment` proofs from non-admins) is the trust basis.

Stacked on `group/approver-tests` (PR #105). Mirrors onym-ios PR #86.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] Manual smoke: tap a chat row → Share Invite toolbar button → existing share-invite UI opens with the right groupId

🤖 Generated with [Claude Code](https://claude.com/claude-code)