### PR TITLE
feat(release-issue): auto-bump patch tag when Release tag is blank

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -17,10 +17,14 @@ body:
     id: tag
     attributes:
       label: Release tag
-      description: Must match `vX.Y.Z`. The Release workflow validates this and aborts if the tag already exists.
-      placeholder: v0.0.8
+      description: |
+        `vX.Y.Z`. Leave blank to auto-bump the patch version from the latest
+        existing `v*` tag — the `release-from-issue` workflow rewrites this
+        field in the issue body with the resolved tag before dispatching
+        Release. Submitting an explicit tag that already exists fails.
+      placeholder: v0.0.8 (or leave blank to auto-bump)
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: notes

--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -38,6 +38,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Tag history is needed so the auto-bump branch can resolve
+          # the latest patch version when the issue's Tag field is left
+          # blank. `fetch-tags` is lighter than `fetch-depth: 0`.
+          fetch-tags: true
         # No `lfs: true` — this job runs python3 over text only.
 
       - name: Discover instrumented test classes
@@ -47,7 +52,7 @@ jobs:
           echo "Discovered $(wc -l < /tmp/tests.txt) test classes:"
           cat /tmp/tests.txt
 
-      - name: Parse + validate release tag
+      - name: Resolve release tag
         id: tag
         env:
           GH_TOKEN: ${{ github.token }}
@@ -57,24 +62,76 @@ jobs:
           # snapshot at trigger time, which may be stale by a few seconds.
           BODY=$(gh issue view ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} --json body --jq .body)
+          # `parse-tag` returns "" when the field is blank or holds the
+          # GitHub "_No response_" placeholder; it still aborts on a
+          # malformed value (e.g. `0.0.8` without the `v`).
           TAG=$(printf '%s' "$BODY" | python3 scripts/release_issue.py parse-tag)
+
+          if [ -z "$TAG" ]; then
+            # Auto-bump patch from the latest reachable v-tag. `git tag
+            # --sort=-v:refname` puts highest first; filter to vX.Y.Z to
+            # ignore stray rc/build tags.
+            LATEST=$(git tag --sort=-v:refname \
+                       | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                       | head -1)
+            if [ -z "$LATEST" ]; then
+              # First-ever release on a fresh repo — start at v0.0.1.
+              TAG="v0.0.1"
+              echo "::notice::No existing v* tags; defaulting to $TAG"
+            else
+              IFS='.' read -r MAJOR MINOR PATCH <<EOF
+${LATEST#v}
+EOF
+              TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+              echo "::notice::Tag field blank; auto-bumping ${LATEST} → ${TAG}"
+            fi
+            echo "auto_bumped=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "auto_bumped=0" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Refuse to dispatch on a tag that already exists. The
+          # auto-bump path is collision-free by construction; this only
+          # protects an explicit user-typed tag that collides with a
+          # previous release.
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' already exists"
+            gh issue comment ${{ github.event.issue.number }} \
+              --repo ${{ github.repository }} \
+              --body "❌ Tag \`$TAG\` already exists on the repo. Pick a higher patch version or leave the Release tag field blank to auto-bump."
+            exit 1
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved tag: $TAG"
 
-      - name: Hydrate UI_TESTS section
+      - name: Hydrate UI_TESTS + Tag sections in issue body
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          AUTO_BUMPED: ${{ steps.tag.outputs.auto_bumped }}
         run: |
           set -eu
           BODY=$(gh issue view ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} --json body --jq .body)
+          # `--tag` rewrites the `### Release tag` value to the resolved
+          # tag; idempotent for the explicit case, meaningful for the
+          # auto-bumped case so the issue itself shows what got
+          # dispatched.
           NEW_BODY=$(printf '%s' "$BODY" | python3 scripts/release_issue.py hydrate \
-            --tests /tmp/tests.txt)
+            --tests /tmp/tests.txt \
+            --tag "$TAG")
           # Idempotent: if the section is already populated with the
-          # same FQNs, the diff is a no-op. `gh issue edit` skips the
-          # API write when nothing changed.
+          # same FQNs and the tag matches, the diff is a no-op. `gh
+          # issue edit` skips the API write when nothing changed.
           printf '%s' "$NEW_BODY" | gh issue edit ${{ github.event.issue.number }} \
             --repo ${{ github.repository }} --body-file -
