### PR TITLE
feat(chats): ChatMessagePayload wire type (PR 1/3 chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatMessagePayload.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMessagePayload.kt
@@ -1,0 +1,214 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+import java.util.Locale
+import java.util.UUID
+
+/**
+ * Plaintext chat-message payload that gets sealed (X25519 + AES-GCM
+ * via `IdentityRepository.sealInvitation`) and dropped on
+ * `InboxTransport.send` for each group member — same envelope path
+ * as `GroupInvitationPayload`. One envelope per recipient inbox
+ * key; the encrypted bytes carry this struct verbatim.
+ *
+ * [variant] is governance-keyed because each group flavour signs and
+ * routes messages differently down the road: Tyranny only needs the
+ * body, but a 1-on-1 dialog will carry per-message ratchet state and
+ * Anarchy will carry a per-member signature. Today only
+ * [ChatMessageVariant.Tyranny] ships — adding a new case is the
+ * entire surface-area cost of turning a new governance type on for
+ * chat.
+ *
+ * Versioned for forward compat. `version = 1` is the only shape the
+ * receiver has to handle today; later versions can add fields with
+ * non-failing `decodeIfPresent`-style decoders.
+ *
+ * Mirrors `ChatMessagePayload.swift` from onym-ios PR #147.
+ */
+@Serializable
+data class ChatMessagePayload(
+    /** Wire schema version. Bump on a breaking field change (rename,
+     *  removal, semantic shift). Adding optional fields does NOT
+     *  require a bump. */
+    val version: Int,
+    /**
+     * Stable per-message identifier used for receive-side dedup —
+     * the same Nostr inbox event can be re-delivered, and a single
+     * message fans out as N sealed envelopes (one per recipient),
+     * so the inbox-event ID is not enough.
+     *
+     * Wire encoding is the uppercase 36-char canonical UUID string
+     * (`"00000000-0000-0000-0000-000000000000"`), matching iOS
+     * `JSONEncoder`'s default `UUID` encoding. Decoders accept any
+     * case; encoders always emit uppercase.
+     */
+    @SerialName("message_id")
+    @Serializable(with = UuidStringSerializer::class)
+    val messageId: UUID,
+    /** The group this message belongs to. Receiver looks up the
+     *  [app.onym.android.group.ChatGroup] by this 32-byte id and
+     *  rejects the message if no such group exists locally. */
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    /**
+     * Lowercase BLS pubkey hex (96 chars) of the sender. Keying
+     * matches [app.onym.android.group.ChatGroup.memberProfiles] so
+     * the receiver can verify the sender is a known member with one
+     * dictionary lookup. Sender identity has to live *inside* the
+     * encrypted payload — the sealed envelope's ephemeral key tells
+     * the receiver nothing about who sent it.
+     */
+    @SerialName("sender_bls_pubkey_hex")
+    val senderBlsPubkeyHex: String,
+    /** Milliseconds since Unix epoch at send time. `Long` (not a
+     *  date type) so the wire format is unambiguous and
+     *  cross-platform. */
+    @SerialName("sent_at_millis")
+    val sentAtMillis: Long,
+    val variant: ChatMessageVariant,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ChatMessagePayload) return false
+        return version == other.version &&
+            messageId == other.messageId &&
+            groupId.contentEquals(other.groupId) &&
+            senderBlsPubkeyHex == other.senderBlsPubkeyHex &&
+            sentAtMillis == other.sentAtMillis &&
+            variant == other.variant
+    }
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + messageId.hashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + senderBlsPubkeyHex.hashCode()
+        h = 31 * h + sentAtMillis.hashCode()
+        h = 31 * h + variant.hashCode()
+        return h
+    }
+}
+
+/**
+ * Governance-keyed body. The discriminator string on the wire is
+ * [SepGroupType.wireValue] so a single spelling identifies the
+ * flavour across iOS, Android, the relayer, and the Stellar
+ * contracts.
+ *
+ * Today only [Tyranny] carries a real case. Unknown / unsupported
+ * kinds throw on decode — the chat-receive dispatcher catches and
+ * drops, which is what we want: a 1-on-1 message arriving at a v1
+ * receiver should be ignored, not silently shoehorned into a Tyranny
+ * shape.
+ *
+ * Wire shape is a flat object: `{"kind": "tyranny", "body": "..."}`
+ * — not a nested kotlinx-polymorphic envelope. See
+ * [ChatMessageVariantSerializer].
+ */
+@Serializable(with = ChatMessageVariantSerializer::class)
+sealed interface ChatMessageVariant {
+    /** Plaintext message body. Every variant ships a body string;
+     *  future variants may carry additional fields alongside it. */
+    val body: String
+
+    data class Tyranny(override val body: String) : ChatMessageVariant
+}
+
+/**
+ * Hand-written serializer for [ChatMessageVariant]. The wire shape
+ * is the iOS twin's flat `{"kind": "<SepGroupType.wireValue>",
+ * "body": "..."}` object — kotlinx's polymorphic sealed-class
+ * machinery would either nest under a `type` envelope or silently
+ * route an unknown kind through a fallback, neither of which match
+ * the iOS behavior. We want unknown / unsupported kinds to *throw*
+ * so the dispatcher can catch+drop explicitly.
+ */
+object ChatMessageVariantSerializer : KSerializer<ChatMessageVariant> {
+    private const val KIND_KEY = "kind"
+    private const val BODY_KEY = "body"
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("ChatMessageVariant") {
+            element<String>(KIND_KEY)
+            element<String>(BODY_KEY)
+        }
+
+    override fun serialize(encoder: Encoder, value: ChatMessageVariant) {
+        encoder.encodeStructure(descriptor) {
+            when (value) {
+                is ChatMessageVariant.Tyranny -> {
+                    encodeStringElement(descriptor, 0, SepGroupType.TYRANNY.wireValue)
+                    encodeStringElement(descriptor, 1, value.body)
+                }
+            }
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ChatMessageVariant {
+        return decoder.decodeStructure(descriptor) {
+            var kindRaw: String? = null
+            var body: String? = null
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    CompositeDecoder.DECODE_DONE -> break
+                    0 -> kindRaw = decodeStringElement(descriptor, 0)
+                    1 -> body = decodeStringElement(descriptor, 1)
+                    else -> throw SerializationException("Unexpected element index $index")
+                }
+            }
+            val raw = kindRaw
+                ?: throw SerializationException("Missing required field '$KIND_KEY'")
+            val kind = SepGroupType.fromWire(raw)
+                ?: throw SerializationException("Unknown chat-message kind '$raw'")
+            when (kind) {
+                SepGroupType.TYRANNY -> {
+                    val resolvedBody = body
+                        ?: throw SerializationException("Missing required field '$BODY_KEY'")
+                    ChatMessageVariant.Tyranny(body = resolvedBody)
+                }
+                SepGroupType.ONE_ON_ONE,
+                SepGroupType.ANARCHY,
+                SepGroupType.DEMOCRACY,
+                SepGroupType.OLIGARCHY ->
+                    throw SerializationException(
+                        "Chat-message variant '$raw' is not yet supported",
+                    )
+            }
+        }
+    }
+}
+
+/**
+ * Encodes [UUID] as the uppercase 36-char canonical string
+ * (`"00000000-0000-0000-0000-000000000000"`). Matches iOS
+ * `JSONEncoder`'s default `UUID` encoding (which calls
+ * `UUID.uuidString`, an uppercase form). Decoders accept any case
+ * via [UUID.fromString].
+ */
+object UuidStringSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("UuidString", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        encoder.encodeString(value.toString().uppercase(Locale.ROOT))
+    }
+
+    override fun deserialize(decoder: Decoder): UUID =
+        UUID.fromString(decoder.decodeString())
+}

