### PR TITLE
feat(chats): message persistence layer (PR 2/3 chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatMessage.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMessage.kt
@@ -1,0 +1,46 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import java.util.UUID
+
+/**
+ * Domain shape of one chat message, as the Android app understands
+ * it. Mirrors `ChatMessage.swift` from onym-ios PR #148.
+ *
+ * Two kinds of fields:
+ *  - **Identifying / queryable** ([id], [groupId], [ownerIdentityId],
+ *    [sentAtMillis], [direction], [status], [groupType]) stay plain
+ *    on disk so the DAO can sort and filter without round-tripping
+ *    through the encryption boundary.
+ *  - **Sensitive** ([senderBlsPubkeyHex], [body]) ride encrypted —
+ *    see [PersistedMessage] for the column split.
+ *
+ * [direction] is the local-view distinction (incoming = received
+ * from someone else, outgoing = sent by this device); [status] is
+ * the lifecycle stage (pending → sent / failed, or received). Kept
+ * separate so a `PENDING / OUTGOING` row can survive a relaunch
+ * during a send.
+ */
+data class ChatMessage(
+    /** Stable per-message id. Matches
+     *  [ChatMessagePayload.messageId] on the wire so the receiver
+     *  can dedup re-deliveries. */
+    val id: UUID,
+    /** 64-char lowercase hex of the 32-byte group ID. Matches
+     *  [app.onym.android.group.ChatGroup.id]. */
+    val groupId: String,
+    /** [app.onym.android.identity.IdentityId.value]. Drives the
+     *  per-identity filter on [MessageRepository.snapshots]. */
+    val ownerIdentityId: String,
+    /** 96-char lowercase BLS pubkey hex. Matches
+     *  [app.onym.android.group.ChatGroup.memberProfiles] keying so
+     *  the chat screen can look up the sender's alias with one
+     *  dictionary read. */
+    val senderBlsPubkeyHex: String,
+    val body: String,
+    /** Milliseconds since Unix epoch. */
+    val sentAtMillis: Long,
+    val direction: MessageDirection,
+    val status: MessageStatus,
+    val groupType: SepGroupType,
+)

--- a/app/src/main/kotlin/app/onym/android/chats/MessageDao.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageDao.kt
@@ -1,0 +1,66 @@
+package app.onym.android.chats
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+/**
+ * Room DAO over [PersistedMessage]. Mirrors the verb set the chat
+ * surface needs: per-(owner, group) list for the chat thread,
+ * insert, status update on the hot path, plus the cascade-delete
+ * variants for identity removal and group deletion.
+ *
+ * Suspend throughout; Room's default single-threaded executor
+ * handles the volume (messages arrive at human typing / receive
+ * speed).
+ *
+ * Mirrors the SwiftData fetch / save calls in
+ * `SwiftDataMessageStore` from onym-ios PR #148.
+ */
+@Dao
+interface MessageDao {
+
+    /** Chat-thread read: per identity, per group, oldest first.
+     *  The composite (owner, group) filter rides on the two
+     *  separate indices defined in [PersistedMessage] — Room picks
+     *  one and post-filters; the volumes don't justify a composite
+     *  index yet. */
+    @Query(
+        "SELECT * FROM messages " +
+            "WHERE ownerIdentityId = :ownerIdentityId AND groupId = :groupId " +
+            "ORDER BY sentAt ASC",
+    )
+    suspend fun listForOwnerAndGroup(
+        ownerIdentityId: String,
+        groupId: String,
+    ): List<PersistedMessage>
+
+    @Query("SELECT * FROM messages WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): PersistedMessage?
+
+    /** Pure insert. Throws on PK conflict — the store's caller has
+     *  already routed through dedup (the [PersistedMessage.id] is
+     *  the wire-stable message UUID, so re-delivery must be filtered
+     *  upstream of this DAO). */
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(record: PersistedMessage)
+
+    /** Hot path: flip `PENDING` → `SENT` / `FAILED` (or any other
+     *  status transition) without re-encrypting the body. Skipping
+     *  the encryption round-trip matters because send-confirmation
+     *  callbacks fire on every relay ACK. Returns the row count. */
+    @Query("UPDATE messages SET statusRaw = :statusRaw WHERE id = :id")
+    suspend fun updateStatus(id: String, statusRaw: String): Int
+
+    /** Cascade delete for the identity-removal flow. Returns the
+     *  number of rows deleted so the caller can log cleanup size. */
+    @Query("DELETE FROM messages WHERE ownerIdentityId = :ownerIdentityId")
+    suspend fun deleteForOwner(ownerIdentityId: String): Int
+
+    /** Cascade delete for the group-deletion flow (a user nukes a
+     *  group → its messages go with it). Returns the number of rows
+     *  deleted. */
+    @Query("DELETE FROM messages WHERE groupId = :groupId")
+    suspend fun deleteForGroup(groupId: String): Int
+}

--- a/app/src/main/kotlin/app/onym/android/chats/MessageDatabase.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageDatabase.kt
@@ -1,0 +1,31 @@
+package app.onym.android.chats
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * Room database housing [PersistedMessage]. **Separate database
+ * (and separate `.db` file) from
+ * [app.onym.android.group.GroupDatabase]** so a schema bump in
+ * either domain doesn't force a wipe of the other — same rationale
+ * the `GroupDatabase` doc-comment calls out:
+ *
+ * > each persistence domain (invitations, groups, messages later)
+ * > gets its own `@Database` so migrations stay scoped per-domain
+ * > and the version number doesn't accumulate the `version = 17`
+ * > rebase pain the stellar-mls reference impl suffers from.
+ *
+ * Production wiring (when it lands in a later PR): use database
+ * name `"app.onym.android.messages"`.
+ *
+ * Mirrors the SwiftData `ModelContainer([PersistedMessage.self])`
+ * that `SwiftDataMessageStore` constructs in onym-ios PR #148.
+ */
+@Database(
+    entities = [PersistedMessage::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class MessageDatabase : RoomDatabase() {
+    abstract fun messageDao(): MessageDao
+}

--- a/app/src/main/kotlin/app/onym/android/chats/MessageDirection.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageDirection.kt
@@ -1,0 +1,9 @@
+package app.onym.android.chats
+
+/**
+ * Local-view direction of a chat message. Persisted as the enum
+ * name on disk (`INCOMING` / `OUTGOING`); not on the wire.
+ *
+ * Mirrors `MessageDirection.swift` from onym-ios PR #148.
+ */
+enum class MessageDirection { INCOMING, OUTGOING }

--- a/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
@@ -1,0 +1,172 @@
+package app.onym.android.chats
+
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.IdentityId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+
+/**
+ * Owns the per-group view of chat messages and the corresponding
+ * writes to the persistence seam. Compose / view-models subscribe
+ * to one group's [snapshots] flow and re-render on every emission.
+ *
+ * **Per-group lazy cache.** Unlike
+ * [app.onym.android.group.GroupRepository] (which loads the entire
+ * groups list into one [StateFlow] at start time), messages are
+ * read on demand — the chat thread UI subscribes to one group at a
+ * time, so hydrating the full table at launch would be wasted I/O.
+ * The first [snapshots] call for a `groupId` hits the store; later
+ * calls share the cached flow.
+ *
+ * Cascade semantics:
+ *  - **Identity removal** ([IdentityRepository.registerRemovalListener])
+ *    deletes rows for that owner from the store and refreshes every
+ *    cached group (drop the per-group flow's contents to empty
+ *    *if and only if* the active identity matches; other-identity
+ *    rows in the same group are not modified here).
+ *  - **Group deletion** ([removeForGroup]) drops the cached flow for
+ *    that group after deleting from the store.
+ *  - **Identity switch** wipes the in-memory cache entirely; the
+ *    new identity's groups refill on demand.
+ *
+ * iOS uses `actor MessageRepository`; Android uses `Mutex +
+ * StateFlow` so Compose can `collectAsStateWithLifecycle()` the
+ * per-group stream directly without per-view ceremony. Same per-
+ * group lazy-cache semantics as iOS PR #148.
+ *
+ * Mirrors `MessageRepository.swift` from onym-ios PR #148.
+ */
+class MessageRepository(
+    private val store: MessageStore,
+    private val identity: ActiveIdentityProvider,
+    /** Scope owning the active-identity collector. Pass an
+     *  `applicationScope` (SupervisorJob + Dispatchers.IO). */
+    private val scope: CoroutineScope,
+) {
+    private val mutex = Mutex()
+    private val perGroup = mutableMapOf<String, MutableStateFlow<List<ChatMessage>>>()
+
+    init {
+        identity.registerRemovalListener { id ->
+            mutex.withLock { handleOwnerRemovalLocked(id) }
+        }
+    }
+
+    /**
+     * Start observing the active-identity flow. Idempotent — safe
+     * to call from `onCreate`. On every identity change (including
+     * → null), wipes the cached per-group flows. The new identity's
+     * groups refill on demand.
+     */
+    fun start() {
+        scope.launch {
+            identity.currentIdentityId.collectLatest {
+                mutex.withLock { perGroup.clear() }
+            }
+        }
+    }
+
+    /**
+     * Hot per-group stream. First call for a `groupId` hydrates
+     * from the store under the currently-active identity; later
+     * calls return the cached flow (multiple subscribers share one).
+     * If no identity is selected, the returned flow stays empty
+     * and emits the group's rows once an identity is selected and
+     * [snapshots] is re-requested.
+     */
+    suspend fun snapshots(groupId: String): StateFlow<List<ChatMessage>> = mutex.withLock {
+        val cached = perGroup[groupId]
+        if (cached != null) return@withLock cached.asStateFlow()
+        val flow = MutableStateFlow<List<ChatMessage>>(emptyList())
+        perGroup[groupId] = flow
+        val ownerId = identity.currentIdentityId.value
+        if (ownerId != null) {
+            flow.value = store.listForGroup(ownerId.value, groupId)
+        }
+        flow.asStateFlow()
+    }
+
+    /**
+     * Persist [message] and emit on the corresponding group's
+     * cached flow. No-op (other than the store write) if no
+     * subscriber has ever opened [snapshots] for this group.
+     */
+    suspend fun append(message: ChatMessage) = mutex.withLock {
+        store.insert(message)
+        refreshGroupLocked(message.ownerIdentityId, message.groupId)
+    }
+
+    /**
+     * Flip a single message's [MessageStatus]. Sweeps every cached
+     * group's flow for the matching id and updates in place — chat
+     * status callbacks land on the outgoing pipeline without
+     * needing to know the source group.
+     */
+    suspend fun updateStatus(id: UUID, status: MessageStatus) = mutex.withLock {
+        store.updateStatus(id, status)
+        for ((_, flow) in perGroup) {
+            val current = flow.value
+            val replaced = current.map { if (it.id == id) it.copy(status = status) else it }
+            // Only emit when a row actually changed — avoids spurious
+            // re-renders on groups that didn't contain the id.
+            if (replaced !== current && replaced != current) {
+                flow.value = replaced
+            }
+        }
+    }
+
+    /**
+     * Cascade entry point for identity removal. The store is
+     * already wiped by [registerRemovalListener]'s closure; this
+     * method just refreshes every cached group so subscribers see
+     * the updated state immediately.
+     */
+    suspend fun removeForOwner(ownerId: String) = mutex.withLock {
+        store.deleteForOwner(ownerId)
+        // Refresh every cached group under the currently-active
+        // identity. Other-identity flows (if any are cached) are
+        // unaffected — their rows in the store weren't touched.
+        val activeOwnerId = identity.currentIdentityId.value?.value
+        for ((groupId, _) in perGroup) {
+            refreshGroupLocked(activeOwnerId, groupId)
+        }
+    }
+
+    /**
+     * Cascade entry point for group deletion. Drops the store rows
+     * and removes the cached flow.
+     */
+    suspend fun removeForGroup(groupId: String) = mutex.withLock {
+        store.deleteForGroup(groupId)
+        perGroup.remove(groupId)?.also { it.value = emptyList() }
+    }
+
+    // ─── private ──────────────────────────────────────────────────
+
+    private suspend fun handleOwnerRemovalLocked(id: IdentityId) {
+        store.deleteForOwner(id.value)
+        // Don't wipe perGroup wholesale — other-identity rows in
+        // the same group must survive. Refresh under the
+        // currently-active identity instead.
+        val activeOwnerId = identity.currentIdentityId.value?.value
+        for ((groupId, _) in perGroup) {
+            refreshGroupLocked(activeOwnerId, groupId)
+        }
+    }
+
+    private suspend fun refreshGroupLocked(ownerId: String?, groupId: String) {
+        val flow = perGroup[groupId] ?: return
+        flow.value = if (ownerId == null) {
+            emptyList()
+        } else {
+            store.listForGroup(ownerId, groupId)
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/MessageStatus.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageStatus.kt
@@ -1,0 +1,14 @@
+package app.onym.android.chats
+
+/**
+ * Lifecycle stage of a chat message on the local device:
+ *  - [PENDING] — outgoing, queued, not yet acknowledged by any
+ *    relay.
+ *  - [SENT] — outgoing, at least one relay accepted.
+ *  - [FAILED] — outgoing, every relay rejected (or the seal step
+ *    threw). Retry path lives outside this enum.
+ *  - [RECEIVED] — incoming, decrypted and persisted locally.
+ *
+ * Mirrors `MessageStatus.swift` from onym-ios PR #148.
+ */
+enum class MessageStatus { PENDING, SENT, FAILED, RECEIVED }

--- a/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
@@ -1,0 +1,39 @@
+package app.onym.android.chats
+
+import java.util.UUID
+
+/**
+ * Persistence seam for chat messages. Async surface mirrors
+ * [app.onym.android.group.GroupStore] so a concrete impl can
+ * serialize writes on its own dispatcher without forcing callers
+ * onto a specific one.
+ *
+ * [ChatMessage] is the domain shape; the store is responsible for
+ * AES-GCM-wrapping the sensitive columns at the boundary.
+ *
+ * Mirrors `MessageStore` from onym-ios PR #148.
+ */
+interface MessageStore {
+
+    /** Messages for one identity in one group, oldest first. Drives
+     *  the chat-thread read path. */
+    suspend fun listForGroup(ownerIdentityId: String, groupId: String): List<ChatMessage>
+
+    /** Insert one row. Caller is responsible for upstream dedup —
+     *  the DAO throws on PK conflict because re-delivery dedup is a
+     *  dispatcher-side concern (lands in PR A4). */
+    suspend fun insert(message: ChatMessage)
+
+    /** Hot path for the outgoing send pipeline (pending → sent /
+     *  failed) — skips the encryption round-trip the full row would
+     *  require. */
+    suspend fun updateStatus(id: UUID, status: MessageStatus)
+
+    /** Cascade delete for the identity-removal flow. Returns the
+     *  number of rows deleted. */
+    suspend fun deleteForOwner(ownerIdentityId: String): Int
+
+    /** Cascade delete for the group-deletion flow. Returns the
+     *  number of rows deleted. */
+    suspend fun deleteForGroup(groupId: String): Int
+}

--- a/app/src/main/kotlin/app/onym/android/chats/PersistedMessage.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/PersistedMessage.kt
@@ -1,0 +1,77 @@
+package app.onym.android.chats
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room row shape for one chat message on disk. Splits into plain
+ * (queryable, non-identifying) and AES-GCM-encrypted (sensitive)
+ * columns — same pattern as [app.onym.android.group.PersistedGroup].
+ *
+ * Plain columns:
+ *  - [id] — UUID string. Stable per message; used for dedup +
+ *    `updateStatus` lookups.
+ *  - [groupId] — 64-char lowercase hex of the 32-byte group ID;
+ *    matches [app.onym.android.group.ChatGroup.id]. Indexed for
+ *    the per-group chat-thread query.
+ *  - [ownerIdentityId] — [app.onym.android.identity.IdentityId.value].
+ *    Indexed for the per-identity filter + cascade delete.
+ *  - [sentAt] — wall-clock ms since epoch. Plain INTEGER so the
+ *    DAO can `ORDER BY sentAt ASC` without a converter.
+ *  - [directionRaw], [statusRaw], [groupTypeRaw] — small enums
+ *    persisted as their enum-name / wireValue strings; not
+ *    user-identifying.
+ *
+ * Encrypted columns (`StorageEncryption.encrypt`):
+ *  - [encryptedSenderBlsPubkeyHex] — sender identity claim.
+ *    Decryption boundary lives in [RoomMessageStore].
+ *  - [encryptedBody] — message plaintext.
+ *
+ * Mirrors `PersistedMessage.swift` from onym-ios PR #148.
+ */
+@Entity(
+    tableName = "messages",
+    indices = [
+        Index(value = ["groupId"]),
+        Index(value = ["ownerIdentityId"]),
+    ],
+)
+data class PersistedMessage(
+    @PrimaryKey val id: String,
+    val groupId: String,
+    val ownerIdentityId: String,
+    val sentAt: Long,
+    val directionRaw: String,
+    val statusRaw: String,
+    val groupTypeRaw: String,
+    val encryptedSenderBlsPubkeyHex: ByteArray,
+    val encryptedBody: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PersistedMessage) return false
+        return id == other.id &&
+            groupId == other.groupId &&
+            ownerIdentityId == other.ownerIdentityId &&
+            sentAt == other.sentAt &&
+            directionRaw == other.directionRaw &&
+            statusRaw == other.statusRaw &&
+            groupTypeRaw == other.groupTypeRaw &&
+            encryptedSenderBlsPubkeyHex.contentEquals(other.encryptedSenderBlsPubkeyHex) &&
+            encryptedBody.contentEquals(other.encryptedBody)
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + groupId.hashCode()
+        h = 31 * h + ownerIdentityId.hashCode()
+        h = 31 * h + sentAt.hashCode()
+        h = 31 * h + directionRaw.hashCode()
+        h = 31 * h + statusRaw.hashCode()
+        h = 31 * h + groupTypeRaw.hashCode()
+        h = 31 * h + encryptedSenderBlsPubkeyHex.contentHashCode()
+        h = 31 * h + encryptedBody.contentHashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
@@ -1,0 +1,91 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.persistence.StorageEncryption
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.UUID
+
+/**
+ * [MessageStore] backed by Room + [StorageEncryption]. Wraps the
+ * sensitive columns with AES-GCM on the way in, unwraps on the way
+ * out — the encryption is invisible to callers.
+ *
+ * IO happens on [ioDispatcher]; default is [Dispatchers.IO]. Tests
+ * pass `UnconfinedTestDispatcher` or rely on
+ * `Room.allowMainThreadQueries()`.
+ *
+ * Mirrors `SwiftDataMessageStore` from onym-ios PR #148.
+ */
+class RoomMessageStore(
+    private val dao: MessageDao,
+    private val encryption: StorageEncryption,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : MessageStore {
+
+    override suspend fun listForGroup(
+        ownerIdentityId: String,
+        groupId: String,
+    ): List<ChatMessage> = withContext(ioDispatcher) {
+        dao.listForOwnerAndGroup(ownerIdentityId, groupId).mapNotNull(::decode)
+    }
+
+    override suspend fun insert(message: ChatMessage) {
+        withContext(ioDispatcher) { dao.insert(encode(message)) }
+    }
+
+    override suspend fun updateStatus(id: UUID, status: MessageStatus) {
+        withContext(ioDispatcher) { dao.updateStatus(id.toString(), status.name) }
+    }
+
+    override suspend fun deleteForOwner(ownerIdentityId: String): Int =
+        withContext(ioDispatcher) { dao.deleteForOwner(ownerIdentityId) }
+
+    override suspend fun deleteForGroup(groupId: String): Int =
+        withContext(ioDispatcher) { dao.deleteForGroup(groupId) }
+
+    // ─── encode / decode boundary ──────────────────────────────────
+
+    private fun encode(message: ChatMessage): PersistedMessage = PersistedMessage(
+        id = message.id.toString(),
+        groupId = message.groupId,
+        ownerIdentityId = message.ownerIdentityId,
+        sentAt = message.sentAtMillis,
+        directionRaw = message.direction.name,
+        statusRaw = message.status.name,
+        groupTypeRaw = message.groupType.wireValue,
+        encryptedSenderBlsPubkeyHex = encryption.encrypt(message.senderBlsPubkeyHex),
+        encryptedBody = encryption.encrypt(message.body),
+    )
+
+    /** Tolerant decode: a row whose encrypted columns fail to
+     *  decrypt or whose enum string doesn't resolve is skipped
+     *  rather than crashing the whole list read. Mirrors the
+     *  `guard let … else { return nil }` ladder in iOS's `decode`. */
+    private fun decode(row: PersistedMessage): ChatMessage? {
+        val senderHex = tryDecryptString(row.encryptedSenderBlsPubkeyHex) ?: return null
+        val body = tryDecryptString(row.encryptedBody) ?: return null
+        val direction = MessageDirection.entries.firstOrNull { it.name == row.directionRaw }
+            ?: return null
+        val status = MessageStatus.entries.firstOrNull { it.name == row.statusRaw }
+            ?: return null
+        val groupType = SepGroupType.fromWire(row.groupTypeRaw) ?: return null
+        val id = try { UUID.fromString(row.id) } catch (_: Throwable) { return null }
+        return ChatMessage(
+            id = id,
+            groupId = row.groupId,
+            ownerIdentityId = row.ownerIdentityId,
+            senderBlsPubkeyHex = senderHex,
+            body = body,
+            sentAtMillis = row.sentAt,
+            direction = direction,
+            status = status,
+            groupType = groupType,
+        )
+    }
+
+    private fun tryDecryptString(bytes: ByteArray): String? = try {
+        encryption.decryptString(bytes)
+    } catch (_: Throwable) { null }
+}

--- a/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
+++ b/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
@@ -1,0 +1,64 @@
+package app.onym.android.support
+
+import app.onym.android.chats.ChatMessage
+import app.onym.android.chats.MessageStatus
+import app.onym.android.chats.MessageStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.UUID
+
+/**
+ * Reusable in-memory [MessageStore]. Same contract as
+ * [app.onym.android.chats.RoomMessageStore] — no Room, no
+ * StorageEncryption — fast tests of [app.onym.android.chats.MessageRepository]
+ * semantics without the persistence-plumbing tax.
+ *
+ * Mirrors the test fixture pattern established by
+ * [InMemoryGroupStore] for the groups domain.
+ */
+class InMemoryMessageStore : MessageStore {
+
+    private val mutex = Mutex()
+    private val rows = LinkedHashMap<String, ChatMessage>()
+
+    suspend fun preload(messages: List<ChatMessage>) = mutex.withLock {
+        for (m in messages) rows[m.id.toString()] = m
+    }
+
+    override suspend fun listForGroup(
+        ownerIdentityId: String,
+        groupId: String,
+    ): List<ChatMessage> = mutex.withLock {
+        rows.values
+            .filter { it.ownerIdentityId == ownerIdentityId && it.groupId == groupId }
+            .sortedBy { it.sentAtMillis }
+    }
+
+    override suspend fun insert(message: ChatMessage) {
+        mutex.withLock {
+            check(!rows.containsKey(message.id.toString())) {
+                "duplicate message id ${message.id}"
+            }
+            rows[message.id.toString()] = message
+        }
+    }
+
+    override suspend fun updateStatus(id: UUID, status: MessageStatus) {
+        mutex.withLock {
+            val existing = rows[id.toString()] ?: return@withLock
+            rows[id.toString()] = existing.copy(status = status)
+        }
+    }
+
+    override suspend fun deleteForOwner(ownerIdentityId: String): Int = mutex.withLock {
+        val before = rows.size
+        rows.values.removeAll { it.ownerIdentityId == ownerIdentityId }
+        before - rows.size
+    }
+
+    override suspend fun deleteForGroup(groupId: String): Int = mutex.withLock {
+        val before = rows.size
+        rows.values.removeAll { it.groupId == groupId }
+        before - rows.size
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/chats/MessageRepositoryTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/MessageRepositoryTest.kt
@@ -1,0 +1,234 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.identity.IdentityId
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.InMemoryMessageStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Reactive-surface tests for [MessageRepository]. Backed by an
+ * in-memory [MessageStore] fake + a [FakeActiveIdentityProvider]
+ * so the Room layer doesn't pull in `Robolectric` /
+ * `StorageEncryption` here — those are [RoomMessageStoreTest]'s
+ * responsibility.
+ *
+ * Mirrors `MessageRepositoryTests.swift` from onym-ios PR #148.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageRepositoryTest {
+
+    private val aliceId = IdentityId("alice-uuid")
+    private val bobId = IdentityId("bob-uuid")
+    private val groupA = "aa".repeat(32)
+    private val groupB = "bb".repeat(32)
+
+    // ─── snapshots() lazy + initial hydration ─────────────────────
+
+    @Test
+    fun snapshots_hydratesFromStoreOnFirstCall() = runTest {
+        val store = InMemoryMessageStore()
+        val msg = makeMessage(owner = aliceId, group = groupA, body = "hi")
+        store.preload(listOf(msg))
+        val repo = makeRepo(store, active = aliceId)
+
+        val flow = repo.snapshots(groupA)
+        assertEquals(1, flow.first().size)
+        assertEquals("hi", flow.first().single().body)
+    }
+
+    @Test
+    fun snapshots_emptyWhenNoActiveIdentity() = runTest {
+        val store = InMemoryMessageStore()
+        store.preload(listOf(makeMessage(owner = aliceId, group = groupA, body = "hi")))
+        val repo = makeRepo(store, active = null)
+
+        val flow = repo.snapshots(groupA)
+        assertTrue("no active identity → empty snapshot", flow.first().isEmpty())
+    }
+
+    @Test
+    fun snapshots_secondCallSharesUnderlyingState() = runTest {
+        val store = InMemoryMessageStore()
+        store.preload(listOf(makeMessage(owner = aliceId, group = groupA, body = "hi")))
+        val repo = makeRepo(store, active = aliceId)
+
+        val a = repo.snapshots(groupA)
+        val b = repo.snapshots(groupA)
+        // .asStateFlow() returns a fresh ReadonlyStateFlow wrapper
+        // each call, so the wrappers needn't be identical — but both
+        // must observe the same underlying MutableStateFlow. Asserting
+        // post-append emissions hit BOTH proves the cache is shared.
+        repo.append(makeMessage(owner = aliceId, group = groupA, body = "second"))
+        assertEquals(2, a.first().size)
+        assertEquals(2, b.first().size)
+    }
+
+    // ─── append() ─────────────────────────────────────────────────
+
+    @Test
+    fun append_emitsOnTheGroupFlow() = runTest {
+        val store = InMemoryMessageStore()
+        val repo = makeRepo(store, active = aliceId)
+        val flow = repo.snapshots(groupA)
+        assertTrue(flow.first().isEmpty())
+
+        repo.append(makeMessage(owner = aliceId, group = groupA, body = "first"))
+
+        val snapshot = flow.first()
+        assertEquals(1, snapshot.size)
+        assertEquals("first", snapshot.single().body)
+    }
+
+    @Test
+    fun append_doesNotEmitOnUnrelatedGroupFlows() = runTest {
+        val store = InMemoryMessageStore()
+        val repo = makeRepo(store, active = aliceId)
+        val flowA = repo.snapshots(groupA)
+        val flowB = repo.snapshots(groupB)
+
+        repo.append(makeMessage(owner = aliceId, group = groupA, body = "a-msg"))
+
+        assertEquals(1, flowA.first().size)
+        assertTrue("group B subscribers see no emission", flowB.first().isEmpty())
+    }
+
+    // ─── updateStatus() ───────────────────────────────────────────
+
+    @Test
+    fun updateStatus_flipsStatusOnCachedFlow() = runTest {
+        val store = InMemoryMessageStore()
+        val msg = makeMessage(owner = aliceId, group = groupA, body = "x")
+        val repo = makeRepo(store, active = aliceId)
+        repo.append(msg)
+        val flow = repo.snapshots(groupA)
+
+        repo.updateStatus(msg.id, MessageStatus.SENT)
+        assertEquals(MessageStatus.SENT, flow.first().single().status)
+    }
+
+    @Test
+    fun updateStatus_unknownId_doesNotMutateAnyGroup() = runTest {
+        val store = InMemoryMessageStore()
+        val repo = makeRepo(store, active = aliceId)
+        val msg = makeMessage(owner = aliceId, group = groupA, body = "x")
+        repo.append(msg)
+        val before = repo.snapshots(groupA).first()
+
+        repo.updateStatus(UUID.randomUUID(), MessageStatus.SENT)
+
+        val after = repo.snapshots(groupA).first()
+        assertEquals("status of existing rows must not change", before, after)
+    }
+
+    // ─── removeForOwner cascade ───────────────────────────────────
+
+    @Test
+    fun removeForOwner_clearsCachedFlowsForActiveIdentity_butPreservesOtherIdentityRowsInStore() = runTest {
+        val store = InMemoryMessageStore()
+        // Alice + Bob both have a message in group A.
+        store.preload(listOf(
+            makeMessage(owner = aliceId, group = groupA, body = "alice-msg"),
+            makeMessage(owner = bobId, group = groupA, body = "bob-msg"),
+        ))
+        val repo = makeRepo(store, active = aliceId)
+        val flow = repo.snapshots(groupA)
+        assertEquals(1, flow.first().size)
+
+        repo.removeForOwner(aliceId.value)
+
+        // Cached flow under active Alice empties out.
+        assertTrue("alice rows are gone", flow.first().isEmpty())
+        // Bob's row in the same group survives in the store.
+        assertEquals(1, store.listForGroup(bobId.value, groupA).size)
+    }
+
+    // ─── removeForGroup cascade ───────────────────────────────────
+
+    @Test
+    fun removeForGroup_clearsThatGroupsCacheAndStoreRows() = runTest {
+        val store = InMemoryMessageStore()
+        store.preload(listOf(
+            makeMessage(owner = aliceId, group = groupA, body = "a"),
+            makeMessage(owner = aliceId, group = groupB, body = "b"),
+        ))
+        val repo = makeRepo(store, active = aliceId)
+        val flowA = repo.snapshots(groupA)
+        val flowB = repo.snapshots(groupB)
+        assertEquals(1, flowA.first().size)
+        assertEquals(1, flowB.first().size)
+
+        repo.removeForGroup(groupA)
+
+        // The cached flow for A is dropped — re-subscribing yields a
+        // fresh empty flow (different identity from the original).
+        val flowAReborn = repo.snapshots(groupA)
+        assertNotSame(flowA, flowAReborn)
+        assertTrue(flowAReborn.first().isEmpty())
+        // Group B is untouched.
+        assertEquals(1, flowB.first().size)
+    }
+
+    // ─── identity switch wipes cache ──────────────────────────────
+
+    @Test
+    fun start_identityChange_wipesCache() = runTest {
+        val store = InMemoryMessageStore()
+        store.preload(listOf(
+            makeMessage(owner = aliceId, group = groupA, body = "alice-msg"),
+            makeMessage(owner = bobId, group = groupA, body = "bob-msg"),
+        ))
+        val active = FakeActiveIdentityProvider(initial = aliceId)
+        val testScope = TestScope(UnconfinedTestDispatcher())
+        val repo = MessageRepository(store, active, testScope)
+        repo.start()
+
+        val flowAsAlice = repo.snapshots(groupA)
+        assertEquals("alice-msg", flowAsAlice.first().single().body)
+
+        active.setActive(bobId)
+        // Re-subscribing post-switch produces a fresh flow that loads
+        // Bob's rows for this group.
+        val flowAsBob = repo.snapshots(groupA)
+        assertNotSame(flowAsAlice, flowAsBob)
+        assertEquals("bob-msg", flowAsBob.first().single().body)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeRepo(
+        store: InMemoryMessageStore,
+        active: IdentityId?,
+    ): MessageRepository = MessageRepository(
+        store = store,
+        identity = FakeActiveIdentityProvider(initial = active),
+        scope = TestScope(UnconfinedTestDispatcher()),
+    )
+
+    private fun makeMessage(
+        owner: IdentityId,
+        group: String,
+        body: String,
+        sentAtMillis: Long = 1_700_000_000_000L,
+    ): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = group,
+        ownerIdentityId = owner.value,
+        senderBlsPubkeyHex = "cc".repeat(48),
+        body = body,
+        sentAtMillis = sentAtMillis,
+        direction = MessageDirection.OUTGOING,
+        status = MessageStatus.PENDING,
+        groupType = SepGroupType.TYRANNY,
+    )
+}

--- a/app/src/test/kotlin/app/onym/android/chats/RoomMessageStoreTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/RoomMessageStoreTest.kt
@@ -1,0 +1,250 @@
+package app.onym.android.chats
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.onym.android.chain.SepGroupType
+import app.onym.android.persistence.StorageEncryption
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.security.SecureRandom
+import java.util.UUID
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Round-trip tests for [RoomMessageStore]. Uses
+ * `Room.inMemoryDatabaseBuilder` so the on-disk store isn't
+ * touched. Encrypted columns go through a real [StorageEncryption]
+ * backed by a fresh AES key per test (no Robolectric Keystore
+ * dance).
+ *
+ * Mirrors `SwiftDataMessageStoreTests.swift` from onym-ios PR #148.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+class RoomMessageStoreTest {
+
+    private lateinit var db: MessageDatabase
+    private lateinit var store: RoomMessageStore
+    private lateinit var encryption: StorageEncryption
+
+    @Before
+    fun setUp() {
+        val ctx: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(ctx, MessageDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        encryption = StorageEncryption(
+            SecretKeySpec(ByteArray(32).also { SecureRandom().nextBytes(it) }, "AES"),
+        )
+        store = RoomMessageStore(db.messageDao(), encryption)
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    // ─── round-trip ───────────────────────────────────────────────
+
+    @Test
+    fun insert_thenList_roundtripsAllFields() = runTest {
+        val msg = makeMessage(body = "hello", sender = "ab".repeat(48))
+        store.insert(msg)
+
+        val listed = store.listForGroup(msg.ownerIdentityId, msg.groupId)
+        assertEquals(1, listed.size)
+        val first = listed.single()
+        assertEquals(msg.id, first.id)
+        assertEquals(msg.groupId, first.groupId)
+        assertEquals(msg.ownerIdentityId, first.ownerIdentityId)
+        assertEquals("ab".repeat(48), first.senderBlsPubkeyHex)
+        assertEquals("hello", first.body)
+        assertEquals(msg.sentAtMillis, first.sentAtMillis)
+        assertEquals(MessageDirection.OUTGOING, first.direction)
+        assertEquals(MessageStatus.PENDING, first.status)
+        assertEquals(SepGroupType.TYRANNY, first.groupType)
+    }
+
+    // ─── encryption-at-rest ───────────────────────────────────────
+
+    @Test
+    fun encryptedColumns_doNotContainPlaintext() = runTest {
+        val plaintextBody = "secret payload".toByteArray(Charsets.UTF_8)
+        val msg = makeMessage(body = "secret payload")
+        store.insert(msg)
+
+        val raw = db.messageDao().findById(msg.id.toString())!!
+        assertNotEquals(
+            "encryptedBody must not contain the plaintext body",
+            plaintextBody.toList(),
+            raw.encryptedBody.toList(),
+        )
+        // Layout sanity: nonce(12) + ciphertext("secret payload", 14 bytes) + tag(16) = 42B.
+        assertEquals(
+            StorageEncryption.NONCE_SIZE + plaintextBody.size + StorageEncryption.TAG_SIZE,
+            raw.encryptedBody.size,
+        )
+        // …and the seam decrypts it back to plaintext.
+        assertEquals("secret payload", store.listForGroup(msg.ownerIdentityId, msg.groupId).single().body)
+    }
+
+    // ─── updateStatus hot path ────────────────────────────────────
+
+    @Test
+    fun updateStatus_changesStatusWithoutTouchingEncryptedColumns() = runTest {
+        val msg = makeMessage(body = "draft")
+        store.insert(msg)
+        val originalRow = db.messageDao().findById(msg.id.toString())!!
+
+        store.updateStatus(msg.id, MessageStatus.SENT)
+
+        val updatedRow = db.messageDao().findById(msg.id.toString())!!
+        assertEquals(MessageStatus.SENT.name, updatedRow.statusRaw)
+        // Hot path skips the encryption round-trip: encryptedBody +
+        // encryptedSenderBlsPubkeyHex bytes are unchanged byte-for-byte.
+        assertEquals(originalRow.encryptedBody.toList(), updatedRow.encryptedBody.toList())
+        assertEquals(
+            originalRow.encryptedSenderBlsPubkeyHex.toList(),
+            updatedRow.encryptedSenderBlsPubkeyHex.toList(),
+        )
+        // Domain view reflects the status flip.
+        assertEquals(
+            MessageStatus.SENT,
+            store.listForGroup(msg.ownerIdentityId, msg.groupId).single().status,
+        )
+    }
+
+    @Test
+    fun updateStatus_unknownIdIsNoOp() = runTest {
+        store.updateStatus(UUID.randomUUID(), MessageStatus.SENT)
+        assertTrue(store.listForGroup("alice", "00".repeat(32)).isEmpty())
+    }
+
+    // ─── ordering ─────────────────────────────────────────────────
+
+    @Test
+    fun listForGroup_sortsBySentAtAscending() = runTest {
+        val older = makeMessage(body = "older", sentAtMillis = 1_700_000_000_000L)
+        val newer = makeMessage(body = "newer", sentAtMillis = 1_700_000_500_000L)
+        // insert in reverse so we know ordering isn't insertion-order coincidence.
+        store.insert(newer)
+        store.insert(older)
+
+        val listed = store.listForGroup(older.ownerIdentityId, older.groupId)
+        assertEquals(listOf("older", "newer"), listed.map { it.body })
+    }
+
+    // ─── per-(owner, group) filter ────────────────────────────────
+
+    @Test
+    fun listForGroup_filtersByOwnerAndGroup() = runTest {
+        val aliceGroupA = makeMessage(owner = "alice", group = "aa".repeat(32), body = "a-A")
+        val aliceGroupB = makeMessage(owner = "alice", group = "bb".repeat(32), body = "a-B")
+        val bobGroupA = makeMessage(owner = "bob", group = "aa".repeat(32), body = "b-A")
+        store.insert(aliceGroupA)
+        store.insert(aliceGroupB)
+        store.insert(bobGroupA)
+
+        val out = store.listForGroup("alice", "aa".repeat(32))
+        assertEquals(1, out.size)
+        assertEquals("a-A", out.single().body)
+    }
+
+    // ─── cascade deletes ──────────────────────────────────────────
+
+    @Test
+    fun deleteForOwner_removesEveryRowForThatOwner() = runTest {
+        val alice1 = makeMessage(owner = "alice", body = "a1")
+        val alice2 = makeMessage(owner = "alice", body = "a2")
+        val bob1 = makeMessage(owner = "bob", body = "b1")
+        store.insert(alice1)
+        store.insert(alice2)
+        store.insert(bob1)
+
+        val deleted = store.deleteForOwner("alice")
+        assertEquals(2, deleted)
+        assertTrue(store.listForGroup("alice", alice1.groupId).isEmpty())
+        assertEquals(1, store.listForGroup("bob", bob1.groupId).size)
+    }
+
+    @Test
+    fun deleteForGroup_removesEveryRowForThatGroup() = runTest {
+        val groupA = "aa".repeat(32)
+        val groupB = "bb".repeat(32)
+        store.insert(makeMessage(owner = "alice", group = groupA, body = "a-A1"))
+        store.insert(makeMessage(owner = "alice", group = groupA, body = "a-A2"))
+        store.insert(makeMessage(owner = "alice", group = groupB, body = "a-B1"))
+
+        val deleted = store.deleteForGroup(groupA)
+        assertEquals(2, deleted)
+        assertTrue(store.listForGroup("alice", groupA).isEmpty())
+        assertEquals(1, store.listForGroup("alice", groupB).size)
+    }
+
+    // ─── tolerant decode ──────────────────────────────────────────
+
+    @Test
+    fun decode_skipsRowsWithUnknownEnumValues() = runTest {
+        val good = makeMessage(body = "ok")
+        store.insert(good)
+        // Insert a row directly via the DAO with a bogus groupTypeRaw —
+        // decoder must skip it, leaving the good row.
+        val bogusRow = PersistedMessage(
+            id = UUID.randomUUID().toString(),
+            groupId = good.groupId,
+            ownerIdentityId = good.ownerIdentityId,
+            sentAt = good.sentAtMillis + 1,
+            directionRaw = MessageDirection.INCOMING.name,
+            statusRaw = MessageStatus.RECEIVED.name,
+            groupTypeRaw = "spaghetti",
+            encryptedSenderBlsPubkeyHex = encryption.encrypt("aa".repeat(48)),
+            encryptedBody = encryption.encrypt("x"),
+        )
+        db.messageDao().insert(bogusRow)
+        // Sanity: row was actually written.
+        assertNotNull(db.messageDao().findById(bogusRow.id))
+
+        val listed = store.listForGroup(good.ownerIdentityId, good.groupId)
+        assertEquals("bogus row must be filtered out", 1, listed.size)
+        assertEquals(good.id, listed.single().id)
+    }
+
+    // ─── empty case ───────────────────────────────────────────────
+
+    @Test
+    fun listForGroup_unknownGroupReturnsEmptyList() = runTest {
+        assertTrue(store.listForGroup("nobody", "ff".repeat(32)).isEmpty())
+    }
+
+    @Suppress("unused")
+    private fun assertNullOk(value: Any?) { assertNull(value) }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeMessage(
+        body: String,
+        owner: String = "test-owner",
+        group: String = "aa".repeat(32),
+        sender: String = "cc".repeat(48),
+        sentAtMillis: Long = 1_700_000_000_000L,
+    ): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = group,
+        ownerIdentityId = owner,
+        senderBlsPubkeyHex = sender,
+        body = body,
+        sentAtMillis = sentAtMillis,
+        direction = MessageDirection.OUTGOING,
+        status = MessageStatus.PENDING,
+        groupType = SepGroupType.TYRANNY,
+    )
+}


### PR DESCRIPTION
**Stacked on #141.** Second PR in the Android chat stack. Adds on-disk persistence + a per-group reactive snapshots stream for chat messages. **Mirrors `GroupStore` / `GroupRepository` exactly** so the chat thread UI (later PRs) can subscribe to one group's messages the same way `ChatsScreen` subscribes to the group list. Mirrors [onym-ios PR #148](https://github.com/onymchat/onym-ios/pull/148).

## What's in here

| File | Role |
|---|---|
| `ChatMessage` | Domain type (id, groupId, owner, sender BLS hex, body, sentAt, direction, status, groupType) |
| `MessageDirection` / `MessageStatus` | enums: `INCOMING` / `OUTGOING` ; `PENDING` / `SENT` / `FAILED` / `RECEIVED` |
| `PersistedMessage` | `@Entity`. Plain columns (id / groupId / ownerIdentityId / sentAt / direction / status / groupType) for querying + sort, indexed on `groupId` and `ownerIdentityId`; sender BLS hex and body encrypted via `StorageEncryption` |
| `MessageDao` | Room DAO with the 6 verbs the repo needs (`listForOwnerAndGroup`, `findById`, `insert`, `updateStatus`, `deleteForOwner`, `deleteForGroup`) |
| `MessageDatabase` | **Separate `@Database` + separate `.db` file** from `GroupDatabase` so a schema bump in either domain doesn't force a wipe of the other. The `GroupDatabase` doc-comment predicted this exact split: *"each persistence domain (invitations, groups, messages later) gets its own `@Database`"* |
| `MessageStore` | Async protocol seam |
| `RoomMessageStore` | Wraps encryption at the boundary, tolerant decode (skips corrupt rows), hot-path `updateStatus` skips the encryption round-trip |
| `MessageRepository` | Per-group `MutableStateFlow` cached lazily on first `snapshots(groupId)` call. Chat thread reads one group at a time, so hydrating the whole table at launch would be wasted I/O |
| `InMemoryMessageStore` (sharedTest) | Reusable fake — same pattern as `InMemoryGroupStore` |

## Design notes

- Encryption split matches `PersistedGroup`: queryable / sort columns stay plain, content is encrypted. `(groupId, ownerIdentityId)` get composite indexing via two single-column indices — volumes don't justify a composite index yet.
- `MessageRepository.removeForOwner` refreshes each cached group from the store rather than wiping in-memory — other-identity rows in the same group must survive (tested in `removeForOwner_clearsCachedFlowsForActiveIdentity_butPreservesOtherIdentityRowsInStore`).
- `updateStatus` is a hot path for the outgoing pipeline (`PENDING` → `SENT` / `FAILED`) so we don't round-trip the whole row through the encryption boundary on every relay ACK.
- Identity switch wipes the in-memory cache (via `start()`); the new identity's groups refill on demand. Mirrors the cascade semantics of `GroupRepository`.

## Divergence from iOS

- **`actor MessageRepository` → `Mutex + StateFlow`.** Compose subscribes to `StateFlow` directly via `collectAsStateWithLifecycle()` without per-view ceremony — same reason `GroupRepository` made this swap on day one.
- **`AsyncStream snapshots(groupID:)` → `StateFlow snapshots(groupId)`** backed by a `Map<String, MutableStateFlow<List<ChatMessage>>>` lazy cache. Same lazy-per-group semantics as iOS PR #148.
- **SwiftData `@Model` → Room `@Entity` + DAO**, with a separate `@Database` so the groups and messages schemas migrate independently.

## Out of scope (deferred)

- No wiring to `IncomingMessageDispatcher` or any send path — that lands in PR A4.
- No `OnymApplication` wiring (the `MessageRepository` constructor exists but is unreferenced).
- No production `MessageDatabase` builder in `OnymApplication` — same deferral.

## Test plan

- [x] `RoomMessageStoreTest` — 10 tests (roundtrip, encryption-at-rest, in-place `updateStatus` skips re-encryption, sort, per-(owner, group) filter, cascade `deleteForOwner`, cascade `deleteForGroup`, tolerant decode, empty case, `updateStatus` unknown-id no-op)
- [x] `MessageRepositoryTest` — 10 tests (initial hydration, empty-when-no-active, shared cache across subscribers, `append` emits, per-group isolation, `updateStatus` emits, `updateStatus` unknown-id no-op, cascade `removeForOwner` preserves other-identity rows, `removeForGroup` drops cache, identity switch wipes cache)
- [x] Full `:app:testDebugUnitTest` suite — **461 / 461 pass**, 0 failures, 0 errors, 0 regressions

## Plan context

PR 2 of 3 in the Android chat stack. **PR A1** (#141) added the wire-format payload. **PR A3 next** plumbs the Ed25519 sending pubkey through `MemberProfile` so PR A4's chat dispatcher can verify envelope signatures against the claimed BLS sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)