### PR TITLE
feat(transport): Nostr relays config + Settings → Transport section

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/chat/onym/android/AppDependencies.kt
@@ -59,4 +59,9 @@ class AppDependencies(
      *  lands on the relay shows up in the badge before the modal
      *  is opened. */
     val approveRequestsViewModel: chat.onym.android.group.ApproveRequestsViewModel,
+    /** Settings → Transport → Nostr Relays. */
+    val makeNostrRelaySettingsViewModel: () -> chat.onym.android.settings.NostrRelaySettingsViewModel,
+    /** Live snapshot of configured Nostr relays — drives the
+     *  Settings entry's "{n} configured" subtitle. */
+    val nostrRelaysFlow: kotlinx.coroutines.flow.StateFlow<chat.onym.android.transport.nostr.NostrRelaysConfiguration>,
 )

--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -81,6 +81,15 @@ private val Context.networkPreferenceDataStore: DataStore<Preferences> by prefer
 )
 
 /**
+ * DataStore Preferences for Nostr relay configuration. Separate
+ * from [relayerDataStore] (which holds chain-relayer URLs) — different
+ * domain, different lifecycle.
+ */
+private val Context.nostrRelaysDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "chat.onym.android.nostr_relays_prefs",
+)
+
+/**
  * Composition root. Two responsibilities:
  *
  *  - Register the BouncyCastle JCE provider once at process start
@@ -301,10 +310,40 @@ class OnymApplication : Application() {
         groupRepository.start()
         applicationScope.launch { groupRepository.reload() }
 
+        // PR 87: Nostr relays configuration + first-launch seed. The
+        // inbox transport reads endpoints once at boot — no live
+        // re-connect on Settings changes (a banner explains this).
+        // Without this seed the user sees "send: not connected" on
+        // every send attempt, since nothing else wires endpoints
+        // into NostrInboxTransport at startup.
+        val nostrRelaysRepository = chat.onym.android.transport.nostr.NostrRelaysRepository(
+            store = chat.onym.android.transport.nostr.DataStoreNostrRelaysSelectionStore(
+                dataStore = applicationContext.nostrRelaysDataStore,
+            ),
+        )
+        applicationScope.launch { nostrRelaysRepository.bootstrap() }
+
         // Inbox transport for invitation send. Constructed once;
         // CreateGroupInteractor.create blocks on `send` (which
         // connects on first use via `NostrInboxTransport`).
         val inboxTransport = NostrInboxTransport(signerProvider = nostrSignerProvider)
+        applicationScope.launch {
+            // Bootstrap above writes _snapshots; this read happens on
+            // the same scope so it observes the bootstrap result.
+            nostrRelaysRepository.bootstrap()
+            val endpoints = nostrRelaysRepository.currentEndpoints()
+            if (endpoints.isNotEmpty()) {
+                runCatching {
+                    inboxTransport.connect(
+                        endpoints.map { endpoint ->
+                            chat.onym.android.transport.TransportEndpoint(
+                                java.net.URI(endpoint.url),
+                            )
+                        },
+                    )
+                }
+            }
+        }
 
         // Multi-identity inbox fan-out (PR-4) + per-identity
         // decryption routing (PR-6). Subscribes to every identity's
@@ -489,6 +528,12 @@ class OnymApplication : Application() {
                 )
             },
             approveRequestsViewModel = approveRequestsViewModel,
+            makeNostrRelaySettingsViewModel = {
+                chat.onym.android.settings.NostrRelaySettingsViewModel(
+                    repository = nostrRelaysRepository,
+                )
+            },
+            nostrRelaysFlow = nostrRelaysRepository.snapshots,
             makeJoinViewModel = { capability ->
                 // Suggest the active identity's display name as the
                 // initial label. Falls back to a generic "Anonymous"

--- a/app/src/main/kotlin/chat/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/RootScreen.kt
@@ -214,6 +214,7 @@ fun RootScreen(
                         initializer { dependencies.makeIdentitiesViewModel() }
                     },
                 )
+                val nostrRelays by dependencies.nostrRelaysFlow.collectAsStateWithLifecycle()
                 SettingsScreen(
                     identitiesViewModel = identitiesVm,
                     onRelayerClick = { navController.navigate(ROUTE_RELAYER_SETTINGS) },
@@ -233,6 +234,8 @@ fun RootScreen(
                             )
                         }
                     },
+                    onNostrRelaysClick = { navController.navigate(ROUTE_NOSTR_RELAYS) },
+                    nostrRelaysCount = nostrRelays.endpoints.size,
                 )
             }
             composable(ROUTE_CREATE_GROUP) {
@@ -344,6 +347,17 @@ fun RootScreen(
             }
             composable(ROUTE_ABOUT) {
                 AboutOnymScreen(
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable(ROUTE_NOSTR_RELAYS) {
+                val vm = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeNostrRelaySettingsViewModel() }
+                    },
+                ) as chat.onym.android.settings.NostrRelaySettingsViewModel
+                chat.onym.android.settings.NostrRelaySettingsScreen(
+                    viewModel = vm,
                     onBack = { navController.popBackStack() },
                 )
             }
@@ -503,6 +517,7 @@ private const val ROUTE_IDENTITIES = "identities"
 private const val ROUTE_PRIVACY = "privacy"
 private const val ROUTE_ABOUT = "about_onym"
 private const val ROUTE_RELAYER_SETTINGS = "relayer_settings"
+private const val ROUTE_NOSTR_RELAYS = "nostr_relays"
 private const val ROUTE_RUN_RELAYER = "run_relayer"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"

--- a/app/src/main/kotlin/chat/onym/android/settings/NostrRelaySettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/NostrRelaySettingsScreen.kt
@@ -1,0 +1,291 @@
+package chat.onym.android.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import chat.onym.android.transport.nostr.NostrRelayEndpoint
+
+/**
+ * Settings → Transport → Nostr Relays. Mirrors
+ * `NostrRelaySettingsView.swift` from onym-ios PR #87.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NostrRelaySettingsScreen(
+    viewModel: NostrRelaySettingsViewModel,
+    onBack: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Nostr Relays") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding).testTag("nostr.list"),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            item {
+                ConfiguredCard(
+                    endpoints = state.snapshot.endpoints,
+                    onRemove = viewModel::tappedRemove,
+                )
+            }
+            item {
+                AddCustomCard(
+                    draft = state.customDraft,
+                    error = state.customDraftError,
+                    onChange = viewModel::customDraftChanged,
+                    onAdd = viewModel::tappedAddCustom,
+                )
+            }
+            item {
+                SectionFootnote(
+                    "Use a private deployment, localhost, or any Nostr relay you trust. " +
+                        "URLs must use the wss:// (or ws://) scheme.",
+                )
+            }
+            item {
+                ResetCard(onReset = viewModel::tappedResetToDefault)
+            }
+            item {
+                SectionFootnote(
+                    "Changes apply on the next app launch. The inbox transport reads " +
+                        "relays once at boot.",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfiguredCard(
+    endpoints: List<NostrRelayEndpoint>,
+    onRemove: (String) -> Unit,
+) {
+    SectionLabel(text = "CONFIGURED · ${endpoints.size}")
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        if (endpoints.isEmpty()) {
+            Text(
+                text = "No relays configured.",
+                modifier = Modifier
+                    .padding(16.dp)
+                    .testTag("nostr.configured.empty"),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            endpoints.forEachIndexed { idx, endpoint ->
+                EndpointRow(endpoint = endpoint, onRemove = { onRemove(endpoint.url) })
+                if (idx != endpoints.lastIndex) HorizontalDivider(thickness = 0.5.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EndpointRow(
+    endpoint: NostrRelayEndpoint,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(Icons.Filled.Cloud, contentDescription = null, modifier = Modifier.size(20.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(endpoint.name, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+                if (endpoint.isDefault) {
+                    Spacer(Modifier.size(6.dp))
+                    DefaultPill()
+                }
+            }
+            Text(
+                text = endpoint.url,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier.testTag("nostr.configured.remove.${endpoint.url}"),
+        ) {
+            Icon(Icons.Filled.Delete, contentDescription = "Remove")
+        }
+    }
+}
+
+@Composable
+private fun AddCustomCard(
+    draft: String,
+    error: String?,
+    onChange: (String) -> Unit,
+    onAdd: () -> Unit,
+) {
+    SectionLabel(text = "ADD CUSTOM URL")
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedTextField(
+            value = draft,
+            onValueChange = onChange,
+            placeholder = { Text("wss://relay.example.com") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("nostr.add.custom_url_field"),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction = ImeAction.Done,
+                capitalization = KeyboardCapitalization.None,
+            ),
+            isError = error != null,
+        )
+        if (error != null) {
+            Text(
+                text = error,
+                modifier = Modifier.testTag("nostr.add.custom_error"),
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        Button(
+            onClick = onAdd,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("nostr.add.custom_button"),
+        ) {
+            Text("Add")
+        }
+    }
+}
+
+@Composable
+private fun ResetCard(onReset: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp)
+                .testTag("nostr.reset_default"),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(Icons.Filled.RestartAlt, contentDescription = null, modifier = Modifier.size(20.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Restore default", fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+                Text(
+                    text = "Re-seed the configuration with the Onym Official relay.",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Button(onClick = onReset) { Text("Reset") }
+        }
+    }
+}
+
+@Composable
+private fun DefaultPill() {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
+            .padding(horizontal = 6.dp, vertical = 1.dp),
+    ) {
+        Text(
+            "DEFAULT",
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        modifier = Modifier.padding(start = 16.dp, bottom = 6.dp),
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun SectionFootnote(text: String) {
+    Text(
+        text = text,
+        modifier = Modifier.padding(horizontal = 16.dp),
+        fontSize = 12.sp,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Start,
+    )
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/NostrRelaySettingsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/NostrRelaySettingsViewModel.kt
@@ -1,0 +1,96 @@
+package chat.onym.android.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import chat.onym.android.transport.nostr.NostrRelayEndpoint
+import chat.onym.android.transport.nostr.NostrRelaysConfiguration
+import chat.onym.android.transport.nostr.NostrRelaysRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.net.URI
+
+/**
+ * View-state for the Settings → Transport → Nostr Relays screen.
+ *
+ * Mirrors `NostrRelaySettingsFlow.swift` from onym-ios PR #87.
+ */
+data class NostrRelaySettingsState(
+    val snapshot: NostrRelaysConfiguration = NostrRelaysConfiguration.empty,
+    val customDraft: String = "",
+    val customDraftError: String? = null,
+)
+
+class NostrRelaySettingsViewModel(
+    private val repository: NostrRelaysRepository,
+) : ViewModel() {
+
+    private val _draft = MutableStateFlow("")
+    private val _draftError = MutableStateFlow<String?>(null)
+
+    val state: StateFlow<NostrRelaySettingsState> = combine(
+        repository.snapshots,
+        _draft,
+        _draftError,
+    ) { snapshot, draft, error ->
+        NostrRelaySettingsState(snapshot = snapshot, customDraft = draft, customDraftError = error)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = NostrRelaySettingsState(),
+    )
+
+    fun customDraftChanged(text: String) {
+        _draft.value = text
+        _draftError.value = null
+    }
+
+    fun tappedAddCustom() {
+        val raw = _draft.value
+        val normalized = validate(raw)
+        if (normalized == null) {
+            _draftError.value =
+                "Use wss:// or ws:// with a hostname, e.g. wss://relay.example.com"
+            return
+        }
+        viewModelScope.launch {
+            val added = repository.addEndpoint(NostrRelayEndpoint.custom(normalized))
+            if (added) {
+                _draft.value = ""
+                _draftError.value = null
+            } else {
+                _draftError.value = "That URL is already configured."
+            }
+        }
+    }
+
+    fun tappedRemove(url: String) {
+        viewModelScope.launch { repository.removeEndpoint(url) }
+    }
+
+    fun tappedResetToDefault() {
+        viewModelScope.launch { repository.resetToDefault() }
+    }
+
+    companion object {
+        /** Returns the trimmed URL when it's a valid wss/ws URL with a
+         *  non-empty host; null otherwise. */
+        fun validate(raw: String): String? {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return null
+            return try {
+                val uri = URI(trimmed)
+                val scheme = uri.scheme?.lowercase()
+                val host = uri.host
+                if ((scheme == "wss" || scheme == "ws") && !host.isNullOrEmpty()) trimmed
+                else null
+            } catch (_: Throwable) {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/chat/onym/android/settings/SettingsScreen.kt
@@ -85,6 +85,11 @@ fun SettingsScreen(
      *  → "Use Mainnet" Switch. */
     useMainnet: Boolean,
     onToggleMainnet: (Boolean) -> Unit,
+    /** Settings → Transport → Nostr Relays entry. PR 87. */
+    onNostrRelaysClick: (() -> Unit)? = null,
+    /** Live count of configured Nostr relays — drives the Settings
+     *  row's subtitle. */
+    nostrRelaysCount: Int = 0,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(
         rememberTopAppBarState()
@@ -162,6 +167,26 @@ fun SettingsScreen(
                         isLast = true,
                         modifier = Modifier.testTag("settings.privacy_row"),
                     )
+                }
+            }
+
+            // ─── TRANSPORT ─────────────────────────────────────────
+            if (onNostrRelaysClick != null) {
+                item { SettingsSectionLabel("TRANSPORT") }
+                item {
+                    SettingsCard {
+                        SettingsRow(
+                            leading = {
+                                SettingsTileBox(Icons.Filled.Cloud, SettingsTile.Indigo)
+                            },
+                            title = "Nostr Relays",
+                            subtitle = if (nostrRelaysCount == 1) "1 configured"
+                            else "$nostrRelaysCount configured",
+                            onClick = onNostrRelaysClick,
+                            isLast = true,
+                            modifier = Modifier.testTag("settings.nostr_relays_row"),
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelayEndpoint.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelayEndpoint.kt
@@ -1,0 +1,56 @@
+package chat.onym.android.transport.nostr
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Configured Nostr relay endpoint persisted in the device's
+ * preferences. URL is stored as a String so the [java.net.URI] /
+ * [java.net.URL] coercion lives at use sites only.
+ *
+ * Mirrors `NostrRelayEndpoint.swift` from onym-ios PR #87.
+ */
+@Serializable
+data class NostrRelayEndpoint(
+    val url: String,
+    val name: String,
+    val isDefault: Boolean = false,
+) {
+    companion object {
+        /** Onym-operated default relay, seeded on first launch so the
+         *  inbox transport has somewhere to connect before the user
+         *  configures anything. */
+        val onymOfficial = NostrRelayEndpoint(
+            url = "wss://nostr.onym.chat",
+            name = "Onym Official",
+            isDefault = true,
+        )
+
+        fun custom(url: String): NostrRelayEndpoint =
+            NostrRelayEndpoint(url = url, name = "Custom", isDefault = false)
+    }
+}
+
+/**
+ * Persisted snapshot of the user's relay preferences.
+ *
+ * [hasUserInteracted] is the sticky bit that controls whether the
+ * "first launch seed" applies on subsequent boots: once the user
+ * adds, removes, or otherwise touches the list, we never re-seed
+ * — even if they end up with an empty list. [resetToDefault] flips
+ * it back to `false` so a deliberate reset re-enables seeding.
+ *
+ * Mirrors `NostrRelaysConfiguration.swift` from onym-ios PR #87.
+ */
+@Serializable
+data class NostrRelaysConfiguration(
+    val endpoints: List<NostrRelayEndpoint> = emptyList(),
+    val hasUserInteracted: Boolean = false,
+) {
+    companion object {
+        val empty = NostrRelaysConfiguration()
+        val seed = NostrRelaysConfiguration(
+            endpoints = listOf(NostrRelayEndpoint.onymOfficial),
+            hasUserInteracted = false,
+        )
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelaysRepository.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelaysRepository.kt
@@ -1,0 +1,97 @@
+package chat.onym.android.transport.nostr
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns the in-memory view of [NostrRelaysConfiguration] + writes to
+ * the persistence seam. The inbox transport reads relay endpoints
+ * once at boot via [currentEndpoints]; live re-connect on settings
+ * change is out of scope for V1.
+ *
+ * First-launch seed: if storage starts empty AND
+ * [NostrRelaysConfiguration.hasUserInteracted] is false, the
+ * repository writes [NostrRelaysConfiguration.seed] back to disk
+ * so subsequent launches load the seeded config without going
+ * through the seed branch again. The bit flips to `true` on every
+ * mutation EXCEPT [resetToDefault] (which restores the seed and
+ * re-enables seeding for any future "clear + relaunch" flow).
+ *
+ * Mirrors `NostrRelaysRepository.swift` from onym-ios PR #87.
+ */
+class NostrRelaysRepository(
+    private val store: NostrRelaysSelectionStore,
+) {
+    private val mutex = Mutex()
+    private val _snapshots = MutableStateFlow(NostrRelaysConfiguration.empty)
+    val snapshots: StateFlow<NostrRelaysConfiguration> = _snapshots.asStateFlow()
+
+    /** Hydrate from disk + apply the first-launch seed when relevant.
+     *  Idempotent — safe to call from `onCreate` / app start. */
+    suspend fun bootstrap() = mutex.withLock {
+        val loaded = store.load()
+        val effective = if (loaded.endpoints.isEmpty() && !loaded.hasUserInteracted) {
+            store.save(NostrRelaysConfiguration.seed)
+            NostrRelaysConfiguration.seed
+        } else {
+            loaded
+        }
+        _snapshots.value = effective
+    }
+
+    /** Read snapshot — non-suspend convenience for boot wiring. */
+    fun currentEndpoints(): List<NostrRelayEndpoint> = _snapshots.value.endpoints
+
+    /** Append [endpoint] when its URL isn't already configured.
+     *  Returns `true` on append, `false` on duplicate-no-op. Flips
+     *  [NostrRelaysConfiguration.hasUserInteracted] to `true`. */
+    suspend fun addEndpoint(endpoint: NostrRelayEndpoint): Boolean = mutex.withLock {
+        val current = _snapshots.value
+        if (current.endpoints.any { it.url == endpoint.url }) return@withLock false
+        val updated = current.copy(
+            endpoints = current.endpoints + endpoint,
+            hasUserInteracted = true,
+        )
+        store.save(updated)
+        _snapshots.value = updated
+        true
+    }
+
+    /** Remove the endpoint matching [url]. Flips
+     *  [NostrRelaysConfiguration.hasUserInteracted] to `true` even
+     *  when the URL isn't configured (matches iOS — the user pressed
+     *  Remove, that's interaction). */
+    suspend fun removeEndpoint(url: String) = mutex.withLock {
+        val current = _snapshots.value
+        val updated = current.copy(
+            endpoints = current.endpoints.filter { it.url != url },
+            hasUserInteracted = true,
+        )
+        store.save(updated)
+        _snapshots.value = updated
+    }
+
+    /** Restore the seeded default. Resets [hasUserInteracted] to
+     *  `false` so a subsequent "clear all" + relaunch re-enables the
+     *  first-launch seed branch. */
+    suspend fun resetToDefault() = mutex.withLock {
+        store.save(NostrRelaysConfiguration.seed)
+        _snapshots.value = NostrRelaysConfiguration.seed
+    }
+
+    /** Wipe every endpoint (without going through the seed branch).
+     *  Useful when the user wants an explicitly-empty configuration
+     *  — interactionFlag stays `true` so we don't re-seed at next
+     *  launch. */
+    suspend fun clearAll() = mutex.withLock {
+        val updated = NostrRelaysConfiguration(
+            endpoints = emptyList(),
+            hasUserInteracted = true,
+        )
+        store.save(updated)
+        _snapshots.value = updated
+    }
+}

--- a/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelaysSelectionStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/transport/nostr/NostrRelaysSelectionStore.kt
@@ -1,0 +1,61 @@
+package chat.onym.android.transport.nostr
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.json.Json
+
+/**
+ * Persistence seam for [NostrRelaysConfiguration]. Same DataStore
+ * Preferences pattern as the relayer + contracts stores; the JSON
+ * blob lives under a single key so the schema can grow without
+ * touching the storage layer.
+ *
+ * Mirrors `NostrRelaysSelectionStore.swift` from onym-ios PR #87.
+ */
+interface NostrRelaysSelectionStore {
+    suspend fun load(): NostrRelaysConfiguration
+    suspend fun save(config: NostrRelaysConfiguration)
+}
+
+/** Production [NostrRelaysSelectionStore] backed by DataStore. */
+class DataStoreNostrRelaysSelectionStore(
+    private val dataStore: DataStore<Preferences>,
+) : NostrRelaysSelectionStore {
+
+    override suspend fun load(): NostrRelaysConfiguration {
+        val prefs = dataStore.data.first()
+        val raw = prefs[KEY_CONFIG] ?: return NostrRelaysConfiguration.empty
+        return try {
+            jsonFormat.decodeFromString(NostrRelaysConfiguration.serializer(), raw)
+        } catch (_: Throwable) {
+            NostrRelaysConfiguration.empty
+        }
+    }
+
+    override suspend fun save(config: NostrRelaysConfiguration) {
+        val raw = jsonFormat.encodeToString(NostrRelaysConfiguration.serializer(), config)
+        dataStore.edit { it[KEY_CONFIG] = raw }
+    }
+
+    private companion object {
+        private val KEY_CONFIG = stringPreferencesKey("nostr.relays.config.v1")
+        private val jsonFormat = Json { ignoreUnknownKeys = true }
+    }
+}
+
+/** In-memory [NostrRelaysSelectionStore] for tests. */
+class InMemoryNostrRelaysSelectionStore(
+    initial: NostrRelaysConfiguration = NostrRelaysConfiguration.empty,
+) : NostrRelaysSelectionStore {
+    @Volatile
+    private var snapshot: NostrRelaysConfiguration = initial
+
+    override suspend fun load(): NostrRelaysConfiguration = snapshot
+
+    override suspend fun save(config: NostrRelaysConfiguration) {
+        snapshot = config
+    }
+}

--- a/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrRelaysRepositoryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/transport/nostr/NostrRelaysRepositoryTest.kt
@@ -1,0 +1,105 @@
+package chat.onym.android.transport.nostr
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioral tests for [NostrRelaysRepository] — first-launch seed,
+ * sticky-interaction bit, add / remove / reset semantics.
+ *
+ * Mirrors `NostrRelaysRepositoryTests.swift` from onym-ios PR #87.
+ */
+class NostrRelaysRepositoryTest {
+
+    @Test
+    fun firstLaunch_seedsOnymOfficial() = runTest {
+        val store = InMemoryNostrRelaysSelectionStore(NostrRelaysConfiguration.empty)
+        val repo = NostrRelaysRepository(store)
+        repo.bootstrap()
+
+        val snap = repo.snapshots.value
+        assertEquals(1, snap.endpoints.size)
+        assertEquals("wss://nostr.onym.chat", snap.endpoints[0].url)
+        assertTrue(snap.endpoints[0].isDefault)
+        assertFalse("seed leaves hasUserInteracted=false", snap.hasUserInteracted)
+        // Seed is persisted so subsequent boots load it directly.
+        assertEquals(snap, store.load())
+    }
+
+    @Test
+    fun userClearedAll_doesNotReSeedOnRelaunch() = runTest {
+        // User cleared the list — store has empty endpoints +
+        // hasUserInteracted = true.
+        val cleared = NostrRelaysConfiguration(emptyList(), hasUserInteracted = true)
+        val store = InMemoryNostrRelaysSelectionStore(cleared)
+        val repo = NostrRelaysRepository(store)
+        repo.bootstrap()
+        assertEquals(0, repo.snapshots.value.endpoints.size)
+        assertTrue(repo.snapshots.value.hasUserInteracted)
+    }
+
+    @Test
+    fun addEndpoint_appendsAndFlipsInteraction() = runTest {
+        val repo = bootstrappedRepo()
+        val added = repo.addEndpoint(NostrRelayEndpoint.custom("wss://relay.example.com"))
+        assertTrue(added)
+        assertEquals(2, repo.snapshots.value.endpoints.size)
+        assertTrue(repo.snapshots.value.hasUserInteracted)
+    }
+
+    @Test
+    fun addEndpoint_duplicateIsNoOp() = runTest {
+        val repo = bootstrappedRepo()
+        val added = repo.addEndpoint(NostrRelayEndpoint.onymOfficial)
+        assertFalse(added)
+        assertEquals(1, repo.snapshots.value.endpoints.size)
+    }
+
+    @Test
+    fun removeEndpoint_drops() = runTest {
+        val repo = bootstrappedRepo()
+        repo.removeEndpoint("wss://nostr.onym.chat")
+        assertEquals(0, repo.snapshots.value.endpoints.size)
+        assertTrue(repo.snapshots.value.hasUserInteracted)
+    }
+
+    @Test
+    fun resetToDefault_restoresSeedAndClearsInteraction() = runTest {
+        val repo = bootstrappedRepo()
+        repo.removeEndpoint("wss://nostr.onym.chat")
+        assertTrue(repo.snapshots.value.hasUserInteracted)
+
+        repo.resetToDefault()
+        assertEquals(1, repo.snapshots.value.endpoints.size)
+        assertFalse(repo.snapshots.value.hasUserInteracted)
+    }
+
+    @Test
+    fun viewModel_validatesScheme() {
+        assertNotNull(
+            NostrRelaySettingsViewModelValidate("wss://x.com"),
+        )
+        assertNotNull(
+            NostrRelaySettingsViewModelValidate("ws://localhost:7777"),
+        )
+        assertEquals(null, NostrRelaySettingsViewModelValidate("https://x.com"))
+        assertEquals(null, NostrRelaySettingsViewModelValidate(""))
+        assertEquals(null, NostrRelaySettingsViewModelValidate("   "))
+    }
+
+    private suspend fun bootstrappedRepo(): NostrRelaysRepository {
+        val store = InMemoryNostrRelaysSelectionStore(NostrRelaysConfiguration.empty)
+        val repo = NostrRelaysRepository(store)
+        repo.bootstrap()
+        return repo
+    }
+
+    /** Bridge to the static validator so this test file doesn't have
+     *  to import the `chat.onym.android.settings` package. */
+    private fun NostrRelaySettingsViewModelValidate(raw: String): String? =
+        chat.onym.android.settings.NostrRelaySettingsViewModel.validate(raw)
+}


### PR DESCRIPTION
## Summary

Adds Nostr-relay configuration with first-launch seed of \`wss://nostr.onym.chat\` so the inbox transport actually has somewhere to connect at boot. This fixes the \`send: not connected\` symptom seen on real devices.

- `NostrRelayEndpoint`, `NostrRelaysConfiguration` value types.
- `DataStoreNostrRelaysSelectionStore` (DataStore Preferences-backed).
- `NostrRelaysRepository`: first-launch seed + sticky `hasUserInteracted` bit + add/remove/reset semantics. `resetToDefault` clears the bit so a deliberate reset re-enables seeding.
- Settings → Transport → Nostr Relays screen (`NostrRelaySettingsScreen` + view-model).
- Boot wiring: `NostrInboxTransport.connect` runs once at app start.

Stacked on `chats/share-invite-from-members` (PR #106). Mirrors onym-ios PR #87.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `NostrRelaysRepositoryTest` covers first-launch seed, sticky-interaction bit, add/remove/reset, validation.
- [ ] Manual smoke: fresh install boots with Onym Official; Settings → Transport row shows "1 configured"; Create Group → invite send no longer fails with "not connected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)