### PR TITLE
feat(invite): expire group invite links 24h after minting

### DIFF
--- a/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/EncryptedPrefsIntroKeyStore.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.json.Json
 class EncryptedPrefsIntroKeyStore(
     private val context: Context,
     private val prefsFileName: String = DEFAULT_PREFS_FILE_NAME,
+    private val clock: () -> Long = { System.currentTimeMillis() },
 ) : IntroKeyStore {
 
     private val mutex = Mutex()
@@ -68,12 +69,14 @@ class EncryptedPrefsIntroKeyStore(
         // sees the on-disk state without needing an explicit reload.
         // EncryptedSharedPreferences read is lazy via the `prefs`
         // delegate, so this only does work if a previous session
-        // wrote something.
-        _entriesFlow.value = loadAllUnlocked().map { it.toEntry() }
+        // wrote something. Routes through loadActiveUnlocked so
+        // entries that aged past the lifetime while the app was
+        // closed are pruned at boot.
+        _entriesFlow.value = loadActiveUnlocked().map { it.toEntry() }
     }
 
     override suspend fun save(entry: IntroKeyEntry) = mutex.withLock {
-        val current = loadAllUnlocked().toMutableList()
+        val current = loadActiveUnlocked().toMutableList()
         val existingIdx = current.indexOfFirst {
             it.introPub.contentEquals(entry.introPublicKey)
         }
@@ -90,26 +93,26 @@ class EncryptedPrefsIntroKeyStore(
     }
 
     override suspend fun find(introPublicKey: ByteArray): IntroKeyEntry? = mutex.withLock {
-        loadAllUnlocked()
+        loadActiveUnlocked()
             .firstOrNull { it.introPub.contentEquals(introPublicKey) }
             ?.toEntry()
     }
 
     override suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry> = mutex.withLock {
-        loadAllUnlocked()
+        loadActiveUnlocked()
             .filter { it.ownerIdentityId == ownerIdentityId.value }
             .sortedByDescending { it.createdAtMillis }
             .map { it.toEntry() }
     }
 
     override suspend fun revoke(introPublicKey: ByteArray) = mutex.withLock {
-        val current = loadAllUnlocked()
+        val current = loadActiveUnlocked()
         val filtered = current.filterNot { it.introPub.contentEquals(introPublicKey) }
         if (filtered.size != current.size) saveAllUnlocked(filtered)
     }
 
     override suspend fun deleteForOwner(ownerIdentityId: IdentityId): Int = mutex.withLock {
-        val current = loadAllUnlocked()
+        val current = loadActiveUnlocked()
         val filtered = current.filterNot { it.ownerIdentityId == ownerIdentityId.value }
         val removed = current.size - filtered.size
         if (removed > 0) saveAllUnlocked(filtered)
@@ -117,6 +120,21 @@ class EncryptedPrefsIntroKeyStore(
     }
 
     // ─── private ──────────────────────────────────────────────────
+
+    /** Load the blob, drop rows older than
+     *  [IntroKeyEntry.LIFETIME_MILLIS], and rewrite if anything was
+     *  pruned. Every read funnels through here so expired keys are
+     *  invisible to callers and the blob stays bounded without a
+     *  background timer. When rows are pruned, [_entriesFlow]
+     *  re-emits so [IntroInboxPump] cancels relayer subscriptions
+     *  for expired slots. */
+    private fun loadActiveUnlocked(): List<StoredIntroKey> {
+        val all = loadAllUnlocked()
+        val cutoffMillis = clock() - IntroKeyEntry.LIFETIME_MILLIS
+        val active = all.filter { it.createdAtMillis > cutoffMillis }
+        if (active.size != all.size) saveAllUnlocked(active)
+        return active
+    }
 
     private fun loadAllUnlocked(): List<StoredIntroKey> {
         val raw = prefs.getString(KEY_BLOB, null) ?: return emptyList()

--- a/app/src/main/kotlin/chat/onym/android/group/IntroKeyEntry.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroKeyEntry.kt
@@ -19,8 +19,11 @@ import chat.onym.android.identity.IdentityId
  * - [groupId] is the on-chain `group_id` the invite is for —
  *   needed when the inviter's app surfaces "Bob wants to join
  *   <group>?" so it can render the group's name.
- * - [createdAtMillis] drives optional expiration UI (PR-7+ may
- *   prune invites older than N days).
+ * - [createdAtMillis] drives time-based expiry. Entries older than
+ *   [LIFETIME_MILLIS] are treated as revoked at the [IntroKeyStore]
+ *   boundary ([IntroKeyStore.find] returns null,
+ *   [IntroKeyStore.listForOwner] and [IntroKeyStore.entriesFlow]
+ *   omit them) and lazily purged on the next read.
  */
 data class IntroKeyEntry(
     val introPublicKey: ByteArray,
@@ -39,6 +42,16 @@ data class IntroKeyEntry(
         require(groupId.size == 32) {
             "groupId: expected 32 bytes, got ${groupId.size}"
         }
+    }
+
+    fun isExpired(atMillis: Long, lifetimeMillis: Long = LIFETIME_MILLIS): Boolean =
+        atMillis - createdAtMillis >= lifetimeMillis
+
+    companion object {
+        /** How long an invite link is honored after minting. Issue
+         *  onymchat/onym-ios#111 — rotate every 24 hours to shrink
+         *  the leak window of a forwarded or screenshotted link. */
+        const val LIFETIME_MILLIS: Long = 24L * 60L * 60L * 1000L
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
+++ b/app/src/main/kotlin/chat/onym/android/group/IntroKeyStore.kt
@@ -23,16 +23,26 @@ import kotlinx.coroutines.flow.StateFlow
  * Owner-scoping: every entry carries an [IdentityId]. Removing an
  * identity (multi-identity PR-3) cascades a [deleteForOwner] so
  * we don't leak intro privkeys past the identity that minted them.
+ *
+ * Time-based expiry: entries older than [IntroKeyEntry.LIFETIME_MILLIS]
+ * (24h) are treated as revoked at this boundary — [find] returns
+ * null for them, [listForOwner] and [entriesFlow] omit them.
+ * Implementations lazy-purge expired rows on each read so the
+ * underlying blob stays bounded without a background sweeper, and
+ * re-emit on [entriesFlow] so [IntroInboxPump] can cancel relayer
+ * subscriptions for expired slots.
  */
 interface IntroKeyStore {
-    /** Hot stream of every entry across every owner. Emits the
-     *  current snapshot on subscribe, then a fresh value after
-     *  every [save] / [revoke] / [deleteForOwner].
+    /** Hot stream of every active (non-expired) entry across every
+     *  owner. Emits the current snapshot on subscribe, then a fresh
+     *  value after every [save] / [revoke] / [deleteForOwner], and
+     *  whenever a read lazy-purges expired rows.
      *
      *  Drives the inbox fan-out (PR-3): the wiring layer maps
      *  this → list of intro inbox tags → feeds into the request
      *  pump. New entry → new subscription within the next
-     *  emission window. */
+     *  emission window. Expired entry → subscription gets cancelled
+     *  on the next emission. */
     val entriesFlow: StateFlow<List<IntroKeyEntry>>
 
     /** Persist a freshly-minted intro entry. Idempotent on
@@ -43,13 +53,15 @@ interface IntroKeyStore {
 
     /** Look up an entry by its public key. Returns null when the
      *  pubkey is unknown — happens when an old entry was
-     *  [revoke]d, or when a request envelope targets a pubkey
-     *  this device never minted (probably a forged link). */
+     *  [revoke]d, has aged past [IntroKeyEntry.LIFETIME_MILLIS], or
+     *  when a request envelope targets a pubkey this device never
+     *  minted (probably a forged link). */
     suspend fun find(introPublicKey: ByteArray): IntroKeyEntry?
 
-    /** Every entry minted by [ownerIdentityId]. Sorted newest
-     *  first by [IntroKeyEntry.createdAtMillis]. UI's "Active
-     *  invites" list reads here. */
+    /** Every entry minted by [ownerIdentityId] that has not aged
+     *  past [IntroKeyEntry.LIFETIME_MILLIS]. Sorted newest first
+     *  by [IntroKeyEntry.createdAtMillis]. UI's "Active invites"
+     *  list reads here. */
     suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry>
 
     /** Single-entry deletion. Called after a request is accepted

--- a/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
+++ b/app/src/sharedTest/kotlin/chat/onym/android/support/InMemoryIntroKeyStore.kt
@@ -16,7 +16,9 @@ import kotlinx.coroutines.sync.withLock
  * `InviteIntroducer` / future request-flow interactors that don't
  * want to stand up the Keystore.
  */
-class InMemoryIntroKeyStore : IntroKeyStore {
+class InMemoryIntroKeyStore(
+    private val clock: () -> Long = { System.currentTimeMillis() },
+) : IntroKeyStore {
 
     private val mutex = Mutex()
     private val entries = mutableListOf<IntroKeyEntry>()
@@ -25,16 +27,19 @@ class InMemoryIntroKeyStore : IntroKeyStore {
     override val entriesFlow: StateFlow<List<IntroKeyEntry>> = _entriesFlow.asStateFlow()
 
     override suspend fun save(entry: IntroKeyEntry) = mutex.withLock {
+        purgeExpiredUnlocked()
         entries.removeAll { it.introPublicKey.contentEquals(entry.introPublicKey) }
         entries += entry
         _entriesFlow.value = entries.toList()
     }
 
     override suspend fun find(introPublicKey: ByteArray): IntroKeyEntry? = mutex.withLock {
+        purgeExpiredUnlocked()
         entries.firstOrNull { it.introPublicKey.contentEquals(introPublicKey) }
     }
 
     override suspend fun listForOwner(ownerIdentityId: IdentityId): List<IntroKeyEntry> = mutex.withLock {
+        purgeExpiredUnlocked()
         entries
             .filter { it.ownerIdentityId == ownerIdentityId }
             .sortedByDescending { it.createdAtMillis }
@@ -53,5 +58,17 @@ class InMemoryIntroKeyStore : IntroKeyStore {
         val removed = before - entries.size
         if (removed > 0) _entriesFlow.value = entries.toList()
         removed
+    }
+
+    /** Drop entries whose [IntroKeyEntry.createdAtMillis] is older
+     *  than [IntroKeyEntry.LIFETIME_MILLIS] relative to the
+     *  injected [clock] and re-emit [entriesFlow] so the
+     *  [chat.onym.android.group.IntroInboxPump] reconciler can
+     *  cancel relayer subscriptions for expired slots. */
+    private fun purgeExpiredUnlocked() {
+        val nowMillis = clock()
+        val before = entries.size
+        entries.removeAll { it.isExpired(nowMillis) }
+        if (entries.size != before) _entriesFlow.value = entries.toList()
     }
 }

--- a/app/src/test/kotlin/chat/onym/android/group/IntroKeyStoreExpiryTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/IntroKeyStoreExpiryTest.kt
@@ -1,0 +1,134 @@
+package chat.onym.android.group
+
+import chat.onym.android.identity.IdentityId
+import chat.onym.android.support.InMemoryIntroKeyStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Time-based expiry contract for [IntroKeyStore] (issue
+ * onymchat/onym-ios#111). An entry older than
+ * [IntroKeyEntry.LIFETIME_MILLIS] is treated as if it were revoked:
+ * [IntroKeyStore.find] returns null, [IntroKeyStore.listForOwner]
+ * and [IntroKeyStore.entriesFlow] omit it, and storage is
+ * lazy-purged so [IntroInboxPump] cancels relayer subscriptions.
+ */
+class IntroKeyStoreExpiryTest {
+
+    private val alice = IdentityId("11111111-1111-1111-1111-111111111111")
+    private val sampleGroupId = ByteArray(32) { 0x42 }
+
+    private fun entry(seed: Byte, createdAtMillis: Long): IntroKeyEntry =
+        IntroKeyEntry(
+            introPublicKey = ByteArray(32) { seed },
+            introPrivateKey = ByteArray(32) { (seed + 1).toByte() },
+            ownerIdentityId = alice,
+            groupId = sampleGroupId,
+            createdAtMillis = createdAtMillis,
+        )
+
+    @Test
+    fun find_returnsNull_forEntryOlderThanLifetime() = runTest {
+        val now = 1_700_000_000_000L
+        val store = InMemoryIntroKeyStore(clock = { now })
+        val stale = entry(
+            seed = 0x10,
+            createdAtMillis = now - IntroKeyEntry.LIFETIME_MILLIS - 1,
+        )
+        store.save(stale)
+
+        assertNull(
+            "expired intro key must not be findable",
+            store.find(stale.introPublicKey),
+        )
+    }
+
+    @Test
+    fun find_returnsEntry_atLifetimeBoundary_minusOne() = runTest {
+        val now = 1_700_000_000_000L
+        val store = InMemoryIntroKeyStore(clock = { now })
+        val fresh = entry(
+            seed = 0x11,
+            createdAtMillis = now - IntroKeyEntry.LIFETIME_MILLIS + 1,
+        )
+        store.save(fresh)
+
+        assertNotNull(
+            "entry one millisecond under lifetime must still be honored",
+            store.find(fresh.introPublicKey),
+        )
+    }
+
+    @Test
+    fun listForOwner_omitsExpiredEntries_keepsFresh() = runTest {
+        // Save two entries while both are fresh, then advance the
+        // clock so only one crosses the expiry threshold. Exercises
+        // the read-side filter, not just the purge-on-save path.
+        val clock = AtomicLong(1_700_000_000_000L)
+        val store = InMemoryIntroKeyStore(clock = clock::get)
+        val older = entry(seed = 0x10, createdAtMillis = clock.get())
+        store.save(older)
+        clock.addAndGet(IntroKeyEntry.LIFETIME_MILLIS - 60_000L)
+        val newer = entry(seed = 0x20, createdAtMillis = clock.get())
+        store.save(newer)
+        clock.addAndGet(120_000L) // older is now expired, newer is not.
+
+        val list = store.listForOwner(alice)
+        assertEquals(1, list.size)
+        assertEquals(
+            newer.introPublicKey.toList(),
+            list[0].introPublicKey.toList(),
+        )
+    }
+
+    @Test
+    fun entriesFlow_reEmits_whenLazyPurgeDropsRows() = runTest {
+        // Clock starts inside the lifetime window so the seeded
+        // entry is initially live, then advances past expiry so a
+        // read triggers the lazy purge and entriesFlow re-emits an
+        // empty snapshot — that's what IntroInboxPump needs in
+        // order to cancel its relayer subscription.
+        val clock = AtomicLong(1_700_000_000_000L)
+        val store = InMemoryIntroKeyStore(clock = clock::get)
+        val staleSoon = entry(seed = 0x30, createdAtMillis = clock.get())
+        store.save(staleSoon)
+
+        // Sanity: flow currently carries the live entry.
+        val initial = store.entriesFlow.first()
+        assertEquals(1, initial.size)
+
+        clock.addAndGet(IntroKeyEntry.LIFETIME_MILLIS + 1)
+        // Trigger the lazy purge.
+        store.listForOwner(alice)
+
+        val afterPurge = store.entriesFlow.first()
+        assertEquals(
+            "lazy purge must clear entriesFlow so the inbox pump cancels relayer subscriptions",
+            0,
+            afterPurge.size,
+        )
+    }
+
+    @Test
+    fun save_purgesExpiredEntries_priorToInsertion() = runTest {
+        // Mint A while fresh, advance past expiry, mint B. The
+        // store must silently drop A as part of B's save so the
+        // EncryptedSharedPreferences blob doesn't grow unbounded.
+        val clock = AtomicLong(1_700_000_000_000L)
+        val store = InMemoryIntroKeyStore(clock = clock::get)
+        val first = entry(seed = 0x40, createdAtMillis = clock.get())
+        store.save(first)
+        clock.addAndGet(IntroKeyEntry.LIFETIME_MILLIS + 1)
+        val second = entry(seed = 0x50, createdAtMillis = clock.get())
+        store.save(second)
+
+        assertNull(store.find(first.introPublicKey))
+        assertNotNull(store.find(second.introPublicKey))
+    }
+
+}

--- a/app/src/test/kotlin/chat/onym/android/group/InviteIntroducerTest.kt
+++ b/app/src/test/kotlin/chat/onym/android/group/InviteIntroducerTest.kt
@@ -147,8 +147,11 @@ class InviteIntroducerTest {
 
     @Test
     fun mint_clockProvider_stampsCreatedAt() = runTest {
-        val store = InMemoryIntroKeyStore()
         val frozenNow = 1_700_000_000_000L
+        // Sync the store's clock with the introducer's so the lazy
+        // expiry sweep doesn't drop a freshly-minted 2023-dated
+        // entry against today's wall clock (issue onymchat/onym-ios#111).
+        val store = InMemoryIntroKeyStore(clock = { frozenNow })
         val introducer = InviteIntroducer(
             store = store,
             ioDispatcher = Dispatchers.Unconfined,


### PR DESCRIPTION
## Summary

- Time-based expiry on the `IntroKeyStore` boundary: entries older than `IntroKeyEntry.LIFETIME_MILLIS` (24h) are treated as revoked. `find` returns null, `listForOwner` and `entriesFlow` omit them, and storage is lazy-purged on read. The flow re-emit means `IntroInboxPump` cancels the relayer subscription — an expired link is dead network-side, not just hidden in the UI.
- Mirrors iOS commit [`3804771`](https://github.com/onymchat/onym-ios/commit/3804771) (issue [onymchat/onym-ios#111](https://github.com/onymchat/onym-ios/issues/111)). Event-based rotation (revoke-on-approve in `JoinRequestApprover`) was already wired; this adds the time-based half.
- New `IntroKeyStoreExpiryTest` covers: `find` returns null past lifetime, `find` honors boundary minus 1ms, `listForOwner` omits expired keeps fresh, `entriesFlow` re-emits on lazy purge, `save` purges before insertion.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` (passes)
- [ ] Targeted: `IntroKeyStoreExpiryTest`, `InviteIntroducerTest`, `IntroInboxPumpTest`, `JoinRequestApproverTest` (all pass)
- [ ] Manual: cold-launch on device with an existing fresh entry, confirm app boots without `EncryptedPrefsIntroKeyStore` NPE (the `prefs` lazy-delegate ordering is unchanged)
- [ ] Manual: mint an invite, fast-forward device clock past 24h, confirm joiner sees no relayer pickup and inviter's "Active invites" list omits the expired entry

## Out of scope

The UX softening called out in [the iOS comment](https://github.com/onymchat/onym-ios/issues/111#issuecomment-4416318364) — countdown on the share screen, grace window for multi-invitee scans — is **not** included. This PR only ports the shipped expiry logic; UX follow-ups should be tracked separately and built on both platforms together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)