+
+          if [ "$AUTO_BUMPED" = "1" ]; then
+            gh issue comment ${{ github.event.issue.number }} \
+              --repo ${{ github.repository }} \
+              --body "ℹ️ Release tag was blank — auto-bumped to \`${TAG}\` (next patch after the latest \`v*\` tag). Edit the issue and re-open if you want a different version."
+          fi
 
       - name: Dispatch Release workflow
         env:

--- a/.github/workflows/release-from-issue.yml
+++ b/.github/workflows/release-from-issue.yml
@@ -79,9 +79,7 @@ jobs:
               TAG="v0.0.1"
               echo "::notice::No existing v* tags; defaulting to $TAG"
             else
-              IFS='.' read -r MAJOR MINOR PATCH <<EOF
-${LATEST#v}
-EOF
+              IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST#v}"
               TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
               echo "::notice::Tag field blank; auto-bumping ${LATEST} → ${TAG}"
             fi

--- a/scripts/release_issue.py
+++ b/scripts/release_issue.py
@@ -8,11 +8,19 @@ Subcommands:
                              the dynamic checklist in the release issue.
 
     parse-tag                Read an issue body on stdin, print the
-                             `vX.Y.Z` tag the user typed in the form.
+                             `vX.Y.Z` tag the user typed in the form,
+                             or print nothing (exit 0) when the field
+                             was left blank — caller auto-bumps from
+                             the latest reachable `v*` tag in that
+                             case. Malformed values still abort with a
+                             clear error.
 
     hydrate    --tests F     Read issue body on stdin; replace the
                              UI_TESTS section with `- [ ] <FQN>` lines
-                             from F (one FQN per line).
+                             from F (one FQN per line). Optionally
+                             rewrites the `### Release tag` value via
+                             `--tag vX.Y.Z` so an auto-bumped tag
+                             shows in the issue body.
 
     tick       --results D   Read issue body on stdin; tick UI_TESTS
                              checkboxes for classes whose JUnit XML in D
@@ -101,7 +109,15 @@ def parse_tag(body: str) -> str:
         v0.0.8
 
     We grab the first non-blank line after the `### Release tag` heading,
-    strip whitespace, and validate the shape.
+    strip whitespace, and validate the shape. Two non-error cases return
+    the empty string for the caller to auto-bump:
+
+      * the heading is present but has no value (the form was submitted
+        without filling the field — the field is now optional);
+      * the value is GitHub's "_No response_" placeholder (issue forms
+        render an unfilled `input` field that way).
+
+    Malformed values (e.g. `0.0.8` without the `v`) still abort.
     """
     lines = body.splitlines()
     in_section = False
@@ -112,14 +128,16 @@ def parse_tag(body: str) -> str:
                 in_section = True
             continue
         if stripped.startswith("###"):
-            break  # next section, no tag found
+            return ""  # next section, value left blank
         if stripped:
+            if stripped == "_No response_":
+                return ""
             if not re.fullmatch(r"v\d+\.\d+\.\d+", stripped):
                 raise SystemExit(
                     f"tag `{stripped}` does not match vX.Y.Z — fix the issue body and reopen"
                 )
             return stripped
-    raise SystemExit("no `Release tag` field found in issue body")
+    return ""  # heading missing entirely (also treated as auto-bump)
 
 
 # ─── body editing ─────────────────────────────────────────────────────
@@ -143,11 +161,36 @@ def _split_body(body: str) -> tuple[str, str, str]:
     return body[:start_idx], body[start_idx:end_idx], body[end_idx:]
 
 
-def hydrate(body: str, fqns: list[str]) -> str:
-    """Replace the UI_TESTS section with a fresh `- [ ] FQN` checklist."""
+def hydrate(body: str, fqns: list[str], tag: str | None = None) -> str:
+    """Replace the UI_TESTS section with a fresh `- [ ] FQN` checklist.
+
+    Optionally also overwrites the `### Release tag` field's value with
+    `tag` — used when the workflow auto-bumped the patch version because
+    the field was blank, so the issue itself reflects the dispatched
+    tag. Idempotent for the explicit case (the existing value matches).
+    """
+    if tag:
+        body = _rewrite_tag(body, tag)
     prefix, _, suffix = _split_body(body)
     lines = ["", *(f"- [ ] {fqn}" for fqn in fqns), ""]
     return prefix + "\n" + "\n".join(lines) + "\n" + suffix
+
+
+# Match `### Release tag` (or `### Tag`) heading + the next non-blank
+# line — the value the user typed (or `_No response_` for a blank
+# submit). MULTILINE so `^`/`$` anchor at line bounds; IGNORECASE so
+# the heading text variants stay tolerated.
+_TAG_FIELD_RE = re.compile(
+    r"^(### (?:Release tag|Tag))\s*\n\n([^\n]+)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _rewrite_tag(body: str, tag: str) -> str:
+    """Overwrite the `### Release tag` field's value with `tag`. Returns
+    the body unchanged when the heading isn't found — `parse-tag`
+    already abort-or-warned about that path."""
+    return _TAG_FIELD_RE.sub(lambda m: f"{m.group(1)}\n\n{tag}", body, count=1)
 
 
 def tick(body: str, results: dict[str, bool]) -> str:
@@ -258,6 +301,11 @@ def main(argv: list[str]) -> int:
 
     p_hydrate = sub.add_parser("hydrate", help="seed UI_TESTS section with discovered FQNs")
     p_hydrate.add_argument("--tests", required=True, help="file with one FQN per line")
+    p_hydrate.add_argument(
+        "--tag",
+        default=None,
+        help="optional resolved tag (e.g. auto-bumped vX.Y.Z); rewrites the `### Release tag` value",
+    )
 
     p_tick = sub.add_parser("tick", help="mark UI_TESTS boxes from JUnit results")
     p_tick.add_argument("--results", required=True, help="dir with TEST-*.xml under it")
@@ -282,7 +330,7 @@ def main(argv: list[str]) -> int:
             for line in pathlib.Path(args.tests).read_text(encoding="utf-8").splitlines()
             if line.strip()
         ]
-        sys.stdout.write(hydrate(body, fqns))
+        sys.stdout.write(hydrate(body, fqns, tag=args.tag))
         return 0
     if args.cmd == "tick":
         body = sys.stdin.read()


### PR DESCRIPTION
## Summary

File a release issue without filling in the **Release tag** field and the `release-from-issue` workflow now resolves the next patch version itself — `v0.0.38 → v0.0.39` against current `main` — and dispatches Release with that. Mirrors onymchat/onym-ios#123.

### Issue template
- `Release tag` is no longer required. New help text + placeholder explain the auto-bump behaviour.

### `scripts/release_issue.py`
- **`parse-tag`** returns `""` (exit 0) for both blank fields and GitHub's `_No response_` placeholder. Malformed values still abort with the existing error message — only the missing-value path changed.
- **`hydrate`** gains an optional `--tag vX.Y.Z` flag that rewrites the `### Release tag` field's value via a new `_rewrite_tag()` helper. Idempotent for the explicit case; meaningful for the auto-bumped case so the issue body itself shows what got dispatched.

### `release-from-issue.yml`
- `actions/checkout@v4` now uses `fetch-tags: true` so the runner sees `v*` tags (default depth-1 fetch wouldn't).
- **Resolve release tag** step (renamed from "Parse + validate"):
  - On empty `parse-tag` output: picks latest `v[0-9]+\.[0-9]+\.[0-9]+` tag, bumps patch, falls back to `v0.0.1` on a tagless repo. Emits an `auto_bumped` step output.
  - Refuses to dispatch on a tag that already exists — protects a hand-typed value that collides with a previous release. The auto-bump path is collision-free by construction.
- **Body-rewrite step** passes `--tag $TAG` to `hydrate`, then comments on the issue when auto-bumped so the maintainer can correct it (close + reopen with a different value) if needed.

## Test plan

Verified locally:
- [x] `parse-tag` returns the typed tag, `""` for `_No response_`, and rejects `0.0.45` (missing `v`) with the existing error.
- [x] `hydrate --tag v0.0.39` rewrites `### Release tag` and fills the UI_TESTS section in a single pass.
- [x] Auto-bump arithmetic against `git tag --sort=-v:refname` on current `main` produces `v0.0.38 → v0.0.39`.

Reviewer checklist:
- [ ] File a release issue with the Release tag field blank — confirm the workflow rewrites the body to show the auto-bumped tag, leaves the explanation comment, and dispatches Release for the right tag.
- [ ] File a release issue with a colliding tag (e.g. `v0.0.38`) — confirm the workflow comments + fails before dispatch.
- [ ] File a release issue with a properly-typed new tag — confirm behaviour matches the previous workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)