### PR TITLE
fix(approver): pre-flight admin-identity check before proof generation

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/JoinRequestApprover.kt
@@ -552,6 +552,24 @@ open class JoinRequestApprover(
             )
         }
 
+        // PR 93 pre-flight: confirm the active identity actually IS
+        // the admin of this group before handing the secret to the
+        // prover. Catches the common "user switched identities since
+        // group creation" case cleanly — without this check the SDK
+        // surfaces the same problem as a cryptic
+        // `Poseidon(admin_secret_key) != supplied leaf hash` error
+        // ~3-5s later (after the prover's pre-witness checks fail).
+        val activePubFromSecret = try {
+            GroupCommitmentBuilder.computePublicKey(blsSecret)
+        } catch (e: Throwable) {
+            return AnchorOutcome.Failed(
+                ApproveOutcome.TransportFailed("derive_pub: ${e.message ?: e::class.simpleName}"),
+            )
+        }
+        if (!activePubFromSecret.contentEquals(group.members[adminIndexOld].publicKeyCompressed)) {
+            return AnchorOutcome.Failed(ApproveOutcome.NotAdminOfThisGroup)
+        }
+
         val proofInput = GroupProofUpdateInput(
             groupType = SepGroupType.TYRANNY,
             tier = group.tier,


### PR DESCRIPTION
## Summary

When the active identity isn't this group's admin (user rotated identities since create, or restored from a different recovery phrase), `Tyranny.proveUpdate` surfaces a cryptic "Poseidon(admin_secret_key) != supplied leaf hash" error 3-5 seconds in. This PR catches the case before the cycles are spent: compute BLS pubkey from the keychain's secret and compare to the group's stored admin pubkey. Mismatch → `NotAdminOfThisGroup` immediately, with the user-facing copy already wired in PR 88.

Stacked on `group/prefill-display-name` (PR #112). Mirrors onym-ios PR #93.

## Test plan
- [ ] `./gradlew :app:testDebugUnitTest` green
- [ ] Manual smoke: create a group, switch to a different identity, tap Approve on a join request — `NotAdminOfThisGroup` surfaces immediately rather than after a multi-second proving wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)