### PR TITLE
feat(group): admin anchors update_commitment on approve

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/chat/onym/android/OnymApplication.kt
@@ -437,6 +437,15 @@ class OnymApplication : Application() {
 
         // Approver-side: turn raw IntroRequests into UI-renderable
         // pending requests + ship sealed GroupInvitationPayloads on
+        // App-wide network preference (PR-C follow-up). Defaults to
+        // testnet; the Settings → Network → "Use Mainnet" Switch
+        // flips it. CreateGroupInteractor reads `current()` per call
+        // for both the contract-binding lookup and the wire payload's
+        // top-level `network` field.
+        val networkPreference = DataStoreNetworkPreferenceProvider(
+            dataStore = applicationContext.networkPreferenceDataStore,
+        )
+
         // user approval. Single instance — the toolbar badge + the
         // modal screen share state via [ApproveRequestsViewModel].
         val joinRequestApprover = chat.onym.android.group.JoinRequestApprover(
@@ -446,6 +455,15 @@ class OnymApplication : Application() {
             groupRepository = groupRepository,
             inboxTransport = inboxTransport,
             scope = applicationScope,
+            // PR 88 admin-anchor wiring: same OkHttp client as
+            // CreateGroupInteractor so the relayer's auth token rides
+            // along.
+            relayers = relayerRepository,
+            contracts = contractsRepository,
+            networkPreference = networkPreference,
+            makeContractTransport = { url ->
+                OkHttpSepContractTransport(httpClient = httpClient, endpointUrl = url)
+            },
         )
         val approveRequestsViewModel = chat.onym.android.group.ApproveRequestsViewModel(
             approver = joinRequestApprover,
@@ -453,15 +471,6 @@ class OnymApplication : Application() {
         // Kick the collector at app start so requests landing while
         // the chats screen isn't open still drive the badge count.
         approveRequestsViewModel.start()
-
-        // App-wide network preference (PR-C follow-up). Defaults to
-        // testnet; the Settings → Network → "Use Mainnet" Switch
-        // flips it. CreateGroupInteractor reads `current()` per call
-        // for both the contract-binding lookup and the wire payload's
-        // top-level `network` field.
-        val networkPreference = DataStoreNetworkPreferenceProvider(
-            dataStore = applicationContext.networkPreferenceDataStore,
-        )
 
         return AppDependencies(
             nostrSignerProvider = nostrSignerProvider,

--- a/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
+++ b/app/src/main/kotlin/chat/onym/android/chain/GroupProofGenerator.kt
@@ -166,6 +166,83 @@ interface GroupProofGenerator {
      * to overlap with I/O should not switch dispatchers themselves.
      */
     suspend fun proveCreate(input: GroupProofCreateInput): GroupCreateProof
+
+    /**
+     * Generate a Tyranny update-commitment proof. Used by the admin
+     * to anchor a roster change (typically a join admit) on chain.
+     *
+     * Other governance types throw
+     * [GroupProofGeneratorError.NotYetSupported].
+     *
+     * Mirrors `proveUpdate` from onym-ios PR #88.
+     */
+    suspend fun proveUpdate(input: GroupProofUpdateInput): GroupUpdateProof
+}
+
+/**
+ * Inputs for a Tyranny update-commitment proof. Mirrors the
+ * pre-witness contract: caller supplies the new merkle root +
+ * fresh `salt_new`; the prover synthesises the witness by re-hashing
+ * the admin's leaf inside the circuit.
+ *
+ * Mirrors `GroupProofUpdateInput` from onym-ios PR #88.
+ */
+data class GroupProofUpdateInput(
+    val groupType: SepGroupType,
+    val tier: SepTier,
+    /** Lex-sorted by `publicKeyCompressed`. Same canonical sort the
+     *  create-time roster used. */
+    val oldMembers: List<GovernanceMember>,
+    val adminBlsSecretKey: ByteArray,
+    val adminIndexOld: Int,
+    val epochOld: ULong,
+    /** Poseidon merkle root over the lex-sorted new roster. */
+    val memberRootNew: ByteArray,
+    val groupId: ByteArray,
+    val saltOld: ByteArray,
+    val saltNew: ByteArray,
+)
+
+/**
+ * Output of [GroupProofGenerator.proveUpdate]. PI bundle is 160
+ * bytes = 5 × 32B chunks:
+ * `c_old || epoch_old_be || c_new || admin_pubkey_commitment || group_id_fr`.
+ *
+ * Mirrors `GroupUpdateProof` from onym-ios PR #88.
+ */
+data class GroupUpdateProof(
+    val proof: ByteArray,
+    val publicInputs: List<ByteArray>,
+) {
+    val commitmentOld: ByteArray get() = publicInputs[0]
+    val commitmentNew: ByteArray get() = publicInputs[2]
+    val adminPubkeyCommitment: ByteArray get() = publicInputs[3]
+    val groupIdFr: ByteArray get() = publicInputs[4]
+
+    fun epochNew(): ULong = currentEpochOld() + 1uL
+
+    /** Read epoch_old back from the PI bundle's second chunk. */
+    fun currentEpochOld(): ULong {
+        val be = publicInputs[1]
+        // Last 8 bytes are the BE-encoded ULong epoch.
+        var acc = 0uL
+        for (i in 24 until 32) {
+            acc = (acc shl 8) or (be[i].toULong() and 0xFFuL)
+        }
+        return acc
+    }
+
+    override fun equals(other: Any?): Boolean = this === other ||
+        (other is GroupUpdateProof &&
+            proof.contentEquals(other.proof) &&
+            publicInputs.size == other.publicInputs.size &&
+            publicInputs.zip(other.publicInputs).all { (a, b) -> a.contentEquals(b) })
+
+    override fun hashCode(): Int {
+        var h = proof.contentHashCode()
+        for (p in publicInputs) h = 31 * h + p.contentHashCode()
+        return h
+    }
 }
 
 /**
@@ -184,6 +261,59 @@ class OnymGroupProofGenerator : GroupProofGenerator {
             SepGroupType.OLIGARCHY,
                 -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
         }
+
+    override suspend fun proveUpdate(input: GroupProofUpdateInput): GroupUpdateProof =
+        when (input.groupType) {
+            SepGroupType.TYRANNY -> proveTyrannyUpdate(input)
+            else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
+        }
+
+    private suspend fun proveTyrannyUpdate(input: GroupProofUpdateInput): GroupUpdateProof {
+        if (input.adminIndexOld < 0 || input.adminIndexOld >= input.oldMembers.size) {
+            throw GroupProofGeneratorError.AdminIndexOutOfRange(
+                index = input.adminIndexOld,
+                count = input.oldMembers.size,
+            )
+        }
+        val packedLeaves = ByteArray(input.oldMembers.size * 32)
+        for ((i, member) in input.oldMembers.withIndex()) {
+            require(member.leafHash.size == 32) {
+                "leafHash for member $i has unexpected size ${member.leafHash.size}, expected 32"
+            }
+            System.arraycopy(member.leafHash, 0, packedLeaves, i * 32, 32)
+        }
+
+        return withContext(Dispatchers.Default) {
+            val raw = try {
+                Tyranny.proveUpdate(
+                    /* depth = */ input.tier.depth,
+                    /* memberLeafHashesOld = */ packedLeaves,
+                    /* adminSecretKey = */ input.adminBlsSecretKey,
+                    /* adminIndexOld = */ input.adminIndexOld,
+                    /* epochOld = */ input.epochOld.toLong(),
+                    /* memberRootNew = */ input.memberRootNew,
+                    /* groupIdFr = */ input.groupId,
+                    /* saltOld = */ input.saltOld,
+                    /* saltNew = */ input.saltNew,
+                )
+            } catch (e: Throwable) {
+                throw GroupProofGeneratorError.SdkFailure(e.message ?: e.toString())
+            }
+            // PI bundle layout (`Tyranny.UpdateProof.publicInputs`, 160 B):
+            //   c_old(32) || epoch_old_be(32) || c_new(32)
+            //     || admin_pubkey_commitment(32) || group_id_fr(32)
+            val bundle = raw.publicInputs
+            if (bundle.size != 160) {
+                throw GroupProofGeneratorError.SdkFailure(
+                    "expected 160-byte PI bundle, got ${bundle.size}",
+                )
+            }
+            val chunks = (0 until 160 step 32).map { offset ->
+                bundle.copyOfRange(offset, offset + 32)
+            }
+            GroupUpdateProof(proof = raw.proof, publicInputs = chunks)
+        }
+    }
 
     private suspend fun proveAnarchyCreate(input: GroupProofCreateInput): GroupCreateProof {
         // Anarchy reuses the membership proof at create-time — the

--- a/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
@@ -124,6 +124,18 @@ class ApproveRequestsViewModel(
                 "Sign in first."
             is JoinRequestApprover.ApproveOutcome.TransportFailed ->
                 "Couldn’t send: ${outcome.reason}"
+            is JoinRequestApprover.ApproveOutcome.OutdatedJoinerClient ->
+                "Joiner is on an outdated app. Ask them to update."
+            is JoinRequestApprover.ApproveOutcome.NoActiveRelayer ->
+                "No chain relayer configured. Set one in Settings → Network → Relayer."
+            is JoinRequestApprover.ApproveOutcome.NoContractBinding ->
+                "No Tyranny contract selected for this network. Pick one in Settings → Network → Anchors."
+            is JoinRequestApprover.ApproveOutcome.NotAdminOfThisGroup ->
+                "The active identity isn’t this group’s admin. Switch to the identity that created the group, then try again."
+            is JoinRequestApprover.ApproveOutcome.ProofFailed ->
+                "Couldn’t generate proof: ${outcome.reason}"
+            is JoinRequestApprover.ApproveOutcome.AnchorRejected ->
+                "Chain rejected the proof: ${outcome.reason}"
         }
     }
 }

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -1,10 +1,26 @@
 package chat.onym.android.group
 
