### PR TITLE
feat(chats): wire chat-message transport directions (PR 4/5 chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -310,6 +310,36 @@ class OnymApplication : Application() {
         groupRepository.start()
         applicationScope.launch { groupRepository.reload() }
 
+        // Message persistence (PR A2 + A4). Separate @Database from
+        // GroupDatabase so a schema bump in either domain doesn't
+        // force a wipe of the other — exact mirror of the
+        // GroupDatabase comment's prediction. Same in-memory fallback
+        // posture as the groups DB: a corrupt on-disk file degrades
+        // to ephemeral storage rather than refusing to launch.
+        val messageDatabase = try {
+            androidx.room.Room.databaseBuilder(
+                applicationContext,
+                app.onym.android.chats.MessageDatabase::class.java,
+                "app.onym.android.messages",
+            )
+                .fallbackToDestructiveMigration()
+                .build()
+        } catch (_: Throwable) {
+            androidx.room.Room.inMemoryDatabaseBuilder(
+                applicationContext,
+                app.onym.android.chats.MessageDatabase::class.java,
+            ).build()
+        }
+        val messageRepository = app.onym.android.chats.MessageRepository(
+            store = app.onym.android.chats.RoomMessageStore(
+                dao = messageDatabase.messageDao(),
+                encryption = storageEncryption,
+            ),
+            identity = identityRepository,
+            scope = applicationScope,
+        )
+        messageRepository.start()
+
         // App-wide network preference (PR-C follow-up). Constructed
         // here (early) so PR-89's chainStateReader can read it.
         val networkPreference = DataStoreNetworkPreferenceProvider(
@@ -385,6 +415,7 @@ class OnymApplication : Application() {
             envelopeDecrypter = identityRepository,
             groupRepository = groupRepository,
             invitationsRepository = invitationsRepository,
+            messageRepository = messageRepository,
             identitiesFlow = identityRepository.identities,
             chainState = chainStateReader,
         )

--- a/app/src/main/kotlin/app/onym/android/chats/MessageDao.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageDao.kt
@@ -39,12 +39,14 @@ interface MessageDao {
     @Query("SELECT * FROM messages WHERE id = :id LIMIT 1")
     suspend fun findById(id: String): PersistedMessage?
 
-    /** Pure insert. Throws on PK conflict — the store's caller has
-     *  already routed through dedup (the [PersistedMessage.id] is
-     *  the wire-stable message UUID, so re-delivery must be filtered
-     *  upstream of this DAO). */
-    @Insert(onConflict = OnConflictStrategy.ABORT)
-    suspend fun insert(record: PersistedMessage)
+    /** Idempotent on [PersistedMessage.id]: a re-delivery of the
+     *  same wire message is a silent no-op rather than a thrown
+     *  exception, mirroring the dispatcher's "drop duplicates"
+     *  contract. Returns the row id on insert and `-1` when the
+     *  conflict strategy ignored the write — callers expose that as
+     *  `Boolean` at the [MessageStore] seam. */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(record: PersistedMessage): Long
 
     /** Hot path: flip `PENDING` → `SENT` / `FAILED` (or any other
      *  status transition) without re-encrypting the body. Skipping

--- a/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
@@ -95,12 +95,19 @@ class MessageRepository(
 
     /**
      * Persist [message] and emit on the corresponding group's
-     * cached flow. No-op (other than the store write) if no
-     * subscriber has ever opened [snapshots] for this group.
+     * cached flow. Idempotent on [ChatMessage.id] — a re-delivery
+     * (same wire `messageId`) is a no-op: returns `false`, skips the
+     * cache refresh, no subscriber re-emission. Returns `true` on a
+     * fresh insert.
+     *
+     * Cache refresh is conditional so a duplicate-arrival storm
+     * doesn't spam every chat-thread subscriber with redundant
+     * StateFlow emissions.
      */
-    suspend fun append(message: ChatMessage) = mutex.withLock {
-        store.insert(message)
-        refreshGroupLocked(message.ownerIdentityId, message.groupId)
+    suspend fun append(message: ChatMessage): Boolean = mutex.withLock {
+        val inserted = store.insert(message)
+        if (inserted) refreshGroupLocked(message.ownerIdentityId, message.groupId)
+        inserted
     }
 
     /**

--- a/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
@@ -19,10 +19,11 @@ interface MessageStore {
      *  the chat-thread read path. */
     suspend fun listForGroup(ownerIdentityId: String, groupId: String): List<ChatMessage>
 
-    /** Insert one row. Caller is responsible for upstream dedup —
-     *  the DAO throws on PK conflict because re-delivery dedup is a
-     *  dispatcher-side concern (lands in PR A4). */
-    suspend fun insert(message: ChatMessage)
+    /** Idempotent insert on [ChatMessage.id]. Returns `true` on a
+     *  fresh write, `false` when the row already exists. Nostr
+     *  re-delivery of the same wire `messageId` becomes a no-op at
+     *  this seam — dispatchers don't need their own dedup. */
+    suspend fun insert(message: ChatMessage): Boolean
 
     /** Hot path for the outgoing send pipeline (pending → sent /
      *  failed) — skips the encryption round-trip the full row would

--- a/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
@@ -31,9 +31,11 @@ class RoomMessageStore(
         dao.listForOwnerAndGroup(ownerIdentityId, groupId).mapNotNull(::decode)
     }
 
-    override suspend fun insert(message: ChatMessage) {
-        withContext(ioDispatcher) { dao.insert(encode(message)) }
-    }
+    override suspend fun insert(message: ChatMessage): Boolean =
+        withContext(ioDispatcher) {
+            // OnConflictStrategy.IGNORE returns -1 on a PK clash.
+            dao.insert(encode(message)) != -1L
+        }
 
     override suspend fun updateStatus(id: UUID, status: MessageStatus) {
         withContext(ioDispatcher) { dao.updateStatus(id.toString(), status.name) }

--- a/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
@@ -1,0 +1,198 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.group.GroupRepository
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.IdentityRepository
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.transport.InboxTransport
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+/**
+ * Outgoing-message pipeline. Persist a `PENDING` row locally
+ * (optimistic insert so the chat thread shows the bubble
+ * immediately), seal one envelope per other group member, ship via
+ * [InboxTransport.send], then flip the status to:
+ *
+ *  - [MessageStatus.SENT] if at least one relay accepted any
+ *    envelope (or the roster is just the sender — a local-only
+ *    "note to self" sends with no recipients).
+ *  - [MessageStatus.FAILED] if every send threw or no relay
+ *    accepted.
+ *
+ * Mirrors [app.onym.android.group.CreateGroupInteractor]'s invitation
+ * send loop — same `sealInvitation` + `InboxTransport.send` per
+ * recipient, same inbox-tag derivation. Splits the optimistic insert
+ * out so the chat UI sees the bubble before the fan-out completes;
+ * the status flip is the UI's signal that the network is done.
+ *
+ * ## Dependencies
+ *
+ * Takes [ActiveIdentityProvider] + [identitiesFlow] + [envelopeSealer]
+ * instead of the concrete [IdentityRepository] so the interactor is
+ * unit-testable without standing up the real keychain. Production
+ * wiring in `OnymApplication` passes the `IdentityRepository` for
+ * all three slots (it implements [ActiveIdentityProvider] and
+ * [InvitationEnvelopeSealer] and exposes `identities` as a
+ * `StateFlow<List<IdentitySummary>>`).
+ *
+ * Mirrors `SendMessageInteractor.swift` from onym-ios PR #150.
+ */
+class SendMessageInteractor(
+    private val activeIdentity: ActiveIdentityProvider,
+    private val identitiesFlow: StateFlow<List<IdentitySummary>>,
+    private val envelopeSealer: InvitationEnvelopeSealer,
+    private val groupRepository: GroupRepository,
+    private val messageRepository: MessageRepository,
+    private val inboxTransport: InboxTransport,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val clock: () -> Long = { System.currentTimeMillis() },
+    private val idFactory: () -> UUID = { UUID.randomUUID() },
+) {
+
+    /**
+     * Run the full send pipeline. Returns the locally-persisted
+     * [ChatMessage] after the fan-out completes — its
+     * [ChatMessage.status] reflects the final outcome. Callers that
+     * want the optimistic `PENDING` view subscribe to
+     * [MessageRepository.snapshots] instead.
+     */
+    suspend fun send(groupId: String, body: String): ChatMessage = withContext(ioDispatcher) {
+        if (body.isEmpty()) throw SendMessageError.EmptyBody
+
+        val activeIdentityId = activeIdentity.currentIdentityId.value
+            ?: throw SendMessageError.NoIdentityLoaded
+        val activeSummary = identitiesFlow.value.firstOrNull { it.id == activeIdentityId }
+            ?: throw SendMessageError.NoIdentityLoaded
+        val group = groupRepository.findForOwner(activeIdentityId.value, groupId)
+            ?: throw SendMessageError.UnknownGroup
+
+        val myBlsHex = activeSummary.blsPublicKey.toHexLowercase()
+        if (group.memberProfiles[myBlsHex] == null) {
+            throw SendMessageError.SenderNotAMember
+        }
+
+        val variant: ChatMessageVariant = when (group.groupType) {
+            SepGroupType.TYRANNY -> ChatMessageVariant.Tyranny(body = body)
+            SepGroupType.ANARCHY,
+            SepGroupType.ONE_ON_ONE,
+            SepGroupType.DEMOCRACY,
+            SepGroupType.OLIGARCHY ->
+                throw SendMessageError.UnsupportedGroupType(group.groupType)
+        }
+
+        val messageId = idFactory()
+        val sentAtMillis = clock()
+        val payload = ChatMessagePayload(
+            version = 1,
+            messageId = messageId,
+            groupId = group.groupIdBytes,
+            senderBlsPubkeyHex = myBlsHex,
+            sentAtMillis = sentAtMillis,
+            variant = variant,
+        )
+
+        // Optimistic insert — UI shows the bubble immediately.
+        val pending = ChatMessage(
+            id = messageId,
+            groupId = groupId,
+            ownerIdentityId = activeIdentityId.value,
+            senderBlsPubkeyHex = myBlsHex,
+            body = body,
+            sentAtMillis = sentAtMillis,
+            direction = MessageDirection.OUTGOING,
+            status = MessageStatus.PENDING,
+            groupType = group.groupType,
+        )
+        messageRepository.append(pending)
+
+        val payloadBytes = try {
+            jsonFormat.encodeToString(ChatMessagePayload.serializer(), payload)
+                .toByteArray(Charsets.UTF_8)
+        } catch (e: Throwable) {
+            messageRepository.updateStatus(messageId, MessageStatus.FAILED)
+            throw SendMessageError.EncodingFailed(e.message ?: e.javaClass.simpleName)
+        }
+
+        // Fan out to every member's inbox except our own. Best-effort
+        // per recipient — one failed send doesn't doom the whole
+        // message; we flip to SENT if at least one relay accepted
+        // any envelope.
+        val recipients = group.memberProfiles
+            .filterKeys { it != myBlsHex }
+            .map { (_, profile) -> profile.inboxPublicKey }
+
+        var successCount = 0
+        for (inboxKey in recipients) {
+            val sealed = try {
+                envelopeSealer.sealInvitation(payloadBytes, inboxKey)
+            } catch (_: Throwable) {
+                continue
+            }
+            val tag = TransportInboxId(IdentityRepository.inboxTag(inboxKey))
+            val receipt = try {
+                inboxTransport.send(sealed, tag)
+            } catch (_: Throwable) {
+                continue
+            }
+            if (receipt.acceptedBy >= 1) successCount++
+        }
+
+        val finalStatus =
+            if (recipients.isEmpty() || successCount > 0) MessageStatus.SENT
+            else MessageStatus.FAILED
+        messageRepository.updateStatus(messageId, finalStatus)
+
+        pending.copy(status = finalStatus)
+    }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true }
+
+        fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+            for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+        }
+    }
+}
+
+/**
+ * Failure modes for [SendMessageInteractor.send]. Sealed so the UI
+ * can `when`-exhaust and surface a precise message for each kind.
+ */
+sealed class SendMessageError(message: String) : Exception(message) {
+
+    object EmptyBody : SendMessageError("Message body must not be empty") {
+        private fun readResolve(): Any = EmptyBody
+    }
+
+    object NoIdentityLoaded : SendMessageError("No identity is loaded") {
+        private fun readResolve(): Any = NoIdentityLoaded
+    }
+
+    object UnknownGroup : SendMessageError("Group not found for the active identity") {
+        private fun readResolve(): Any = UnknownGroup
+    }
+
+    /** Active identity isn't in the group's `memberProfiles`. Fires
+     *  when the creator's own profile was never recorded (shouldn't
+     *  happen post-PR A3) or when the active identity switched
+     *  mid-flight. */
+    object SenderNotAMember : SendMessageError("Active identity is not a member of this group") {
+        private fun readResolve(): Any = SenderNotAMember
+    }
+
+    /** Today only the Tyranny variant ships; other governance types
+     *  surface as this until their variant cases come online. */
+    class UnsupportedGroupType(val type: SepGroupType) :
+        SendMessageError("$type chat isn't supported yet")
+
+    class EncodingFailed(reason: String) :
+        SendMessageError("Couldn't encode chat-message payload: $reason")
+}

--- a/app/src/main/kotlin/app/onym/android/group/GroupRepository.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupRepository.kt
@@ -114,6 +114,20 @@ class GroupRepository(
         refreshLocked(identity.currentIdentityId.value)
     }
 
+    /**
+     * Cross-identity lookup. Returns the [ChatGroup] owned by
+     * [ownerIdentityId] with hex [groupId] (matched against
+     * [ChatGroup.id]), or `null` if no such row exists. Reads
+     * directly from the store — bypasses the active-identity filter
+     * on [snapshots] so an inbox dispatcher can route an incoming
+     * payload to the correct identity's group even when that
+     * identity isn't the currently-selected one.
+     */
+    suspend fun findForOwner(ownerIdentityId: String, groupId: String): ChatGroup? =
+        mutex.withLock {
+            store.listForOwner(ownerIdentityId).firstOrNull { it.id == groupId }
+        }
+
     private suspend fun refreshLocked(activeId: IdentityId?) {
         _snapshots.value = if (activeId == null) {
             emptyList()

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -3,6 +3,12 @@ package app.onym.android.inbox
 import app.onym.android.chain.ChainStateReading
 import app.onym.android.chain.SepGroupType
 import app.onym.android.chain.SepTier
+import app.onym.android.chats.ChatMessage
+import app.onym.android.chats.ChatMessagePayload
+import app.onym.android.chats.ChatMessageVariant
+import app.onym.android.chats.MessageDirection
+import app.onym.android.chats.MessageRepository
+import app.onym.android.chats.MessageStatus
 import app.onym.android.group.ChatGroup
 import app.onym.android.group.GroupCommitmentBuilder
 import app.onym.android.group.GroupInvitationPayload
@@ -46,6 +52,14 @@ class IncomingMessageDispatcher(
     private val envelopeDecrypter: InvitationEnvelopeDecrypter,
     private val groupRepository: GroupRepository,
     private val invitationsRepository: IncomingInvitationsRepository,
+    /** Persistence target for incoming chat messages. The dispatcher
+     *  looks up the sender's [MemberProfile.sendingPubkey], verifies
+     *  the envelope's Ed25519 signer matches, and persists via
+     *  [MessageRepository.append] (idempotent on
+     *  [ChatMessage.id] so Nostr re-delivery is a no-op).
+     *  Optional so existing dispatcher tests that don't exercise the
+     *  chat-message path can keep their construction sites unchanged. */
+    private val messageRepository: MessageRepository? = null,
     /** Receiver's own identities, keyed by [IdentityId]. The PR-83
      *  invitation fast-path looks up the recipient's
      *  [IdentitySummary] here to backfill their own
@@ -96,6 +110,21 @@ class IncomingMessageDispatcher(
         val invitation = tryDecodeInvitation(envelope.plaintext)
         if (invitation != null) {
             materializeGroup(invitation, ownerIdentityId, envelope.senderEd25519PublicKey)
+            return
+        }
+
+        // Fast path: ChatMessagePayload — body of the chat thread.
+        // Verifies the envelope's Ed25519 signer matches the claimed
+        // sender's [MemberProfile.sendingPubkey] (insider-spoof
+        // defense, PR A3) then persists via [messageRepository].
+        val chatMessage = tryDecodeChatMessage(envelope.plaintext)
+        if (chatMessage != null) {
+            persistChatMessage(
+                payload = chatMessage,
+                ownerIdentityId = ownerIdentityId,
+                senderEd25519PublicKey = envelope.senderEd25519PublicKey,
+                receivedAt = receivedAt,
+            )
             return
         }
 
@@ -279,6 +308,87 @@ class IncomingMessageDispatcher(
         )
     } catch (_: Throwable) {
         null
+    }
+
+    private fun tryDecodeChatMessage(bytes: ByteArray): ChatMessagePayload? = try {
+        permissiveJson.decodeFromString(
+            ChatMessagePayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    /**
+     * Persist an inbound chat message after running the full trust
+     * chain. Drops silently (no fall-through) on any failure — the
+     * envelope decrypted to a well-formed chat payload, so it isn't
+     * a legacy-queue safety-net candidate.
+     *
+     * Trust chain:
+     *   1. Envelope must have been signed
+     *      ([senderEd25519PublicKey] non-null). Anonymous chat
+     *      messages aren't part of the V1 trust model.
+     *   2. Group lookup: payload's `groupId` must map to a local
+     *      [ChatGroup] owned by [ownerIdentityId]. Goes through
+     *      [GroupRepository.findForOwner] so the lookup is correct
+     *      even when [ownerIdentityId] isn't the currently-active
+     *      identity (multi-identity inbox fan-out delivers messages
+     *      to each identity's tag independently).
+     *   3. Sender lookup: payload's `senderBlsPubkeyHex` must
+     *      resolve to a known [MemberProfile] on the group.
+     *   4. Insider-spoof check: the envelope's verified Ed25519
+     *      signer must bytes-equal that member's stored
+     *      [MemberProfile.sendingPubkey]. Closes the gap PR A3 set
+     *      up; without this, any group member could write another
+     *      member's BLS hex into the payload and the receiver would
+     *      mis-attribute.
+     *   5. Variant gate: the payload's variant must match the
+     *      group's [ChatGroup.groupType] — a Tyranny group can't
+     *      receive a 1-on-1-shaped variant.
+     *   6. Persist via [MessageRepository.append] — idempotent on
+     *      [ChatMessage.id] so Nostr re-delivery of the same wire
+     *      `messageId` is a no-op.
+     */
+    private suspend fun persistChatMessage(
+        payload: ChatMessagePayload,
+        ownerIdentityId: IdentityId,
+        senderEd25519PublicKey: ByteArray?,
+        receivedAt: Instant,
+    ) {
+        val messages = messageRepository ?: return
+        val signerPubkey = senderEd25519PublicKey ?: return
+        val groupIdHex = payload.groupId.toHexLowercase()
+        val group = groupRepository.findForOwner(ownerIdentityId.value, groupIdHex) ?: return
+        val claimedSenderHex = payload.senderBlsPubkeyHex.lowercase()
+        val profile = group.memberProfiles[claimedSenderHex] ?: return
+        if (!profile.sendingPubkey.contentEquals(signerPubkey)) return
+        if (!variantMatchesGroup(payload.variant, group.groupType)) return
+
+        val body = payload.variant.body
+        val message = ChatMessage(
+            id = payload.messageId,
+            groupId = groupIdHex,
+            ownerIdentityId = ownerIdentityId.value,
+            senderBlsPubkeyHex = claimedSenderHex,
+            body = body,
+            sentAtMillis = payload.sentAtMillis,
+            direction = MessageDirection.INCOMING,
+            status = MessageStatus.RECEIVED,
+            groupType = group.groupType,
+        )
+        // Use the receivedAt timestamp only for the "ordering by
+        // arrival" UI follow-up — wire `sentAtMillis` is the
+        // canonical sort key today.
+        @Suppress("UNUSED_VARIABLE") val _receivedAt = receivedAt
+        messages.append(message)
+    }
+
+    private fun variantMatchesGroup(
+        variant: ChatMessageVariant,
+        groupType: SepGroupType,
+    ): Boolean = when (variant) {
+        is ChatMessageVariant.Tyranny -> groupType == SepGroupType.TYRANNY
     }
 
     /**

--- a/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
+++ b/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
@@ -34,13 +34,11 @@ class InMemoryMessageStore : MessageStore {
             .sortedBy { it.sentAtMillis }
     }
 
-    override suspend fun insert(message: ChatMessage) {
-        mutex.withLock {
-            check(!rows.containsKey(message.id.toString())) {
-                "duplicate message id ${message.id}"
-            }
-            rows[message.id.toString()] = message
-        }
+    override suspend fun insert(message: ChatMessage): Boolean = mutex.withLock {
+        val key = message.id.toString()
+        if (rows.containsKey(key)) return@withLock false
+        rows[key] = message
+        true
     }
 
     override suspend fun updateStatus(id: UUID, status: MessageStatus) {

--- a/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
@@ -1,0 +1,355 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.MemberProfile
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.IdentityRepository
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.support.ConfigurableInboxTransport
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryMessageStore
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Behavioral tests for [SendMessageInteractor]. Uses the in-memory
+ * fakes for store / transport / identity so the pipeline runs
+ * without the keychain + Nostr stack.
+ *
+ * Mirrors `SendMessageInteractorTests.swift` from onym-ios PR #150.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendMessageInteractorTest {
+
+    private val activeId = IdentityId("alice")
+    private val selfBls = ByteArray(48) { 0x11 }
+    private val selfBlsHex = selfBls.toHexLowercase()
+    private val selfInbox = ByteArray(32) { 0x22 }
+    private val selfSending = ByteArray(32) { 0x33 }
+    private val peerBls = ByteArray(48) { 0x44 }
+    private val peerBlsHex = peerBls.toHexLowercase()
+    private val peerInbox = ByteArray(32) { 0x55 }
+    private val groupIdHex = "aa".repeat(32)
+
+    // ─── happy path ───────────────────────────────────────────────
+
+    @Test
+    fun send_persistsAndFansOut_marksSentOnAnyAccepted() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+
+        val result = fixture.interactor.send(groupIdHex, "hello")
+
+        assertEquals(MessageStatus.SENT, result.status)
+        assertEquals("hello", result.body)
+        assertEquals(MessageDirection.OUTGOING, result.direction)
+        // One row, status SENT (overwriting the optimistic PENDING).
+        val persisted = fixture.messageStore
+            .listForGroup(activeId.value, groupIdHex)
+            .single()
+        assertEquals(MessageStatus.SENT, persisted.status)
+        // One envelope shipped: to the peer's inbox tag, not our own.
+        val sends = fixture.transport.sends()
+        assertEquals(1, sends.size)
+        assertEquals(
+            TransportInboxId(IdentityRepository.inboxTag(peerInbox)),
+            sends.single().inbox,
+        )
+    }
+
+    // ─── self-recipient is skipped ────────────────────────────────
+
+    @Test
+    fun send_skipsSelfRecipient() = runTest {
+        // Group has only the sender — fan-out has zero recipients.
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = false)
+
+        val result = fixture.interactor.send(groupIdHex, "hi")
+        // Zero recipients counts as SENT (a note-to-self is local-only).
+        assertEquals(MessageStatus.SENT, result.status)
+        assertTrue(
+            "no envelopes shipped when only self is in the roster",
+            fixture.transport.sends().isEmpty(),
+        )
+    }
+
+    // ─── all sends fail → status FAILED ───────────────────────────
+
+    @Test
+    fun send_allRecipientsFailed_marksFailed() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        fixture.transport.setReceiptAcceptedBy(0)  // every relay refuses
+
+        val result = fixture.interactor.send(groupIdHex, "hi")
+        assertEquals(MessageStatus.FAILED, result.status)
+        assertEquals(
+            MessageStatus.FAILED,
+            fixture.messageStore.listForGroup(activeId.value, groupIdHex).single().status,
+        )
+    }
+
+    @Test
+    fun send_sendThrows_marksFailed() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        fixture.transport.setSendThrow(RuntimeException("transport down"))
+
+        val result = fixture.interactor.send(groupIdHex, "hi")
+        assertEquals(MessageStatus.FAILED, result.status)
+    }
+
+    // ─── partial success → status SENT ────────────────────────────
+
+    @Test
+    fun send_partialSuccess_marksSentWhenAtLeastOneAccepted() = runTest {
+        // Two peers. First send accepted, second send rejected — the
+        // ConfigurableInboxTransport applies the same acceptedBy
+        // count to both, so this test exercises the "every relay
+        // accepted at least one envelope" branch via a single
+        // successful recipient.
+        val fixture = newFixture()
+        val secondPeerBls = ByteArray(48) { 0x66 }
+        val secondPeerInbox = ByteArray(32) { 0x77 }
+        fixture.seedGroup(
+            includePeer = true,
+            extraPeerBlsHex = secondPeerBls.toHexLowercase(),
+            extraPeerInbox = secondPeerInbox,
+        )
+
+        val result = fixture.interactor.send(groupIdHex, "hi")
+        assertEquals(MessageStatus.SENT, result.status)
+        // Both peers got envelopes (the fan-out is per-recipient).
+        assertEquals(2, fixture.transport.sends().size)
+    }
+
+    // ─── validation error paths ──────────────────────────────────
+
+    @Test
+    fun send_unknownGroup_throws() = runTest {
+        val fixture = newFixture()
+        // No group seeded.
+        assertThrows(SendMessageError.UnknownGroup::class.java) {
+            kotlinx.coroutines.runBlocking { fixture.interactor.send(groupIdHex, "x") }
+        }
+        // Nothing persisted, nothing shipped.
+        assertTrue(fixture.messageStore.listForGroup(activeId.value, groupIdHex).isEmpty())
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    @Test
+    fun send_senderNotAMember_throws() = runTest {
+        // Group exists, peer is in it, but the active identity isn't.
+        // Shouldn't happen post-PR A3, but is a defined error case.
+        val fixture = newFixture()
+        val group = makeGroup(
+            memberProfiles = mapOf(
+                peerBlsHex to MemberProfile(
+                    alias = "Peer",
+                    inboxPublicKey = peerInbox,
+                    sendingPubkey = ByteArray(32) { 0x88.toByte() },
+                ),
+            ),
+        )
+        fixture.groupStore.preload(listOf(group))
+
+        assertThrows(SendMessageError.SenderNotAMember::class.java) {
+            kotlinx.coroutines.runBlocking { fixture.interactor.send(groupIdHex, "x") }
+        }
+    }
+
+    @Test
+    fun send_emptyBody_throws() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        assertThrows(SendMessageError.EmptyBody::class.java) {
+            kotlinx.coroutines.runBlocking { fixture.interactor.send(groupIdHex, "") }
+        }
+        assertTrue(
+            "validation must short-circuit BEFORE the optimistic insert",
+            fixture.messageStore.listForGroup(activeId.value, groupIdHex).isEmpty(),
+        )
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    @Test
+    fun send_unsupportedGovernance_throws() = runTest {
+        val fixture = newFixture()
+        // Group is Anarchy — variant Tyranny doesn't fit; today
+        // SendMessageInteractor only ships .tyranny.
+        val group = makeGroup(
+            groupType = SepGroupType.ANARCHY,
+            memberProfiles = mapOf(
+                selfBlsHex to MemberProfile(
+                    alias = "Self",
+                    inboxPublicKey = selfInbox,
+                    sendingPubkey = selfSending,
+                ),
+                peerBlsHex to MemberProfile(
+                    alias = "Peer",
+                    inboxPublicKey = peerInbox,
+                    sendingPubkey = ByteArray(32) { 0x88.toByte() },
+                ),
+            ),
+        )
+        fixture.groupStore.preload(listOf(group))
+
+        val err = assertThrows(SendMessageError.UnsupportedGroupType::class.java) {
+            kotlinx.coroutines.runBlocking { fixture.interactor.send(groupIdHex, "x") }
+        }
+        assertEquals(SepGroupType.ANARCHY, err.type)
+    }
+
+    // ─── optimistic insert visible before fan-out completes ──────
+
+    @Test
+    fun send_optimisticInsert_visibleBeforeFanoutResolves() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        // Don't gate the transport — just assert that by the time
+        // send() returns, BOTH the optimistic insert AND the status
+        // flip have applied. The "PENDING is visible mid-flight"
+        // property is covered by subscribers to MessageRepository
+        // .snapshots; here we just sanity-check the final state has
+        // exactly one row with id matching what send() returned.
+        val result = fixture.interactor.send(groupIdHex, "first")
+        val rows = fixture.messageStore.listForGroup(activeId.value, groupIdHex)
+        assertEquals(1, rows.size)
+        assertEquals(result.id, rows.single().id)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun newFixture(): Fixture {
+        val activeProvider = FakeActiveIdentityProvider(initial = activeId)
+        val identitiesFlow = MutableStateFlow(
+            listOf(
+                IdentitySummary(
+                    id = activeId,
+                    name = "Alice",
+                    blsPublicKey = selfBls,
+                    inboxPublicKey = selfInbox,
+                    sendingPublicKey = selfSending,
+                ),
+            ),
+        )
+        val groupStore = InMemoryGroupStore()
+        val groupRepository = GroupRepository(
+            store = groupStore,
+            identity = activeProvider,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        val messageStore = InMemoryMessageStore()
+        val messageRepository = MessageRepository(
+            store = messageStore,
+            identity = activeProvider,
+            scope = TestScope(UnconfinedTestDispatcher()),
+        )
+        val transport = ConfigurableInboxTransport()
+        val interactor = SendMessageInteractor(
+            activeIdentity = activeProvider,
+            identitiesFlow = identitiesFlow,
+            envelopeSealer = RecordingSealer(),
+            groupRepository = groupRepository,
+            messageRepository = messageRepository,
+            inboxTransport = transport,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_700_000_000_000L },
+            idFactory = { UUID.fromString("00000000-0000-0000-0000-000000000001") },
+        )
+        return Fixture(
+            interactor = interactor,
+            groupStore = groupStore,
+            messageStore = messageStore,
+            transport = transport,
+        )
+    }
+
+    private inner class Fixture(
+        val interactor: SendMessageInteractor,
+        val groupStore: InMemoryGroupStore,
+        val messageStore: InMemoryMessageStore,
+        val transport: ConfigurableInboxTransport,
+    ) {
+        suspend fun seedGroup(
+            includePeer: Boolean,
+            extraPeerBlsHex: String? = null,
+            extraPeerInbox: ByteArray? = null,
+        ) {
+            val profiles = buildMap<String, MemberProfile> {
+                put(selfBlsHex, MemberProfile(
+                    alias = "Self",
+                    inboxPublicKey = selfInbox,
+                    sendingPubkey = selfSending,
+                ))
+                if (includePeer) {
+                    put(peerBlsHex, MemberProfile(
+                        alias = "Peer",
+                        inboxPublicKey = peerInbox,
+                        sendingPubkey = ByteArray(32) { 0x88.toByte() },
+                    ))
+                }
+                if (extraPeerBlsHex != null && extraPeerInbox != null) {
+                    put(extraPeerBlsHex, MemberProfile(
+                        alias = "Peer2",
+                        inboxPublicKey = extraPeerInbox,
+                        sendingPubkey = ByteArray(32) { 0x99.toByte() },
+                    ))
+                }
+            }
+            groupStore.preload(listOf(makeGroup(memberProfiles = profiles)))
+        }
+    }
+
+    private fun makeGroup(
+        groupType: SepGroupType = SepGroupType.TYRANNY,
+        memberProfiles: Map<String, MemberProfile>,
+    ) = ChatGroup(
+        id = groupIdHex,
+        name = "Family",
+        groupSecret = ByteArray(32),
+        createdAtMillis = 0L,
+        members = emptyList(),
+        memberProfiles = memberProfiles,
+        epoch = 0uL,
+        salt = ByteArray(32),
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = groupType,
+        adminPubkeyHex = null,
+        isPublishedOnChain = true,
+        ownerIdentityId = activeId.value,
+    )
+}
+
+/** Sealer that just returns the plaintext bytes — the tests don't
+ *  care about the envelope shape, only that one call happens per
+ *  recipient and the resulting bytes get handed to [InboxTransport]. */
+private class RecordingSealer : InvitationEnvelopeSealer {
+    override suspend fun sealInvitation(
+        payload: ByteArray,
+        recipientInboxPublicKey: ByteArray,
+    ): ByteArray = payload
+}
+
+private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+    for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+}

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
@@ -1,0 +1,348 @@
+package app.onym.android.inbox
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.chats.ChatMessagePayload
+import app.onym.android.chats.ChatMessageVariant
+import app.onym.android.chats.MessageDirection
+import app.onym.android.chats.MessageRepository
+import app.onym.android.chats.MessageStatus
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.MemberProfile
+import app.onym.android.identity.DecryptedEnvelope
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.InvitationEnvelopeDecrypter
+import app.onym.android.persistence.InMemoryInvitationStore
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryMessageStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Behavioral tests for the chat-message fast path on
+ * [IncomingMessageDispatcher] (PR A4). Drives the dispatcher with a
+ * fake decrypter that returns a pre-baked [DecryptedEnvelope] and
+ * verifies the full trust chain rejects mismatches without falling
+ * through to the legacy invitations queue.
+ *
+ * Mirrors `IncomingMessageDispatcherChatMessageTests.swift` from
+ * onym-ios PR #150.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class IncomingMessageDispatcherChatMessageTest {
+
+    private val ownerIdentity = IdentityId("alice-id")
+    private val otherIdentity = IdentityId("bob-id")
+    private val groupIdBytes = ByteArray(32) { 0xAA.toByte() }
+    private val groupIdHex = groupIdBytes.toHexLowercase()
+    private val senderBlsBytes = ByteArray(48) { 0x11 }
+    private val senderBlsHex = senderBlsBytes.toHexLowercase()
+    private val senderInbox = ByteArray(32) { 0x22 }
+    private val senderSendingKey = ByteArray(32) { 0x33 }
+
+    // ─── happy path ───────────────────────────────────────────────
+
+    @Test
+    fun chatMessage_persistsAndDoesNotFallThrough() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+
+        val msgId = UUID.fromString("00112233-4455-6677-8899-AABBCCDDEEFF")
+        val payload = chatPayload(msgId, body = "hello")
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+
+        val rows = fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex)
+        assertEquals(1, rows.size)
+        val msg = rows.single()
+        assertEquals(msgId, msg.id)
+        assertEquals("hello", msg.body)
+        assertEquals(MessageDirection.INCOMING, msg.direction)
+        assertEquals(MessageStatus.RECEIVED, msg.status)
+        assertEquals(senderBlsHex, msg.senderBlsPubkeyHex)
+        // Legacy queue stays empty — chat messages don't fall through.
+        fixture.invitationsRepository.bootstrap()
+        assertTrue(fixture.invitationsRepository.invitations.value.isEmpty())
+    }
+
+    // ─── trust-chain failures all drop without falling through ───
+
+    @Test
+    fun chatMessage_unknownGroupIsDroppedNotQueued() = runTest {
+        val fixture = newFixture()
+        // No seeded group at all.
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+        fixture.invitationsRepository.bootstrap()
+        assertTrue(
+            "chat-message decode succeeded; must NOT queue",
+            fixture.invitationsRepository.invitations.value.isEmpty(),
+        )
+    }
+
+    @Test
+    fun chatMessage_unknownSenderIsDropped() = runTest {
+        val fixture = newFixture()
+        // Group present, but the claimed sender's BLS hex isn't in memberProfiles.
+        fixture.seedGroup(ownerIdentity, withSenderProfile = false)
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    @Test
+    fun chatMessage_signatureMismatchIsDropped() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+        // Envelope signed by some OTHER Ed25519 key, not the one
+        // recorded on the sender's MemberProfile.
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        fixture.dispatch(
+            ownerIdentity,
+            payload,
+            signer = ByteArray(32) { 0x99.toByte() },
+        )
+
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    @Test
+    fun chatMessage_missingEnvelopeSignatureIsDropped() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        // Anonymous chat messages aren't part of the V1 trust model.
+        fixture.dispatch(ownerIdentity, payload, signer = null)
+
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    @Test
+    fun chatMessage_wrongOwnerIdentityIsDropped() = runTest {
+        val fixture = newFixture()
+        // Group owned by Alice, but the inbox fan-out delivered this
+        // envelope to Bob's tag — Bob's local view doesn't know about
+        // Alice's group, so the lookup misses.
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        fixture.dispatch(otherIdentity, payload, signer = senderSendingKey)
+
+        assertTrue(fixture.messageStore.listForGroup(otherIdentity.value, groupIdHex).isEmpty())
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    // ─── multi-identity correctness ───────────────────────────────
+
+    @Test
+    fun chatMessage_persistsForNonActiveIdentity() = runTest {
+        // Active identity is Alice, but the inbox tag belongs to Bob;
+        // the message must still land in Bob's group regardless of
+        // whether Bob is currently selected.
+        val activeProvider = FakeActiveIdentityProvider(initial = ownerIdentity)
+        val fixture = newFixture(activeProvider = activeProvider)
+        fixture.seedGroup(otherIdentity, withSenderProfile = true)
+
+        val msgId = UUID.randomUUID()
+        val payload = chatPayload(msgId, body = "for bob")
+        fixture.dispatch(otherIdentity, payload, signer = senderSendingKey)
+
+        // Stored under Bob, even though Alice is active.
+        val bobRows = fixture.messageStore.listForGroup(otherIdentity.value, groupIdHex)
+        assertEquals(1, bobRows.size)
+        assertEquals("for bob", bobRows.single().body)
+        // Active identity (Alice) has nothing.
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    // ─── idempotency ──────────────────────────────────────────────
+
+    @Test
+    fun chatMessage_duplicateMessageIdIsIdempotent() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+
+        val msgId = UUID.randomUUID()
+        val payload = chatPayload(msgId, body = "first delivery")
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+        // Same wire messageId arrives again (e.g., Nostr relay
+        // re-delivery). Body content could be different in a hostile
+        // scenario; we keep whatever landed first.
+        val duplicate = payload.copy()
+        fixture.dispatch(ownerIdentity, duplicate, signer = senderSendingKey)
+
+        val rows = fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex)
+        assertEquals("re-delivery must not duplicate the row", 1, rows.size)
+        assertEquals("first delivery", rows.single().body)
+    }
+
+    // ─── variant gate ─────────────────────────────────────────────
+
+    @Test
+    fun chatMessage_variantMismatchForGovernanceIsDropped() = runTest {
+        // Group is ANARCHY but payload variant is Tyranny —
+        // governance-keyed variant gate must reject so we don't
+        // mis-render or mis-attribute a cross-governance message.
+        val fixture = newFixture()
+        fixture.seedGroup(
+            ownerIdentity,
+            withSenderProfile = true,
+            groupType = SepGroupType.ANARCHY,
+        )
+        val payload = chatPayload(UUID.randomUUID(), body = "x")
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+
+        assertTrue(fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).isEmpty())
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun chatPayload(
+        id: UUID,
+        body: String,
+        sentAtMillis: Long = 1_700_000_000_000L,
+    ) = ChatMessagePayload(
+        version = 1,
+        messageId = id,
+        groupId = groupIdBytes,
+        senderBlsPubkeyHex = senderBlsHex,
+        sentAtMillis = sentAtMillis,
+        variant = ChatMessageVariant.Tyranny(body = body),
+    )
+
+    private fun newFixture(
+        activeProvider: FakeActiveIdentityProvider = FakeActiveIdentityProvider(initial = ownerIdentity),
+    ): Fixture {
+        val groupStore = InMemoryGroupStore()
+        val groupRepository = GroupRepository(
+            store = groupStore,
+            identity = activeProvider,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        val messageStore = InMemoryMessageStore()
+        val messageRepository = MessageRepository(
+            store = messageStore,
+            identity = activeProvider,
+            scope = TestScope(UnconfinedTestDispatcher()),
+        )
+        val invitationsRepository = IncomingInvitationsRepository(
+            store = InMemoryInvitationStore(),
+            identity = activeProvider,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        return Fixture(
+            groupStore = groupStore,
+            groupRepository = groupRepository,
+            messageStore = messageStore,
+            messageRepository = messageRepository,
+            invitationsRepository = invitationsRepository,
+        )
+    }
+
+    private inner class Fixture(
+        val groupStore: InMemoryGroupStore,
+        val groupRepository: GroupRepository,
+        val messageStore: InMemoryMessageStore,
+        val messageRepository: MessageRepository,
+        val invitationsRepository: IncomingInvitationsRepository,
+    ) {
+        suspend fun seedGroup(
+            owner: IdentityId,
+            withSenderProfile: Boolean,
+            groupType: SepGroupType = SepGroupType.TYRANNY,
+        ) {
+            val profiles: Map<String, MemberProfile> = if (withSenderProfile) {
+                mapOf(
+                    senderBlsHex to MemberProfile(
+                        alias = "Sender",
+                        inboxPublicKey = senderInbox,
+                        sendingPubkey = senderSendingKey,
+                    ),
+                )
+            } else {
+                emptyMap()
+            }
+            groupStore.preload(listOf(makeGroup(owner, groupType, profiles)))
+        }
+
+        suspend fun dispatch(
+            owner: IdentityId,
+            payload: ChatMessagePayload,
+            signer: ByteArray?,
+        ) {
+            val plaintext = jsonFormat
+                .encodeToString(ChatMessagePayload.serializer(), payload)
+                .toByteArray(Charsets.UTF_8)
+            val dispatcher = IncomingMessageDispatcher(
+                envelopeDecrypter = StubDecrypterChat(plaintext, signer),
+                groupRepository = groupRepository,
+                invitationsRepository = invitationsRepository,
+                messageRepository = messageRepository,
+            )
+            dispatcher.dispatch(
+                messageId = "envelope-id-${payload.messageId}",
+                ownerIdentityId = owner,
+                payload = byteArrayOf(),
+                receivedAt = Instant.EPOCH,
+            )
+        }
+    }
+
+    private fun makeGroup(
+        owner: IdentityId,
+        groupType: SepGroupType,
+        profiles: Map<String, MemberProfile>,
+    ): ChatGroup = ChatGroup(
+        id = groupIdHex,
+        name = "Family",
+        groupSecret = ByteArray(32),
+        createdAtMillis = 0L,
+        members = emptyList(),
+        memberProfiles = profiles,
+        epoch = 0uL,
+        salt = ByteArray(32),
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = groupType,
+        adminPubkeyHex = null,
+        isPublishedOnChain = true,
+        ownerIdentityId = owner.value,
+    )
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true }
+    }
+}
+
+private class StubDecrypterChat(
+    private val plaintext: ByteArray,
+    private val senderPub: ByteArray?,
+) : InvitationEnvelopeDecrypter {
+    override suspend fun decryptInvitation(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): ByteArray = plaintext
+
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = DecryptedEnvelope(plaintext, senderPub)
+}
+
+private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+    for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+}


### PR DESCRIPTION
**Stacked on #143.** Both directions wired in one PR — symmetric, paired because they share `ChatMessagePayload`. With PRs A1–A3 underneath, two users in a Tyranny group can now exchange encrypted text end-to-end at the data + transport layer. **No UI yet.** Mirrors [onym-ios PR #150](https://github.com/onymchat/onym-ios/pull/150).

## Receive — `IncomingMessageDispatcher` chat-message branch

New third fast path on `dispatch()`: try-decode plaintext as a `ChatMessagePayload`. On match, run the trust chain:

1. **Envelope must have been signed** — guard `envelope.senderEd25519PublicKey != null`. Anonymous chat messages aren't part of the V1 trust model.
2. **Group lookup** — payload's `groupId` must match a local `ChatGroup` owned by the receiving identity. Routes via the new `GroupRepository.findForOwner(ownerIdentityId, groupIdHex)` which **goes through the store directly, bypassing the active-identity filter on `snapshots`**. This is the multi-identity correctness fix: each identity's inbox fan-out supplies the right `ownerIdentityId`, so a message addressed to a non-active identity still lands in the correct group.
3. **Sender lookup** — payload's `sender_bls_pubkey_hex` must be in the group's `memberProfiles`.
4. **Insider-spoof check** — envelope's verified Ed25519 signer must equal that member's stored `MemberProfile.sendingPubkey`. Closes the gap PR A3 (#143) set up; without this, any group member could write another's BLS hex into the payload and the receiver would mis-attribute.
5. **Variant gate** — variant must match the group's governance type.
6. **Persist** via `MessageRepository.append` — idempotent on `ChatMessage.id` (the `MessageDao @Insert` flipped to `OnConflictStrategy.IGNORE` returning `Long`; `-1L` surfaces as `false` at the store seam) so Nostr re-delivery is a no-op.

Dispatcher gains an optional `messageRepository` 4th param. Production wiring in `OnymApplication` instantiates a `MessageDatabase` + `MessageRepository` alongside the existing `GroupDatabase` + `GroupRepository` with the same on-disk-or-in-memory fallback.

## Send — `SendMessageInteractor`

Optimistic-insert pipeline mirroring `CreateGroupInteractor`'s invitation send loop:

1. Validate (identity loaded, group exists, current identity is in roster, body non-empty, variant matches governance).
2. Mint `messageId` + payload, persist locally as `PENDING` so the chat thread shows the bubble immediately.
3. Fan out one sealed envelope per **other** member's inbox key — best-effort, swallow per-recipient failures.
4. Flip status: `SENT` if any relay accepted (or no recipients — note-to-self is local-only), `FAILED` if all sends rejected.

Today only the `Tyranny` variant ships; other group types throw `UnsupportedGroupType` until their variants come online.

**Takes `ActiveIdentityProvider` + `identitiesFlow` + `InvitationEnvelopeSealer` + `InboxTransport`** instead of the concrete `IdentityRepository` so the interactor is unit-testable without standing up the real keychain. Production wiring passes `identityRepository` for all three of the identity slots (it implements both `ActiveIdentityProvider` and `InvitationEnvelopeSealer` and exposes `identities` as a `StateFlow<List<IdentitySummary>>`).

## Tests

- **`IncomingMessageDispatcherChatMessageTest`** (9): happy path, unknown group / sender / signature mismatch / missing signature / wrong owner identity / **non-active identity (proves multi-identity)** / duplicate messageID idempotency / variant-vs-governance mismatch.
- **`SendMessageInteractorTest`** (9): persist + fan out marks SENT, skip self recipient, zero peers (note-to-self), all-fail marks FAILED, send-throws marks FAILED, partial success marks SENT, `unknownGroup` / `senderNotAMember` / `emptyBody` validation paths, `unsupportedGovernance` throws.
- Full `:app:testDebugUnitTest` suite — **490 / 490 pass**, 0 failures, 0 errors, 0 regressions.

## Multi-identity correctness (called out)

A specific test (`chatMessage_persistsForNonActiveIdentity`) seeds two identities, leaves Alice active, and dispatches a message addressed to Bob's identity. Asserts the message lands in Bob's group regardless. The dispatcher routes by the `ownerIdentityId` parameter through `GroupRepository.findForOwner` (which bypasses the active-identity snapshot filter), so inbox fan-out per identity does the right thing.

## Divergence from iOS

- **`actor SendMessageInteractor` → plain `class`** + `withContext(ioDispatcher)`. Same serialization guarantees via the dispatcher hop.
- **`identity: IdentityRepository` → split interfaces** (`ActiveIdentityProvider` + `StateFlow<List<IdentitySummary>>` + `InvitationEnvelopeSealer`). Android-side testability — no `actor`-style protocol on the concrete repo to stub against.
- **`messageRepository: MessageRepository` non-optional on iOS → optional on Android** (`?= null`). Lets the pre-existing `IncomingMessageDispatcherTest` (and the announcement / invitation fast paths) keep working without threading a `MessageRepository` through every construction site.

## Out of scope

UI — that's PR A5 (Compose chat-thread screen).

## Plan context

PR 4 of 5 in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey. **PR A5 next**: Compose chat-thread screen + nav rewire (members list moves one tap deeper behind an info button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)