--- a/app/src/test/kotlin/app/onym/android/chats/ChatMessagePayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatMessagePayloadTest.kt
@@ -1,0 +1,225 @@
+package app.onym.android.chats
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.util.Base64
+import java.util.UUID
+
+/**
+ * Wire-format pin for [ChatMessagePayload]. Mirrors
+ * `ChatMessagePayloadTests.swift` from onym-ios PR #147 — the byte
+ * sequences these tests assert on must round-trip with the iOS
+ * encoder/decoder unchanged.
+ */
+class ChatMessagePayloadTest {
+
+    private val strictJson = Json { encodeDefaults = true }
+
+    // ─── round-trip ───────────────────────────────────────────────
+
+    @Test
+    fun roundtrip_ascii_body_preservesAllFields() {
+        val original = samplePayload(body = "hello")
+        val encoded = strictJson.encodeToString(ChatMessagePayload.serializer(), original)
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun roundtrip_empty_body_preservesAllFields() {
+        val original = samplePayload(body = "")
+        val encoded = strictJson.encodeToString(ChatMessagePayload.serializer(), original)
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertEquals("", (decoded.variant as ChatMessageVariant.Tyranny).body)
+    }
+
+    @Test
+    fun roundtrip_unicode_body_preservesAllFields() {
+        val original = samplePayload(body = "héllo 🌍 ñ 中文")
+        val encoded = strictJson.encodeToString(ChatMessagePayload.serializer(), original)
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertEquals("héllo 🌍 ñ 中文", (decoded.variant as ChatMessageVariant.Tyranny).body)
+    }
+
+    // ─── wire-format pin ──────────────────────────────────────────
+
+    @Test
+    fun wireFormat_pinsTopLevelKeysAndDiscriminator() {
+        val groupIdBytes = ByteArray(32) { 0x11 }
+        val original = ChatMessagePayload(
+            version = 1,
+            messageId = UUID.fromString("00112233-4455-6677-8899-AABBCCDDEEFF"),
+            groupId = groupIdBytes,
+            senderBlsPubkeyHex = "ab".repeat(48),
+            sentAtMillis = 1_700_000_000_000L,
+            variant = ChatMessageVariant.Tyranny(body = "hi"),
+        )
+
+        val encoded = strictJson.encodeToString(ChatMessagePayload.serializer(), original)
+        val root = strictJson.parseToJsonElement(encoded).jsonObject
+
+        // Top-level keys are pinned snake_case (load-bearing for cross-platform).
+        assertTrue("must have 'version' key", root.containsKey("version"))
+        assertTrue("must have 'message_id' key", root.containsKey("message_id"))
+        assertTrue("must have 'group_id' key", root.containsKey("group_id"))
+        assertTrue(
+            "must have 'sender_bls_pubkey_hex' key",
+            root.containsKey("sender_bls_pubkey_hex"),
+        )
+        assertTrue("must have 'sent_at_millis' key", root.containsKey("sent_at_millis"))
+        assertTrue("must have 'variant' key", root.containsKey("variant"))
+
+        assertEquals(1, root["version"]!!.jsonPrimitive.content.toInt())
+        assertEquals(
+            "UUID must wire as uppercase canonical string (iOS UUID.uuidString)",
+            "00112233-4455-6677-8899-AABBCCDDEEFF",
+            root["message_id"]!!.jsonPrimitive.content,
+        )
+        // group_id is base64 of 32 bytes of 0x11.
+        val groupIdB64 = root["group_id"]!!.jsonPrimitive.content
+        assertArrayEquals(groupIdBytes, Base64.getDecoder().decode(groupIdB64))
+        assertEquals("ab".repeat(48), root["sender_bls_pubkey_hex"]!!.jsonPrimitive.content)
+        assertEquals(1_700_000_000_000L, root["sent_at_millis"]!!.jsonPrimitive.content.toLong())
+
+        val variant = root["variant"]!!.jsonObject
+        assertEquals(
+            "discriminator field is 'kind'",
+            "tyranny",
+            variant["kind"]!!.jsonPrimitive.content,
+        )
+        assertEquals("hi", variant["body"]!!.jsonPrimitive.content)
+    }
+
+    // ─── decode rejection paths ───────────────────────────────────
+
+    @Test
+    fun decode_rejectsUnknownKind() {
+        val json = """
+            {
+              "version": 1,
+              "message_id": "00000000-0000-0000-0000-000000000000",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "kind": "jellyfish", "body": "x" }
+            }
+        """.trimIndent()
+        try {
+            strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+            fail("expected SerializationException for unknown kind")
+        } catch (e: SerializationException) {
+            assertTrue(
+                "message should mention the unknown kind, got: ${e.message}",
+                e.message?.contains("jellyfish") == true,
+            )
+        }
+    }
+
+    @Test
+    fun decode_rejectsKnownButUnsupportedKind() {
+        val json = """
+            {
+              "version": 1,
+              "message_id": "00000000-0000-0000-0000-000000000000",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "kind": "oneonone", "body": "x" }
+            }
+        """.trimIndent()
+        try {
+            strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+            fail("expected SerializationException for unsupported kind")
+        } catch (e: SerializationException) {
+            assertTrue(
+                "message should mention 'not yet supported', got: ${e.message}",
+                e.message?.contains("not yet supported") == true,
+            )
+        }
+    }
+
+    @Test
+    fun decode_rejectsMissingBody() {
+        val json = """
+            {
+              "version": 1,
+              "message_id": "00000000-0000-0000-0000-000000000000",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "kind": "tyranny" }
+            }
+        """.trimIndent()
+        try {
+            strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+            fail("expected SerializationException for missing body")
+        } catch (_: SerializationException) {
+            // ok
+        }
+    }
+
+    @Test
+    fun decode_rejectsMissingKind() {
+        val json = """
+            {
+              "version": 1,
+              "message_id": "00000000-0000-0000-0000-000000000000",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "body": "x" }
+            }
+        """.trimIndent()
+        try {
+            strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+            fail("expected SerializationException for missing kind")
+        } catch (_: SerializationException) {
+            // ok
+        }
+    }
+
+    // ─── forward compat ───────────────────────────────────────────
+
+    @Test
+    fun decode_ignoresUnknownTopLevelFields_whenPermissive() {
+        // Older receivers running against a future schema must still
+        // decode v1 messages even if new optional fields appear.
+        val lenient = Json { ignoreUnknownKeys = true }
+        val json = """
+            {
+              "version": 1,
+              "message_id": "00000000-0000-0000-0000-000000000000",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "kind": "tyranny", "body": "x" },
+              "future_field": "ignored"
+            }
+        """.trimIndent()
+        val decoded = lenient.decodeFromString(ChatMessagePayload.serializer(), json)
+        assertEquals("x", (decoded.variant as ChatMessageVariant.Tyranny).body)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun samplePayload(body: String): ChatMessagePayload = ChatMessagePayload(
+        version = 1,
+        messageId = UUID.fromString("12345678-1234-1234-1234-123456789ABC"),
+        groupId = ByteArray(32) { (it * 7).toByte() },
+        senderBlsPubkeyHex = "ab".repeat(48),
+        sentAtMillis = 1_700_000_000_000L,
+        variant = ChatMessageVariant.Tyranny(body = body),
+    )
+
+    private fun b64ZeroBytes(n: Int): String =
+        Base64.getEncoder().encodeToString(ByteArray(n))
+}


### PR DESCRIPTION
First PR in the Android chat stack. Adds the plaintext wire-format payload that future PRs will encrypt + transmit. **No wiring yet** — pure data type plus tests. Mirrors [onym-ios PR #147](https://github.com/onymchat/onym-ios/pull/147).

## What's in here

- `ChatMessagePayload` (`@Serializable` data class): `version`, `messageId` (UUID for dedup), `groupId` (32-byte), `senderBlsPubkeyHex` (matches `ChatGroup.memberProfiles` keying), `sentAtMillis` (Long for cross-platform clarity), `variant`.
- `ChatMessageVariant` sealed interface, governance-keyed:
  - Only `Tyranny(body: String)` ships today.
  - Discriminator on the wire is `SepGroupType.wireValue` (`"tyranny"`, `"oneonone"`, `"anarchy"`, …) — same spelling the relayer, Stellar contracts, and iOS twin already use, so future kinds slot in with no rename.
  - Unknown / known-but-unsupported kinds throw on decode (so PR A4's dispatcher will catch+drop rather than silently coerce).
- Hand-written `ChatMessageVariantSerializer` — kotlinx's polymorphic sealed-class machinery would either nest under a `type` envelope or silently route unknown kinds through a fallback, neither of which match the iOS wire shape.
- `UuidStringSerializer` — pins UUID to iOS's uppercase 36-char `UUID.uuidString` form so byte-for-byte round-trip with iOS holds.
- 9 tests covering: round-trip (ASCII / empty / unicode), wire-format pinning (snake_case keys, discriminator value `"kind":"tyranny"`, UUID uppercase, base64 `group_id`), decode failures (unknown kind, unsupported kind, missing required field, missing kind), forward-compat (extra top-level fields ignored when lenient).

## Why a governance-keyed variant in PR A1

1-on-1 will need per-message ratchet state and Anarchy will need a per-member signature. Baking the variant shape in now means turning a new governance type on for chat is just one new sealed-interface case — no schema migration.

## Divergence from iOS

- **`enum` with associated values → `sealed interface` with data-class cases.** Kotlin's idiomatic shape for the same algebraic-data-type pattern. `body` is exposed as an abstract property so future variants can share the accessor.
- **`extension ChatMessageVariant: Codable` → hand-written `KSerializer`.** Same reason iOS wrote a manual `init(from:)` — the polymorphic envelope shapes that come for free don't match the flat `{"kind":"…","body":"…"}` wire pin and would silently swallow unknown kinds.
- **`UUID` Codable default → `UuidStringSerializer`.** kotlinx-serialization has no built-in `java.util.UUID` serializer; iOS encodes UUID as uppercase via `JSONEncoder.dataEncodingStrategy` defaults, so we mirror that exactly.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests 'app.onym.android.chats.ChatMessagePayloadTest'` — 9/9 pass
- [x] Full `:app:testDebugUnitTest` suite — 441/441 pass, 0 failures, 0 errors, 0 regressions

## Plan context

PR 1 of 3 in the Android chat-stack prefix that mirrors the iOS PRs 1–3 of their 10-PR chain ending in two users in a Tyranny group exchanging plain text. Next PRs:
- **PR A2** ([onym-ios #148](https://github.com/onymchat/onym-ios/pull/148)): persistence layer (`PersistedMessage` + `MessageRepository`)
- **PR A3** ([onym-ios #149](https://github.com/onymchat/onym-ios/pull/149)): plumb `sendingPubkey` through `MemberProfile` so PR A4's dispatcher can verify envelope signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)