+import chat.onym.android.chain.AnchorSelectionKey
+import chat.onym.android.chain.ContractsRepository
+import chat.onym.android.chain.GovernanceType
+import chat.onym.android.chain.GroupProofGenerator
+import chat.onym.android.chain.GroupProofGeneratorError
+import chat.onym.android.chain.GroupProofUpdateInput
+import chat.onym.android.chain.NetworkPreferenceProvider
+import chat.onym.android.chain.OkHttpSepContractTransport
+import chat.onym.android.chain.OnymGroupProofGenerator
+import chat.onym.android.chain.RelayerRepository
+import chat.onym.android.chain.SepContractClient
+import chat.onym.android.chain.SepContractError
+import chat.onym.android.chain.SepContractTransport
+import chat.onym.android.chain.SepGroupType
+import chat.onym.android.chain.TyrannyUpdateCommitmentPayload
 import chat.onym.android.identity.IdentityRepository
 import chat.onym.android.identity.InvitationDecryptError
 import chat.onym.android.transport.InboxTransport
 import chat.onym.android.transport.TransportInboxId
 import kotlinx.coroutines.CoroutineScope
+import okhttp3.OkHttpClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -57,6 +73,19 @@ open class JoinRequestApprover(
     private val groupRepository: GroupRepository,
     private val inboxTransport: InboxTransport,
     private val scope: CoroutineScope,
+    /** Chain-relayer dependencies for the on-chain anchor flow. PR 88
+     *  drives [anchorTyrannyJoin] through these. Optional so existing
+     *  unit tests that don't need the anchor leg can keep working. */
+    private val relayers: RelayerRepository? = null,
+    private val contracts: ContractsRepository? = null,
+    private val networkPreference: NetworkPreferenceProvider? = null,
+    private val proofGenerator: GroupProofGenerator = OnymGroupProofGenerator(),
+    /** Builds a [SepContractTransport] from the relayer URL chosen
+     *  per-call. Injected so tests can swap a fake without touching
+     *  OkHttp. */
+    private val makeContractTransport: (String) -> SepContractTransport = { url ->
+        OkHttpSepContractTransport(httpClient = OkHttpClient(), endpointUrl = url)
+    },
 ) : JoinRequestApproving {
     /** UI-renderable view of one decrypted, awaiting-action request. */
     data class PendingRequest(
@@ -70,6 +99,11 @@ open class JoinRequestApprover(
          *  back, but skips the local roster update because there's
          *  no stable cross-device key to record under. */
         val joinerBlsPublicKey: ByteArray?,
+        /** 32-byte Poseidon leaf hash. Required for the on-chain
+         *  Tyranny `update_commitment` proof (PR 88). `null` from
+         *  pre-PR-88 clients — those approve attempts surface as
+         *  [ApproveOutcome.OutdatedJoinerClient]. */
+        val joinerLeafHash: ByteArray? = null,
         val joinerDisplayLabel: String,
         val groupId: ByteArray,
         /** Looked up from the local [GroupRepository]. Null if the
@@ -84,6 +118,8 @@ open class JoinRequestApprover(
                 joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
                 (joinerBlsPublicKey?.contentEquals(other.joinerBlsPublicKey)
                     ?: (other.joinerBlsPublicKey == null)) &&
+                (joinerLeafHash?.contentEquals(other.joinerLeafHash)
+                    ?: (other.joinerLeafHash == null)) &&
                 joinerDisplayLabel == other.joinerDisplayLabel &&
                 groupId.contentEquals(other.groupId) &&
                 groupName == other.groupName)
@@ -92,6 +128,7 @@ open class JoinRequestApprover(
             var h = id.hashCode()
             h = 31 * h + joinerInboxPublicKey.contentHashCode()
             h = 31 * h + (joinerBlsPublicKey?.contentHashCode() ?: 0)
+            h = 31 * h + (joinerLeafHash?.contentHashCode() ?: 0)
             h = 31 * h + joinerDisplayLabel.hashCode()
             h = 31 * h + groupId.contentHashCode()
             h = 31 * h + (groupName?.hashCode() ?: 0)
@@ -105,6 +142,21 @@ open class JoinRequestApprover(
         object UnknownRequest : ApproveOutcome()
         object NoIdentityLoaded : ApproveOutcome()
         class TransportFailed(val reason: String) : ApproveOutcome()
+        /** Joiner shipped a pre-PR-88 request without
+         *  `joiner_leaf_hash`. Admin can't extend the on-chain tree
+         *  without it; user must ask the joiner to update. */
+        object OutdatedJoinerClient : ApproveOutcome()
+        /** [RelayerRepository.selectUrl] returned null. */
+        object NoActiveRelayer : ApproveOutcome()
+        /** No deployed Tyranny contract for the active network. */
+        object NoContractBinding : ApproveOutcome()
+        /** Active identity isn't this group's admin (PR 93). */
+        object NotAdminOfThisGroup : ApproveOutcome()
+        /** `Tyranny.proveUpdate` failed — corrupted roster, wrong
+         *  tier depth, SDK FFI error, etc. */
+        class ProofFailed(val reason: String) : ApproveOutcome()
+        /** Relayer accepted the POST but the contract rejected. */
+        class AnchorRejected(val reason: String) : ApproveOutcome()
     }
 
     private val mutex = Mutex()
@@ -159,23 +211,39 @@ open class JoinRequestApprover(
             it.groupIdBytes.contentEquals(req.groupId)
         } ?: return@withLock ApproveOutcome.UnknownGroup
 
+        // PR 88 admin-anchor leg — Tyranny only. Other governance
+        // types fall through to the pre-PR-88 ship-only flow below.
+        var anchored = group
+        if (group.groupType == SepGroupType.TYRANNY) {
+            when (val outcome = anchorTyrannyJoin(req, group)) {
+                is AnchorOutcome.Failed -> return@withLock outcome.outcome
+                is AnchorOutcome.Ok -> {
+                    anchored = outcome.group
+                    // Persist the advanced state immediately so a
+                    // subsequent crash before seal+ship doesn't lose
+                    // the chain transition.
+                    groupRepository.insert(anchored)
+                }
+            }
+        }
+
         val invitePayload = GroupInvitationPayload(
             version = 1,
-            groupId = group.groupIdBytes,
-            groupSecret = group.groupSecret,
-            name = group.name,
-            members = group.members,
-            epoch = group.epoch,
-            salt = group.salt,
-            commitment = group.commitment,
-            tierRaw = group.tier.rawValue,
-            groupTypeRaw = group.groupType.wireValue,
-            adminPubkeyHex = group.adminPubkeyHex,
+            groupId = anchored.groupIdBytes,
+            groupSecret = anchored.groupSecret,
+            name = anchored.name,
+            members = anchored.members,
+            epoch = anchored.epoch,
+            salt = anchored.salt,
+            commitment = anchored.commitment,
+            tierRaw = anchored.tier.rawValue,
+            groupTypeRaw = anchored.groupType.wireValue,
+            adminPubkeyHex = anchored.adminPubkeyHex,
             // Ship the directory-as-known so the joiner sees existing
             // peers + admin by name from the moment they land. The
             // joiner's own profile gets backfilled by the receiver's
             // materializer (PR 83) from their active identity.
-            memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
+            memberProfiles = anchored.memberProfiles.takeIf { it.isNotEmpty() },
         )
         val payloadBytes = try {
             jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)
@@ -201,17 +269,19 @@ open class JoinRequestApprover(
         // Record the joiner in the local group's view-facing roster
         // (alias / inbox-pub) so the admin sees them by alias in the
         // UI. Skipped when the joiner shipped a pre-PR-78 request —
-        // no stable cross-device key under which to record.
+        // no stable cross-device key under which to record. Use the
+        // post-anchor group snapshot so PR-88's `commitment + epoch`
+        // ship in the announcement.
         val blsPub = req.joinerBlsPublicKey
         if (blsPub != null) {
             recordJoiner(
-                group = group,
+                group = anchored,
                 blsPub = blsPub,
                 inboxPub = req.joinerInboxPublicKey,
                 alias = req.joinerDisplayLabel,
             )
             broadcastJoin(
-                group = group,
+                group = anchored,
                 joinerBlsPub = blsPub,
                 joinerInboxPub = req.joinerInboxPublicKey,
                 joinerAlias = req.joinerDisplayLabel,
@@ -286,11 +356,16 @@ open class JoinRequestApprover(
                     alias = joinerAlias,
                 ),
                 adminAlias = adminAlias,
-                // PR 88 fills these for Tyranny anchors. Until then,
-                // ship without — receivers fall back to best-effort
-                // acceptance for non-Tyranny / pre-PR-88 announcements.
-                commitment = null,
-                epoch = null,
+                // PR 88: ship the post-anchor commitment + epoch so
+                // PR 89's receivers can verify against
+                // SEPContractClient.getCommitment. Null only when
+                // the calling group hasn't been anchored (legacy /
+                // non-Tyranny path) — receivers fall back to
+                // best-effort acceptance in that case.
+                commitment = group.commitment.takeIf {
+                    group.groupType == SepGroupType.TYRANNY
+                },
+                epoch = if (group.groupType == SepGroupType.TYRANNY) group.epoch else null,
             )
         } catch (_: Throwable) {
             // Wrong-sized BLS / inbox pub shouldn't happen — caller
@@ -379,6 +454,7 @@ open class JoinRequestApprover(
             id = raw.id,
             joinerInboxPublicKey = payload.joinerInboxPublicKey,
             joinerBlsPublicKey = payload.joinerBlsPublicKey,
+            joinerLeafHash = payload.joinerLeafHash,
             joinerDisplayLabel = payload.joinerDisplayLabel,
             groupId = payload.groupId,
             groupName = groupName,
@@ -398,8 +474,161 @@ open class JoinRequestApprover(
         introRequestStore.consume(requestId)
     }
 
+    /** Outcome shape for [anchorTyrannyJoin]. */
+    private sealed class AnchorOutcome {
+        data class Ok(val group: ChatGroup) : AnchorOutcome()
+        data class Failed(val outcome: ApproveOutcome) : AnchorOutcome()
+    }
+
+    /**
+     * On-chain anchor leg of [approve] — Tyranny only. Returns the
+     * updated [ChatGroup] (post-anchor) on success, or an
+     * [ApproveOutcome] describing the failure on any short-circuit.
+     * Pure: never mutates local state. Caller persists.
+     *
+     * Mirrors `anchorTyrannyJoin` from onym-ios PR #88.
+     */
+    private suspend fun anchorTyrannyJoin(
+        req: PendingRequest,
+        group: ChatGroup,
+    ): AnchorOutcome {
+        val joinerBlsPub = req.joinerBlsPublicKey
+        val joinerLeafHash = req.joinerLeafHash
+        if (joinerBlsPub == null || joinerLeafHash == null) {
+            return AnchorOutcome.Failed(ApproveOutcome.OutdatedJoinerClient)
+        }
+        val adminPubkeyHex = group.adminPubkeyHex
+            ?: return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("group missing adminPubkeyHex"),
+            )
+        val relayerUrl = relayers?.selectUrl()
+            ?: return AnchorOutcome.Failed(ApproveOutcome.NoActiveRelayer)
+        val networkPref = networkPreference?.current()
+            ?: return AnchorOutcome.Failed(ApproveOutcome.NoContractBinding)
+        val contractsRepo = contracts
+            ?: return AnchorOutcome.Failed(ApproveOutcome.NoContractBinding)
+        val key = AnchorSelectionKey(
+            network = networkPref.contractNetwork,
+            type = GovernanceType.Tyranny,
+        )
+        val binding = contractsRepo.snapshots.value.binding(key)
+            ?: return AnchorOutcome.Failed(ApproveOutcome.NoContractBinding)
+
+        // Resolve admin's index in the OLD member roster.
+        val adminBytes = ChatGroup.bytesFromHex(adminPubkeyHex)
+        val adminIndexOld = group.members.indexOfFirst {
+            it.publicKeyCompressed.contentEquals(adminBytes)
+        }
+        if (adminIndexOld < 0) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("admin not in members roster"),
+            )
+        }
+
+        // Build new lex-sorted member list including the joiner.
+        // Compute the new Poseidon root over the new tree.
+        val joinerMember = GovernanceMember(
+            publicKeyCompressed = joinerBlsPub,
+            leafHash = joinerLeafHash,
+        )
+        val newMembers = (group.members + joinerMember)
+            .sortedWith(compareBy(byteArrayLexComparator()) { it.publicKeyCompressed })
+        val memberRootNew = try {
+            GroupCommitmentBuilder.computeMerkleRoot(
+                members = newMembers,
+                tier = group.tier,
+            )
+        } catch (e: Throwable) {
+            return AnchorOutcome.Failed(ApproveOutcome.ProofFailed("merkle_root: ${e.message ?: e}"))
+        }
+        val saltNew = GroupCommitmentBuilder.generateSalt()
+
+        val blsSecret = try {
+            // onym:allow-secret-read
+            identity.blsSecretKey()
+        } catch (e: Throwable) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("bls_secret: ${e.message ?: e}"),
+            )
+        }
+
+        val proofInput = GroupProofUpdateInput(
+            groupType = SepGroupType.TYRANNY,
+            tier = group.tier,
+            oldMembers = group.members,
+            adminBlsSecretKey = blsSecret,
+            adminIndexOld = adminIndexOld,
+            epochOld = group.epoch,
+            memberRootNew = memberRootNew,
+            groupId = group.groupIdBytes,
+            saltOld = group.salt,
+            saltNew = saltNew,
+        )
+        val proof = try {
+            proofGenerator.proveUpdate(proofInput)
+        } catch (e: GroupProofGeneratorError) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.ProofFailed(e.message ?: e.javaClass.simpleName),
+            )
+        } catch (e: Throwable) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.ProofFailed(e.message ?: e.toString()),
+            )
+        }
+
+        val transport = makeContractTransport(relayerUrl)
+        val client = SepContractClient(
+            contractID = binding.contractId,
+            contractType = SepGroupType.TYRANNY,
+            network = networkPref.sepNetwork,
+            transport = transport,
+        )
+        val payload = TyrannyUpdateCommitmentPayload(
+            groupId = group.groupIdBytes,
+            proof = proof.proof,
+            publicInputs = proof.publicInputs,
+        )
+        val response = try {
+            client.updateCommitmentTyranny(payload)
+        } catch (e: SepContractError) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("anchor: ${e.message ?: e}"),
+            )
+        } catch (e: Throwable) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("anchor: ${e.message ?: e}"),
+            )
+        }
+        if (!response.accepted) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.AnchorRejected(response.message ?: "(no message)"),
+            )
+        }
+
+        return AnchorOutcome.Ok(
+            group.copy(
+                members = newMembers,
+                commitment = proof.commitmentNew,
+                epoch = group.epoch + 1uL,
+                salt = saltNew,
+            ),
+        )
+    }
+
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+
+        /** Lex comparator over [ByteArray]; matches the canonical
+         *  member ordering already used in [CreateGroupInteractor]. */
+        private fun byteArrayLexComparator(): Comparator<ByteArray> =
+            Comparator { a, b ->
+                val len = minOf(a.size, b.size)
+                for (i in 0 until len) {
+                    val cmp = (a[i].toInt() and 0xFF) - (b[i].toInt() and 0xFF)
+                    if (cmp != 0) return@Comparator cmp
+                }
+                a.size - b.size
+            }
 
         /** Lowercase hex of a [ByteArray]. Lives here so the
          *  approver doesn't have to import the persistence /

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestPayload.kt
@@ -44,6 +44,15 @@ data class JoinRequestPayload(
     @SerialName("joiner_bls_pub")
     @Serializable(with = Base64ByteArraySerializer::class)
     val joinerBlsPublicKey: ByteArray? = null,
+    /**
+     * 32-byte Poseidon leaf hash (PR 88). Required for the admin to
+     * generate the on-chain `update_commitment` proof. `null` for
+     * pre-PR-88 joiners — those requests can't be approved on-chain
+     * and surface as `OutdatedJoinerClient`.
+     */
+    @SerialName("joiner_leaf_hash")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val joinerLeafHash: ByteArray? = null,
     @SerialName("joiner_display_label")
     val joinerDisplayLabel: String,
     @SerialName("group_id")
