### PR TITLE
fix(tests): sync instrumented derivation fixture to post-rebrand salts

### DIFF
--- a/app/src/androidTest/kotlin/app/onym/android/identity/IdentityRepositoryTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/identity/IdentityRepositoryTest.kt
@@ -97,28 +97,28 @@ class IdentityRepositoryTest {
         val identity = repo.restore(mnemonic)
 
         assertEquals(
-            "1ee9632e948a11ff2b00fd0acf11f642fadcf14cd14d1f15b3bb6c072a268894",
+            "d8631b8e96d3d3d6d42cdadd07bc6db04108367dc2ce2d5e9b9a524123dc0821",
             identity.nostrPublicKey.toHex(),
         )
         assertEquals(
-            "93c738ad5a4ff1be5692bd9b9eebb168c23710b7926b105fce3ee82fdf94debd" +
-                "17fef8ab2950622704438a2f16dbe3d6",
+            "a5859e962056987df69617fa41318641def18a1f78959951d1cf07bd164a6dcb" +
+                "50962786c8ead48c4e6aab5db6ce8f10",
             identity.blsPublicKey.toHex(),
         )
         assertEquals(
-            "2d26005ffeaf78d38581e0c1c1cea3a7ae5d9510b0215a122c2b8c7ea24c6118",
+            "7a33c09cdb7f51fe723a4003d2f28272cddc8fa2cf3d74a374a5f2ee6fb1fcdc",
             identity.stellarPublicKey.toHex(),
         )
         assertEquals(
-            "GAWSMAC772XXRU4FQHQMDQOOUOT24XMVCCYCCWQSFQVYY7VCJRQRRF2K",
+            "GB5DHQE43N7VD7TSHJAAHUXSQJZM3XEPULHT25FDOSS7F3TPWH6NYJ7A",
             identity.stellarAccountID,
         )
         assertEquals(
-            "677244099e153cd18331aa2b44132d82b2a7f385f339b05184ac92df77e79d50",
+            "66ac34309b3b73163b628c2c40174ea76d58d4eb769172611e5c42f9a0cefe5f",
             identity.inboxPublicKey.toHex(),
         )
         assertEquals(
-            "2257fa71222dcc05",
+            "f462ae97384bd242",
             identity.inboxTag,
         )
     }


### PR DESCRIPTION
## Summary

- Updates the 6 expected hex values in `IdentityRepositoryTest.derivation_matchesCrossPlatformFixture` to match the post-rebrand HKDF salts (`app.onym.bip39` / `app.onym.ios`) — the JVM `CrossPlatformFixtureTest` was already synced in #137; the instrumented variant was missed.
- Pulls the canonical values from `onym-ios` `Tests/OnymIOSTests/IdentityRepositoryTests.swift:70-93` so Android and iOS stay byte-for-byte aligned.

## Why

Release CI on main ([run 25942787848](https://github.com/onymchat/onym-android/actions/runs/25942787848/job/76264140600)) failed with:
```
org.junit.ComparisonFailure: expected:<[1ee9632e…]> but was:<[d8631b8e…]>
```
The "actual" `d8631b8e…` produced by the emulator matches iOS exactly — Android production behavior is correct, the test fixture was stale.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "app.onym.android.identity.*"` — green locally
- [ ] CI: `UI + instrumented tests on emulator` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)