### PR TITLE
ci(qa-build): comment on linked PR with the published build

### DIFF
--- a/.github/workflows/qa-build.yml
+++ b/.github/workflows/qa-build.yml
@@ -44,7 +44,8 @@ on:
 
 permissions:
   contents: read
-  issues: read   # gh issue view -> resolve issue title for the dashboard entry
+  issues: read           # gh issue view -> resolve issue title for the dashboard entry
+  pull-requests: write   # post the "QA build published" comment back on the originating PR
 
 # Serialize concurrent QA dispatches so two runs don't race against
 # the same builds.json on the droplet. (The workflow does a
@@ -297,3 +298,61 @@ jobs:
             echo "| APK | https://${HOST}/qa/android/${VERSION}/onym.apk |"
             echo "| Dashboard | https://${HOST}/qa/?platform=android |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on linked PR
+        # Drop a one-liner on the originating PR pointing testers at the
+        # signed APK + QA dashboard. PR is discovered in two ways, in order:
+        #   1. `inputs.issue` -- the manager bot passes the PR number
+        #      here when /build is invoked from a PR conversation
+        #      (PRs and issues share number space, and the dashboard
+        #      already treats this as a generic linked-issue field).
+        #   2. Open PRs whose head is this commit -- fallback for runs
+        #      dispatched without `issue`.
+        # Best-effort: failing to comment never fails the build. Posts
+        # as github-actions[bot] (the default ${{ github.token }}
+        # identity), which is the agreed tradeoff for not having to
+        # plumb a separate PAT through the workflow.
+        if: success()
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+          COMMIT:  ${{ steps.ver.outputs.commit }}
+          ISSUE:   ${{ inputs.issue }}
+          REPO:    ${{ github.repository }}
+          HOST:    ${{ secrets.DEPLOY_HOST }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          target_pr=""
+
+          if [ -n "$ISSUE" ]; then
+            is_pr=$(gh api "repos/$REPO/issues/$ISSUE" \
+                      --jq '.pull_request != null' 2>/dev/null || echo "false")
+            if [ "$is_pr" = "true" ]; then
+              target_pr="$ISSUE"
+            fi
+          fi
+
+          if [ -z "$target_pr" ]; then
+            target_pr=$(gh api "repos/$REPO/commits/$COMMIT/pulls" \
+                          -H "Accept: application/vnd.github+json" \
+                          --jq '[.[] | select(.state=="open")] | .[0].number // empty' \
+                          2>/dev/null || true)
+          fi
+
+          if [ -z "$target_pr" ]; then
+            echo "::notice::No open PR linked to commit $COMMIT -- skipping PR comment."
+            exit 0
+          fi
+
+          BODY_FILE=$(mktemp)
+          cat > "$BODY_FILE" <<MSG
+          QA build \`${VERSION}\` published.
+
+          - APK (side-load on Android): https://${HOST}/qa/android/${VERSION}/onym.apk
+          - Dashboard: https://${HOST}/qa/?platform=android
+          MSG
+
+          if ! gh pr comment "$target_pr" --repo "$REPO" --body-file "$BODY_FILE"; then
+            echo "::warning::Failed to post QA-build comment on PR #$target_pr (build itself succeeded)."
+          fi
+          rm -f "$BODY_FILE"


### PR DESCRIPTION
## Summary
- New final step in `qa-build.yml`: **Comment on linked PR**
- Resolves the PR in two ways, in order:
  1. `inputs.issue` — when /build is invoked from a PR conversation the manager bot passes the PR number here (PRs and issues share number space, and the dashboard already treats this as a generic linked-issue field)
  2. Open PRs whose head is this commit (`gh api repos/.../commits/$SHA/pulls`) — fallback for runs dispatched without `issue`
- Posts a one-liner: side-load APK URL + QA dashboard link
- Posts as `github-actions[bot]` via the default `${{ github.token }}` — agreed tradeoff vs. plumbing a separate PAT through the workflow
- Adds `pull-requests: write` to the workflow's `permissions:` block (was `contents: read, issues: read`)
- Best-effort: a comment failure never fails the build (`if !gh pr comment …; then echo ::warning…; fi`)

## Why
Mirrors onymchat/onym-ios#118 — closes the loop spotted on an iOS PR where `/build` was dispatched, the build published to onym.app/qa, but no comment landed on the PR.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('qa-build.yml'))"` → valid, 10 steps
- [ ] Re-run the QA Build workflow against a branch with an open PR, verify comment lands
- [ ] Run from a branch with no open PR (e.g. main directly) → workflow logs "No open PR linked to commit … -- skipping PR comment", build still succeeds
- [ ] Provoke a `gh pr comment` failure → run is marked successful with a warning annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)