### PR TITLE
feat(release): publish signed APK to onym.app/qa/ alongside GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [lint, test, android-test, create-release]
+    # Share the lock with qa-build.yml so a tag-gated release and a
+    # manual ad-hoc QA dispatch don't race on /qa/builds.json. Only
+    # the build job (where the QA publish runs) takes the lock; lint
+    # and tests still run in parallel.
+    concurrency:
+      group: qa-build-android
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -363,6 +370,175 @@ jobs:
         with:
           tag_name: ${{ inputs.tag }}
           files: ${{ steps.apk.outputs.path }}
+
+      # ----------------------------------------------------------------
+      # Publish the same signed APK to onym.app/qa/. Mirror of
+      # `qa-build.yml`'s publish chain — kept inline (rather than
+      # extracted into a composite action) so the manual QA dispatch
+      # and the tag-gated release stay readable side by side. iOS has
+      # the equivalent in `release.yml` after the GitHub-Release upload.
+      #
+      # On a release run, the dashboard entry is `kind: tag` (the
+      # manual dispatch path uses `kind: branch` + commit-decorated
+      # version).
+      # ----------------------------------------------------------------
+
+      - name: Stage signed APK for QA dashboard
+        env:
+          VERSION: ${{ inputs.tag }}
+          APK_PATH: ${{ steps.apk.outputs.path }}
+        run: |
+          set -eu
+          [ -f "$APK_PATH" ] || { echo "expected signed APK at $APK_PATH" >&2; exit 1; }
+          mkdir -p "dist/qa/android/${VERSION}"
+          cp "$APK_PATH" "dist/qa/android/${VERSION}/onym.apk"
+          echo "APK_SIZE=$(stat -c%s "dist/qa/android/${VERSION}/onym.apk")" >> "$GITHUB_ENV"
+
+      - name: Build dashboard entry + merge into builds.json
+        env:
+          VERSION:    ${{ inputs.tag }}
+          TAG:        ${{ inputs.tag }}
+          COMMIT:     ${{ github.sha }}
+          ISSUE:      ${{ inputs.issue_number }}
+          REPO:       ${{ github.repository }}
+          RUN_ID:     ${{ github.run_id }}
+          HOST:       ${{ secrets.DEPLOY_HOST }}
+          GH_TOKEN:   ${{ github.token }}
+        run: |
+          set -eu
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          COMMIT_SHORT=$(printf '%s' "$COMMIT" | cut -c1-5)
+
+          # Resolve the originating release issue's title (best-effort;
+          # gh failure -> empty title). Issue number is plumbed in by
+          # release-from-issue.yml; manual `gh workflow run Release`
+          # dispatches without it leave the field null.
+          ISSUE_OBJ='null'
+          if [ -n "$ISSUE" ]; then
+            TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title 2>/dev/null || echo "")
+            ISSUE_OBJ=$(jq -n \
+              --arg n "$ISSUE" --arg t "$TITLE" \
+              --arg url "https://github.com/$REPO/issues/$ISSUE" \
+              '{number: ($n|tonumber), title: $t, url: $url}')
+          fi
+
+          # Schema must match `qa-build.yml`'s entry shape — the
+          # dashboard at public/qa/index.html in onym-website renders
+          # both kinds with the same fields.
+          jq -n \
+            --arg platform "android" \
+            --arg version "$VERSION" \
+            --arg kind "tag" \
+            --arg tag "$TAG" \
+            --arg commit "$COMMIT" \
+            --arg commit_short "$COMMIT_SHORT" \
+            --arg built_at "$BUILT_AT" \
+            --arg description "Release ${VERSION}" \
+            --argjson issue "$ISSUE_OBJ" \
+            --arg install_url "https://${HOST}/qa/android/${VERSION}/onym.apk" \
+            --arg apk_url     "https://${HOST}/qa/android/${VERSION}/onym.apk" \
+            --argjson size_bytes "${APK_SIZE}" \
+            --arg commit_url   "https://github.com/$REPO/commit/$COMMIT" \
+            --arg workflow_url "https://github.com/$REPO/actions/runs/$RUN_ID" \
+            '{
+              platform: $platform,
+              version: $version,
+              kind: $kind,
+              branch: null,
+              tag: $tag,
+              commit: $commit,
+              commit_short: $commit_short,
+              built_at: $built_at,
+              description: $description,
+              issue: $issue,
+              install_url: $install_url,
+              apk_url: $apk_url,
+              size_bytes: $size_bytes,
+              commit_url: $commit_url,
+              workflow_url: $workflow_url
+            }' > /tmp/new-entry.json
+
+          echo "::group::New dashboard entry"
+          cat /tmp/new-entry.json
+          echo "::endgroup::"
+
+          # Fetch the live builds.json. 404 (no file yet) -> empty skeleton.
+          if curl -sf -o /tmp/current.json "https://${HOST}/qa/builds.json"; then
+            echo "::notice::Fetched current builds.json from https://${HOST}/qa/builds.json"
+          else
+            echo "::notice::No existing builds.json -- starting fresh"
+            echo '{"schema_version":1,"builds":[]}' > /tmp/current.json
+          fi
+
+          # Merge: drop scaffold sample, prepend our entry, dedupe by
+          # platform+version (newer wins — re-running a release for
+          # the same tag overwrites the dashboard entry with this
+          # run's metadata), sort newest first, cap 50.
+          jq --slurpfile new /tmp/new-entry.json '
+            (if .is_sample == true then .builds = [] else . end)
+            | .builds = (
+                [$new[0]] + (.builds // [])
+                | unique_by(.platform + "@" + .version)
+                | sort_by(.built_at) | reverse
+                | .[0:50]
+              )
+            | del(.is_sample)
+            | .schema_version = 1
+            | .generated_at = (now | todate)
+          ' /tmp/current.json > dist/qa/builds.json
+
+          echo "::group::Merged builds.json (head)"
+          jq '{schema_version, generated_at, total: (.builds|length), builds: (.builds[0:5])}' dist/qa/builds.json
+          echo "::endgroup::"
+
+      - name: Publish to onym.app/qa/
+        # delete_stale: false preserves iOS uploads under
+        # /var/www/onym/qa/ios/ and previous Android builds under
+        # /var/www/onym/qa/android/<other>/.
+        uses: onymchat/onym-website/.github/actions/deploy@main
+        with:
+          source_path: dist/qa
+          target_subpath: qa
+          ssh_key: ${{ secrets.DEPLOY_SSH_KEY }}
+          host: ${{ secrets.DEPLOY_HOST }}
+          delete_stale: false
+
+      - name: QA-publish summary
+        env:
+          VERSION: ${{ inputs.tag }}
+          HOST:    ${{ secrets.DEPLOY_HOST }}
+        run: |
+          {
+            echo "## QA build published (alongside GitHub Release \`$VERSION\`)"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Version | \`$VERSION\` |"
+            echo "| APK | https://${HOST}/qa/android/${VERSION}/onym.apk |"
+            echo "| Dashboard | https://${HOST}/qa/?platform=android |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment QA install URL on the linked release issue
+        # Best-effort: gh failure must not fail the release run.
+        if: success() && inputs.issue_number != ''
+        env:
+          ISSUE:    ${{ inputs.issue_number }}
+          VERSION:  ${{ inputs.tag }}
+          HOST:     ${{ secrets.DEPLOY_HOST }}
+          REPO:     ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BODY_FILE=$(mktemp)
+          cat > "$BODY_FILE" <<MSG
+          QA build \`${VERSION}\` published to the dashboard.
+
+          - Install on Android: https://${HOST}/qa/android/${VERSION}/onym.apk
+          - Dashboard: https://${HOST}/qa/?platform=android
+          MSG
+          if ! gh issue comment "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE"; then
+            echo "::warning::Failed to post QA-install comment on issue #$ISSUE (release itself succeeded)."
+          fi
+          rm -f "$BODY_FILE"
 
   # ─── Release-issue reporting ─────────────────────────────────────
   # Only runs when dispatched from `release-from-issue.yml` (which


### PR DESCRIPTION
Closes #130.

## Why this release didn't show up on onym.app/qa/

A successful tag-gated `Release` (`v0.0.42` from #130) attached the signed APK to a GitHub Release and stopped — there is no step in `release.yml` that stages a manifest, merges into `builds.json`, or rsyncs to onym.app. The QA dashboard is populated only by the manually-dispatched `qa-build.yml`, so testers couldn't tap "Install" for an actual release. iOS landed the equivalent fix in onymchat/onym-ios#126 (already merged); this PR mirrors it.

## What changed

In `release.yml`'s `build` job, immediately after `softprops/action-gh-release@…` (the GitHub Release upload):

- **Stage signed APK** under `dist/qa/android/<tag>/onym.apk` (same file path the dashboard expects).
- **Build dashboard entry** (`kind: tag`, `branch: null`, `description: "Release vX.Y.Z"`).
- **Merge into `builds.json`** — fetch the live one, prepend our entry, `unique_by(platform+@+version)` so a re-run for the same tag cleanly overwrites, sort newest-first, cap 50.
- **rsync** via `onymchat/onym-website/.github/actions/deploy@main` with `delete_stale: false` so iOS uploads + earlier Android builds aren't wiped.
- **Step summary table** with install + dashboard URLs.
- **Issue comment** with the install URL when dispatched from a release issue (best-effort — a `gh` failure leaves a `::warning::` but never fails the release run).

### Concurrency

Added a job-level `qa-build-android` group on the release `build` job — same group `qa-build.yml` uses at workflow level. Tag-gated releases and manual QA dispatches now serialize on `builds.json` writes; lint + tests still run in parallel.

### Why inline rather than a composite action

Same trade-off iOS made: the QA-publish chain is now duplicated between `qa-build.yml` and `release.yml`. Refactoring into `.github/actions/qa-publish-android/action.yml` would deduplicate but adds an indirection layer for two callers. Kept inline so both flows stay readable side-by-side; easy refactor opportunity if a third caller ever appears.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses the workflow cleanly.
- [ ] Reviewer files a fresh release issue (auto-bump path) and confirms:
  - The APK lands as a GitHub Release asset (existing behavior).
  - `https://onym.app/qa/android/<tag>/onym.apk` is reachable + installs on a real device.
  - `https://onym.app/qa/?platform=android` shows the new entry with `kind: tag`.
  - The release issue receives a comment with the install URL.
- [ ] Reviewer dispatches a manual `QA Build` while a release is publishing — confirms the second waits on the `qa-build-android` lock instead of racing on `builds.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