@@ -59,6 +68,11 @@ data class JoinRequestPayload(
                 "joinerBlsPublicKey: expected 48 bytes, got ${it.size}"
             }
         }
+        joinerLeafHash?.let {
+            require(it.size == 32) {
+                "joinerLeafHash: expected 32 bytes, got ${it.size}"
+            }
+        }
         require(groupId.size == 32) {
             "groupId: expected 32 bytes, got ${groupId.size}"
         }
@@ -70,6 +84,8 @@ data class JoinRequestPayload(
         return joinerInboxPublicKey.contentEquals(other.joinerInboxPublicKey) &&
             (joinerBlsPublicKey?.contentEquals(other.joinerBlsPublicKey)
                 ?: (other.joinerBlsPublicKey == null)) &&
+            (joinerLeafHash?.contentEquals(other.joinerLeafHash)
+                ?: (other.joinerLeafHash == null)) &&
             joinerDisplayLabel == other.joinerDisplayLabel &&
             groupId.contentEquals(other.groupId)
     }
@@ -77,6 +93,7 @@ data class JoinRequestPayload(
     override fun hashCode(): Int {
         var h = joinerInboxPublicKey.contentHashCode()
         h = 31 * h + (joinerBlsPublicKey?.contentHashCode() ?: 0)
+        h = 31 * h + (joinerLeafHash?.contentHashCode() ?: 0)
         h = 31 * h + joinerDisplayLabel.hashCode()
         h = 31 * h + groupId.contentHashCode()
         return h

--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestSender.kt
@@ -47,12 +47,24 @@ class JoinRequestSender(
         joinerDisplayLabel: String,
     ): Outcome = withContext(ioDispatcher) {
         val activeIdentity = identity.currentIdentity() ?: return@withContext Outcome.NoIdentityLoaded()
+        // PR 88: ship the Poseidon leaf hash so the admin can run
+        // Tyranny.proveUpdate without having to derive it again.
+        // Computation goes through the FFI; pull the BLS secret only
+        // for the duration of the call, never retain.
+        val leafHash = try {
+            // onym:allow-secret-read
+            val sk = identity.blsSecretKey()
+            GroupCommitmentBuilder.computeLeafHash(sk)
+        } catch (_: Throwable) {
+            null
+        }
         val payload = JoinRequestPayload(
             joinerInboxPublicKey = activeIdentity.inboxPublicKey,
             // Stable cross-device identifier — the admin keys the
             // joiner into the local roster under this. Pre-PR-78
             // joiners shipped without it; post-PR-78 ships it always.
             joinerBlsPublicKey = activeIdentity.blsPublicKey,
+            joinerLeafHash = leafHash,
             joinerDisplayLabel = joinerDisplayLabel,
             groupId = capability.groupId,
         )

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/StubGroupProofGenerator.kt
@@ -4,6 +4,8 @@ import chat.onym.android.chain.GroupCreateProof
 import chat.onym.android.chain.GroupProofCreateInput
 import chat.onym.android.chain.GroupProofGenerator
 import chat.onym.android.chain.GroupProofGeneratorError
+import chat.onym.android.chain.GroupProofUpdateInput
+import chat.onym.android.chain.GroupUpdateProof
 import chat.onym.android.chain.SepGroupType
 
 /**
@@ -44,6 +46,24 @@ class StubGroupProofGenerator : GroupProofGenerator {
                 publicInputs = listOf(
                     ByteArray(32) { 0x78.toByte() },  // commitment
                     ByteArray(32),                     // Fr(0) — epoch
+                ),
+            )
+            else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)
+        }
+
+    override suspend fun proveUpdate(input: GroupProofUpdateInput): GroupUpdateProof =
+        when (input.groupType) {
+            SepGroupType.TYRANNY -> GroupUpdateProof(
+                proof = ByteArray(1601) { 0x9A.toByte() },
+                publicInputs = listOf(
+                    ByteArray(32) { 0xC0.toByte() },  // c_old
+                    java.nio.ByteBuffer.allocate(32).apply {
+                        position(24)
+                        putLong(input.epochOld.toLong())
+                    }.array(),                          // epoch_old_be
+                    ByteArray(32) { 0xC1.toByte() },  // c_new
+                    ByteArray(32) { 0xAD.toByte() },  // admin_pubkey_commitment
+                    ByteArray(32) { 0x10.toByte() },  // group_id_fr
                 ),
             )
             else -> throw GroupProofGeneratorError.NotYetSupported(input.groupType)


### PR DESCRIPTION
## Summary

The cryptographic gate of the stack. Tyranny-only on-chain anchor leg of `approve()` — only the admin's BLS secret can produce a valid `Tyranny.proveUpdate` proof, so a non-admin trying to admit Charlie hits a chain rejection.

Pipeline:
1. Verify `joiner_bls_pub` + `joiner_leaf_hash` are present → `OutdatedJoinerClient` when missing.
2. Resolve relayer URL → `NoActiveRelayer`.
3. Resolve Tyranny contract binding → `NoContractBinding`.
4. Build new lex-sorted roster + Poseidon root + fresh `salt_new`.
5. Generate `Tyranny.proveUpdate`.
6. POST `update_commitment`; require `accepted=true` → `AnchorRejected` otherwise.
7. Persist anchored state, then ship the `GroupInvitationPayload` + fan out the announcement (now carrying post-anchor `commitment` + `epoch`).

Wire format:
- `JoinRequestPayload` grows optional `joiner_leaf_hash` (32 bytes).
- `JoinRequestSender` computes it via `GroupCommitmentBuilder.computeLeafHash`.
- `GroupProofGenerator` gains `proveUpdate` (160-byte PI bundle, 5×32).

Outcome surface for the VM is extended (`OutdatedJoinerClient`, `NoActiveRelayer`, `NoContractBinding`, `NotAdminOfThisGroup`, `ProofFailed`, `AnchorRejected`) with copy. PR 93 will fill `NotAdminOfThisGroup` (pre-flight check); PR 89 the receiver-side verify.

Stacked on `transport/nostr-relays-settings` (PR #107). Mirrors onym-ios PR #88.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green (existing tests + StubGroupProofGenerator extended for proveUpdate).
- [ ] `proveUpdate` on non-Tyranny throws `NotYetSupported`.
- [ ] Manual / instrumented run confirms a Tyranny approve POSTs `update_commitment` and advances `epoch` by 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)