### PR TITLE
chain(anarchy): publish "not tracked" sentinel for member_count at create

### DIFF
--- a/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupAnarchyE2ETest.kt
+++ b/app/src/androidTest/kotlin/chat/onym/android/integration/CreateGroupAnarchyE2ETest.kt
@@ -130,8 +130,9 @@ class CreateGroupAnarchyE2ETest {
     /**
      * Happy path with zero invitees. Verifies the group anchors on
      * chain and `get_commitment` round-trips the same commitment
-     * back. Anarchy tolerates a creator-only roster (the contract's
-     * `member_count` is informational; passing `1` is fine).
+     * back. Anarchy tolerates a creator-only roster; production sends
+     * `member_count = 0` (the contract's documented "not tracked"
+     * sentinel) so the chain only learns the tier.
      */
     @Test
     fun create_zeroInvitees_anchorsOnTestnet() = runBlocking {

--- a/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/CreateGroupInteractor.kt
@@ -226,11 +226,15 @@ open class CreateGroupInteractor(
                         groupId = groupId,
                         commitment = proof.commitment,
                         tier = tier.rawValue,
-                        // Send the actual roster size so the contract's
-                        // informational `member_count` reflects reality.
-                        // The relayer would default to `0` ("not tracked")
-                        // if absent, but accurate state is cheap to send.
-                        memberCount = members.size,
+                        // `member_count` is informational and the contract
+                        // accepts `0` as the documented "not tracked"
+                        // sentinel (per `sep-anarchy`'s `create_group` doc —
+                        // "Operators who don't want to publish a count
+                        // pass `0`"). Pass the sentinel so chain observers
+                        // see only the tier, not the exact roster size at
+                        // create time. The accurate count lives in the
+                        // local model.
+                        memberCount = 0,
                         proof = proof.proof,
                         publicInputs = proof.publicInputs,
                     ),


### PR DESCRIPTION
## Summary

- `sep-anarchy`'s `create_group` accepts `member_count: 0` as the documented "not tracked" sentinel. The contract treats `member_count` as informational, never mutates it, and the test-vector pin (`anarchy/v1 sep-xxxx`) reserves `0` for the "not tracked" case.
- Production was passing `members.size` — always `1` at create, since the founding roster is creator-only. That published a small but permanent piece of group structure (`tier=Small, member_count=1`) into the on-chain `GroupCreated` event for every Anarchy group ever created via the Android app.
- Switch to the sentinel. Chain observers now learn only the size class (`tier`), not the exact roster size at create. Accurate counts still live in the local model and the UI — only the wire value sent to the relayer changes.

This is the Android half of a coordinated change with `onymchat/onym-ios` (matching branch / PR title). Web copy on `/humans` and `/threat-model` will be tightened in a follow-up to take advantage of the narrower on-chain footprint.

## Test plan

- [ ] `./gradlew test` — `CreateGroupInteractorTest` and `SepContractTypesTest` / `SepContractClientTest` should pass. The encoder tests are unchanged (they pin `1` to verify u32 serialization works); only the production callsite changed.
- [ ] `./gradlew connectedAndroidTest` — `CreateGroupAnarchyE2ETest.create_zeroInvitees_anchorsOnTestnet` should still anchor and round-trip. The on-chain assertions only check commitment + epoch, so the `member_count` change does not affect them. The doc-comment is refreshed.
- [ ] Manual: create an Anarchy group on testnet and inspect the `GroupCreated` event payload — `member_count` should be `0`.
- [ ] Confirm the local UI still shows the correct count (`group.members.size`); the on-chain value isn't read back into the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)