### PR TITLE
fix(inbox): wrong commitment recompute in PR 89 verifier

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/ApproveRequestsViewModel.kt
@@ -3,6 +3,7 @@ package chat.onym.android.group
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -86,6 +87,7 @@ class ApproveRequestsViewModel(
                     val trimmed = joinerAlias?.trim().orEmpty()
                     val label = if (trimmed.isEmpty()) "this person" else trimmed
                     _lastSuccessMessage.value = "$label is now in the group."
+                    scheduleSuccessDismiss()
                 }
                 else -> {
                     _lastSuccessMessage.value = null
@@ -107,6 +109,21 @@ class ApproveRequestsViewModel(
 
     fun dismissError() {
         _lastError.value = null
+    }
+
+    /**
+     * Auto-clear the success banner after ~3s. The "only zero out
+     * if still equal" check protects against a fresh approve
+     * overwriting the snapshot before the delay completes.
+     */
+    private fun scheduleSuccessDismiss() {
+        val snapshot = _lastSuccessMessage.value
+        viewModelScope.launch {
+            delay(3_000)
+            if (_lastSuccessMessage.value == snapshot) {
+                _lastSuccessMessage.value = null
+            }
+        }
     }
 
     private companion object {

--- a/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/chat/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -310,11 +310,18 @@ class IncomingMessageDispatcher(
         // V1 never reaches the on-chain branch in tests.
         val reader = chainState ?: return true
         val claimed = invitation.commitment ?: return false
-        // Internal consistency (PR 91 fixes this to recompute the
-        // full Poseidon commitment). For now, mirror iOS's PR-89
-        // intermediate state.
+        // Internal consistency: recompute the FULL Poseidon
+        // commitment from `(members, epoch, salt)` and compare. The
+        // commitment is `Poseidon(Poseidon(root, epoch), salt)` —
+        // NOT just the merkle root. PR 89's original implementation
+        // compared the root, which always failed; PR 91 fixes that.
         val recomputed = try {
-            GroupCommitmentBuilder.computeMerkleRoot(invitation.members, tier)
+            val root = GroupCommitmentBuilder.computeMerkleRoot(invitation.members, tier)
+            GroupCommitmentBuilder.computePoseidonCommitment(
+                poseidonRoot = root,
+                epoch = invitation.epoch,
+                salt = invitation.salt,
+            )
         } catch (_: Throwable) {
             return false
         }

--- a/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/ApproveRequestsViewModelTest.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -95,9 +97,18 @@ class ApproveRequestsViewModelTest {
         vm.approve("r1")
         advanceUntilIdle()
         approver.gate.complete(JoinRequestApprover.ApproveOutcome.Sent)
-        advanceUntilIdle()
+        // PR 91: the success banner auto-dismisses after 3s. Run
+        // current work without advancing the virtual clock past
+        // the dismiss timer so the banner is still set when we
+        // assert.
+        runCurrent()
         assertNull(vm.lastError.value)
         assertNotNull(vm.lastSuccessMessage.value)
+
+        // After the timer fires, the banner clears.
+        advanceTimeBy(3_001)
+        runCurrent()
+        assertNull(vm.lastSuccessMessage.value)
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR 89's `verifyTyrannyInvitation` compared the merkle root to the commitment. That always failed because the contract stores `Poseidon(Poseidon(merkle_root, epoch), salt)` — a different value. Joiners stayed stuck on "Waiting for the host to approve…" because their materializer silently rejected every legitimate invitation.

Fix: recompute the FULL Poseidon commitment via `GroupCommitmentBuilder.computePoseidonCommitment`.

Also: success banner auto-dismisses ~3s after a successful approve. The "only zero out if still equal" snapshot check protects against a fresh approve overwriting the message before the delay completes.

Stacked on `group/approver-in-flight-feedback` (PR #110). Mirrors onym-ios PR #91.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] `ApproveRequestsViewModelTest.sentClearsLastError` covers banner-set + auto-dismiss after 3s
- [ ] Manual smoke: a real Tyranny invitation now materializes successfully on the joiner side

🤖 Generated with [Claude Code](https://claude.com/claude-code)