### PR TITLE
feat(qa): comments link to /qa/build/ details page, embed issue body

### DIFF
--- a/.github/workflows/qa-build.yml
+++ b/.github/workflows/qa-build.yml
@@ -185,14 +185,19 @@ jobs:
 
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          # Resolve issue title (best-effort; gh failure -> empty title)
+          # Resolve issue title + body (best-effort; gh failure -> empty
+          # strings). `body` powers the Test Plan section on the build
+          # details page (public/qa/build/ in onym-website) without the
+          # page having to hit the GitHub API at view time.
           ISSUE_OBJ='null'
           if [ -n "$ISSUE" ]; then
-            TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title 2>/dev/null || echo "")
+            ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json title,body 2>/dev/null || echo '{}')
+            TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title // ""')
+            BODY=$(printf  '%s' "$ISSUE_JSON" | jq -r '.body  // ""')
             ISSUE_OBJ=$(jq -n \
-              --arg n "$ISSUE" --arg t "$TITLE" \
+              --arg n "$ISSUE" --arg t "$TITLE" --arg b "$BODY" \
               --arg url "https://github.com/$REPO/issues/$ISSUE" \
-              '{number: ($n|tonumber), title: $t, url: $url}')
+              '{number: ($n|tonumber), title: $t, url: $url, body: $b}')
           fi
 
           # The dashboard's contract -- see public/qa/builds.json on
@@ -296,6 +301,7 @@ jobs:
             echo "| Kind | $KIND |"
             echo "| Branch | \`$BRANCH\` |"
             echo "| APK | https://${HOST}/qa/android/${VERSION}/onym.apk |"
+            echo "| Build details | https://${HOST}/qa/build/?platform=android&version=${VERSION} |"
             echo "| Dashboard | https://${HOST}/qa/?platform=android |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -349,7 +355,7 @@ jobs:
           QA build \`${VERSION}\` published.
 
           - APK (side-load on Android): https://${HOST}/qa/android/${VERSION}/onym.apk
-          - Dashboard: https://${HOST}/qa/?platform=android
+          - Build details (test plan, install, metadata): https://${HOST}/qa/build/?platform=android&version=${VERSION}
           MSG
 
           if ! gh pr comment "$target_pr" --repo "$REPO" --body-file "$BODY_FILE"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,17 +409,22 @@ jobs:
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           COMMIT_SHORT=$(printf '%s' "$COMMIT" | cut -c1-5)
 
-          # Resolve the originating release issue's title (best-effort;
-          # gh failure -> empty title). Issue number is plumbed in by
-          # release-from-issue.yml; manual `gh workflow run Release`
-          # dispatches without it leave the field null.
+          # Resolve the originating release issue's title + body
+          # (best-effort; gh failure -> empty strings). Issue number is
+          # plumbed in by release-from-issue.yml; manual `gh workflow run
+          # Release` dispatches without it leave the field null. `body`
+          # powers the Test Plan section on the build details page
+          # (public/qa/build/ in onym-website) without the page having
+          # to hit the GitHub API at view time.
           ISSUE_OBJ='null'
           if [ -n "$ISSUE" ]; then
-            TITLE=$(gh issue view "$ISSUE" --repo "$REPO" --json title -q .title 2>/dev/null || echo "")
+            ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json title,body 2>/dev/null || echo '{}')
+            TITLE=$(printf '%s' "$ISSUE_JSON" | jq -r '.title // ""')
+            BODY=$(printf  '%s' "$ISSUE_JSON" | jq -r '.body  // ""')
             ISSUE_OBJ=$(jq -n \
-              --arg n "$ISSUE" --arg t "$TITLE" \
+              --arg n "$ISSUE" --arg t "$TITLE" --arg b "$BODY" \
               --arg url "https://github.com/$REPO/issues/$ISSUE" \
-              '{number: ($n|tonumber), title: $t, url: $url}')
+              '{number: ($n|tonumber), title: $t, url: $url, body: $b}')
           fi
 
           # Schema must match `qa-build.yml`'s entry shape — the
@@ -515,6 +520,7 @@ jobs:
             echo "|---|---|"
             echo "| Version | \`$VERSION\` |"
             echo "| APK | https://${HOST}/qa/android/${VERSION}/onym.apk |"
+            echo "| Build details | https://${HOST}/qa/build/?platform=android&version=${VERSION} |"
             echo "| Dashboard | https://${HOST}/qa/?platform=android |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -533,7 +539,7 @@ jobs:
           QA build \`${VERSION}\` published to the dashboard.
 
           - Install on Android: https://${HOST}/qa/android/${VERSION}/onym.apk
-          - Dashboard: https://${HOST}/qa/?platform=android
+          - Build details (test plan, install, metadata): https://${HOST}/qa/build/?platform=android&version=${VERSION}
           MSG
           if ! gh issue comment "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE"; then
             echo "::warning::Failed to post QA-install comment on issue #$ISSUE (release itself succeeded)."


### PR DESCRIPTION
## Summary
- The QA-publish comment posted on the linked PR (qa-build) and on the linked release issue (release) now links to the per-build details page on onym.app instead of the dashboard.
- Build entry written to `qa/builds.json` now carries `issue.body` alongside `title` so the details page can render the Test Plan section without hitting the GitHub API per visitor.
- Adds a "Build details" row to the GH Actions step-summary tables for parity with the comment.

## Why
Pairs with onymchat/onym-website#1, which adds `/qa/build/?platform=android&version=...`. The detail page extracts the `## Test plan` section from `issue.body`. Embedding the body in the dashboard JSON keeps the page snappy and dodges GitHub API rate limits when several testers open the link at once.

## Test plan
- [ ] Dispatch `qa-build.yml` against a branch with a linked PR that has a `## Test plan` section -> PR comment posts and links to `https://onym.app/qa/build/?platform=android&version=...`; opening the link shows the Test Plan rendered without a GitHub API spinner
- [ ] Run `release.yml` from `release-from-issue.yml` against a release issue with a `## Test plan` section -> issue comment posts the new URL; details page renders the test plan
- [ ] Manual `gh workflow run Release -f tag=...` (no `issue_number`) -> `issue` field stays `null` in builds.json, no comment, build entry still publishes
- [ ] Issue body containing markdown special chars (backticks, dollar signs, code fences) survives the `--arg b "$BODY"` round-trip and renders correctly on the details page
- [ ] GH Actions summary table shows both "Build details" and "Dashboard" rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)