### PR TITLE
fix: actionable error when relayer rejects un-allowlisted contract (#117)

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/group/CreateGroupInteractorTest.kt
@@ -299,6 +299,56 @@ class CreateGroupInteractorTest {
     }
 
     @Test
+    fun create_anchorRejected_notAllowlistedBody_throwsContractNotAllowlisted() = runBlocking {
+        // The relayer rejects an un-allowlisted contract with HTTP 400
+        // and a body of the shape:
+        //   {"accepted":false,"message":"contractID C… is not allowlisted for tyranny on testnet"}
+        // Issue #117 — the user should see a distinct, actionable error
+        // rather than the raw transport message.
+        contractTransport.setBehavior(
+            ConfigurableContractTransport.Behavior.Throws(
+                SepContractError.BadStatus(
+                    code = 400,
+                    body = "{\"accepted\":false,\"message\":\"contractID CAFXTEST is not allowlisted for tyranny on testnet\"}",
+                ),
+            ),
+        )
+        try {
+            makeInteractor().create(name = "G", invitees = emptyList())
+            error("expected AnchorContractNotAllowlisted")
+        } catch (e: CreateGroupError.AnchorContractNotAllowlisted) {
+            assertEquals(GovernanceType.Tyranny, e.governance)
+            assertEquals(ContractNetwork.Testnet, e.network)
+            assertTrue(
+                "message should hint at Settings → Anchors",
+                e.message!!.contains("Anchors"),
+            )
+        }
+    }
+
+    @Test
+    fun create_anchorRejectedWith200_notAllowlistedMessage_throwsContractNotAllowlisted() = runBlocking {
+        // Defensive: same JSON body but delivered as HTTP 200 (proxy
+        // that swallows the 400) — should resolve to the same error.
+        contractTransport.setBehavior(
+            ConfigurableContractTransport.Behavior.Response(
+                SepSubmissionResponse(
+                    accepted = false,
+                    transactionHash = null,
+                    message = "contractID CAFXTEST is not allowlisted for tyranny on testnet",
+                ),
+            ),
+        )
+        try {
+            makeInteractor().create(name = "G", invitees = emptyList())
+            error("expected AnchorContractNotAllowlisted")
+        } catch (e: CreateGroupError.AnchorContractNotAllowlisted) {
+            assertEquals(GovernanceType.Tyranny, e.governance)
+            assertEquals(ContractNetwork.Testnet, e.network)
+        }
+    }
+
+    @Test
     fun create_anchorRejected_throws() = runBlocking {
         contractTransport.setBehavior(
             ConfigurableContractTransport.Behavior.Response(

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -3,6 +3,7 @@ package chat.onym.android.group
 import chat.onym.android.chain.AnarchyCreateGroupPayload
 import chat.onym.android.chain.AnchorSelectionKey
 import chat.onym.android.chain.CanonicalFr
+import chat.onym.android.chain.ContractNetwork
 import chat.onym.android.chain.ContractsRepository
 import chat.onym.android.chain.GovernanceType
 import chat.onym.android.chain.GroupCreateProof
@@ -242,6 +243,21 @@ open class CreateGroupInteractor(
                 )
                 else -> throw CreateGroupError.UnsupportedGroupType(groupType)
             }
+        } catch (e: SepContractError.BadStatus) {
+            // Relayer rejects an un-allowlisted contract with HTTP 400 +
+            // a JSON body containing "is not allowlisted". Surface a
+            // distinct, actionable error so the user knows to switch
+            // versions in Settings → Anchors instead of staring at the
+            // raw transport text. Issue #117.
+            if (NOT_ALLOWLISTED_MARKER in e.body) {
+                throw CreateGroupError.AnchorContractNotAllowlisted(
+                    contractId = binding.contractId,
+                    governance = governanceType,
+                    network = activeNetwork.contractNetwork,
+                    release = binding.release,
+                )
+            }
+            throw CreateGroupError.AnchorTransport(e.message ?: "transport error")
         } catch (e: SepContractError) {
             throw CreateGroupError.AnchorTransport(e.message ?: "transport error")
         } catch (e: CreateGroupError) {
@@ -250,6 +266,18 @@ open class CreateGroupInteractor(
             throw CreateGroupError.AnchorTransport(e.message ?: "unknown")
         }
         if (!response.accepted) {
+            // Some relayer versions / proxies may swallow the 400 and
+            // pass the same `{accepted:false, message:"…not allowlisted…"}`
+            // body through with HTTP 200. Mirror the BadStatus handling
+            // so the user gets the same actionable error either way.
+            if (response.message?.contains(NOT_ALLOWLISTED_MARKER) == true) {
+                throw CreateGroupError.AnchorContractNotAllowlisted(
+                    contractId = binding.contractId,
+                    governance = governanceType,
+                    network = activeNetwork.contractNetwork,
+                    release = binding.release,
+                )
+            }
             throw CreateGroupError.AnchorRejected(response.message)
         }
 
@@ -399,6 +427,14 @@ open class CreateGroupInteractor(
             ))
         }
 
+        /** Substring the relayer's rejection body always contains for
+         *  the un-allowlisted-contract case (matches `handler.rs:182`
+         *  in `onym-relayer`: `format!("contractID {} is not
+         *  allowlisted for {} on {}", …)`). Stable across the relayer's
+         *  history — the wording is the public-facing operator
+         *  contract. */
+        const val NOT_ALLOWLISTED_MARKER = "is not allowlisted"
+
         /** Same derivation as `Identity.inboxTag` — duplicated here
          *  because the helper is tied to a specific identity, and we
          *  need it for arbitrary recipient pubkeys. */
@@ -480,6 +516,29 @@ sealed class CreateGroupError(message: String) : Exception(message) {
 
     class AnchorRejected(val serverMessage: String?) :
         CreateGroupError("Relayer rejected the create: ${serverMessage ?: "(no message)"}")
+
+    /**
+     * Distinct rejection variant for the relayer's "contractID … is not
+     * allowlisted for <type> on <network>" response. Carved out of the
+     * generic [AnchorTransport] / [AnchorRejected] paths because it has
+     * a clear remediation — switch to a different release in Settings →
+     * Anchors — and the user shouldn't have to parse the raw HTTP body
+     * to find it.
+     *
+     * See `app/src/main/kotlin/chat/onym/android/chain/ContractsRepository.kt`
+     * for how releases are picked, and `RootScreen` → Settings →
+     * Anchors for the UI that lets the user switch.
+     */
+    class AnchorContractNotAllowlisted(
+        val contractId: String,
+        val governance: GovernanceType,
+        val network: ContractNetwork,
+        /** Release tag the rejected contract came from (e.g. `"v0.0.11"`). */
+        val release: String,
+    ) : CreateGroupError(
+        "The ${governance.wireValue} contract from $release isn't allowlisted on the relayer for ${network.wireValue} yet. " +
+            "Open Settings → Anchors and pick an earlier release for ${governance.wireValue}/${network.wireValue}."
+    )
 
     object InvitationEncodingFailed :
         CreateGroupError("Couldn't encode the invitation payload") {


### PR DESCRIPTION
## Summary

- Detect the relayer's "contractID … is not allowlisted for <type> on <network>" rejection (issue #117) and surface a distinct, actionable error instead of the raw transport text.
- Add `CreateGroupError.AnchorContractNotAllowlisted` carrying `(contractId, governance, network, release)` so the UI can render the precise remediation: "Open Settings → Anchors and pick an earlier release."
- Cover both the live HTTP-400 path and the defensive HTTP-200 / `accepted:false` fallback.

## Why this PR

When a new `onym-contracts` release lands before the relayer's allowlist is rolled (the actual root cause of #117 — v0.0.11 contracts not yet allowlisted on `relayer.onym.chat`), every Tyranny / Anarchy / 1-on-1 create on testnet fails. The relayer is the right side to fix it operationally, but the Android client should still fail informatively: until the relayer is updated, the user has a one-tap escape via Settings → Anchors → pick an earlier release. The current error swallows that affordance under the generic `Couldn't reach the relayer: contract call returned HTTP 400: {…}` banner.

## Test plan

- [x] `:app:compileDebugSources` clean
- [x] New unit tests in `CreateGroupInteractorTest`:
  - `create_anchorRejected_notAllowlistedBody_throwsContractNotAllowlisted` — HTTP 400 + `is not allowlisted` body
  - `create_anchorRejectedWith200_notAllowlistedMessage_throwsContractNotAllowlisted` — defensive HTTP-200 fallback
- [x] Existing `create_anchorTransportError_throws` (HTTP 502) and `create_anchorRejected_throws` (rejected with unrelated message) still hit their original branches.
- [ ] Manual: with v0.0.11 selected on testnet, attempt to create a Tyranny group → confirm new error banner; tap Settings → Anchors → pick v0.0.5 → retry succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)