### PR TITLE
feat(chats): Compose chat-thread shell + nav rewire (PR 5/5 chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/app/onym/android/AppDependencies.kt
@@ -2,6 +2,7 @@ package app.onym.android
 
 import androidx.fragment.app.FragmentActivity
 import app.onym.android.chain.NetworkPreferenceProvider
+import app.onym.android.chats.ChatThreadViewModel
 import app.onym.android.chats.ChatsViewModel
 import app.onym.android.group.CreateGroupViewModel
 import app.onym.android.recovery.RecoveryPhraseBackupViewModel
@@ -45,6 +46,12 @@ class AppDependencies(
     /** Chats tab — read-only view over [app.onym.android.group.GroupRepository.snapshots].
      *  Mirrors `makeChatsFlow` from onym-ios PR #30. */
     val makeChatsViewModel: () -> ChatsViewModel,
+    /** Chat-thread screen factory — takes the path-arg `groupId` so
+     *  the VM can subscribe to that group's [app.onym.android.chats.MessageRepository.snapshots]
+     *  stream and dispatch sends via the captured [SendMessageInteractor].
+     *  Mirrors the UIViewControllerRepresentable bridge factory from
+     *  onym-ios PR #151, Android-idiomatic types. */
+    val makeChatThreadViewModel: (groupId: String) -> ChatThreadViewModel,
     /** Settings → Identities — multi-identity management (PR-5). */
     val makeIdentitiesViewModel: () -> app.onym.android.identity.IdentitiesViewModel,
     /** Post-create deeplink invite share (deeplink-invite PR-5). */

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -567,6 +567,27 @@ class OnymApplication : Application() {
             makeChatsViewModel = {
                 app.onym.android.chats.ChatsViewModel(repository = groupRepository)
             },
+            makeChatThreadViewModel = { groupId ->
+                // PR A5: per-thread VM. The SendMessageInteractor is
+                // built fresh per VM — it's stateless and capturing
+                // the closure here keeps the interactor's
+                // dependencies (identity, transport, message repo)
+                // out of the VM's own constructor.
+                val sender = app.onym.android.chats.SendMessageInteractor(
+                    activeIdentity = identityRepository,
+                    identitiesFlow = identityRepository.identities,
+                    envelopeSealer = identityRepository,
+                    groupRepository = groupRepository,
+                    messageRepository = messageRepository,
+                    inboxTransport = inboxTransport,
+                )
+                app.onym.android.chats.ChatThreadViewModel(
+                    groupId = groupId,
+                    groupRepository = groupRepository,
+                    messageRepository = messageRepository,
+                    sendMessage = sender::send,
+                )
+            },
             makeIdentitiesViewModel = {
                 app.onym.android.identity.IdentitiesViewModel(identity = identityRepository)
             },

--- a/app/src/main/kotlin/app/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/RootScreen.kt
@@ -165,6 +165,24 @@ fun RootScreen(
                     approveRequestsViewModel = dependencies.approveRequestsViewModel,
                     onOpenApproveRequests = { navController.navigate(ROUTE_APPROVE_REQUESTS) },
                     onOpenChat = { groupId ->
+                        // PR A5: chats list now opens the thread,
+                        // not the members roster. Members move one
+                        // tap deeper behind the thread's info button.
+                        navController.navigate("chat_thread/$groupId")
+                    },
+                )
+            }
+            composable("chat_thread/{groupId}") { entry ->
+                val groupId = entry.arguments?.getString("groupId") ?: return@composable
+                val vm: app.onym.android.chats.ChatThreadViewModel = viewModel(
+                    factory = viewModelFactory {
+                        initializer { dependencies.makeChatThreadViewModel(groupId) }
+                    },
+                )
+                app.onym.android.chats.ChatThreadScreen(
+                    viewModel = vm,
+                    onBack = { navController.popBackStack() },
+                    onShowMembers = {
                         navController.navigate("chat_members/$groupId")
                     },
                 )

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -1,0 +1,182 @@
+package app.onym.android.chats
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Compose chat-thread screen. Tapping a group in the Chats tab
+ * opens this destination; the members list moves one tap deeper
+ * behind the info action in the top bar.
+ *
+ * Skeleton only — the message list and input panel are placeholders
+ * that the next PR fills in (custom bubble cells, auto-scroll,
+ * keyboard avoidance, send wiring through [ChatThreadViewModel.send]).
+ *
+ * The data plumbing is already in place via [ChatThreadViewModel]:
+ * the screen collects [ChatThreadViewModel.messages] and
+ * [ChatThreadViewModel.group] so when the rendering lands later it's
+ * a UI-only diff.
+ *
+ * Mirrors `ChatThreadView.swift` from onym-ios PR #151 — same nav
+ * surface (back + group name + info), same placeholder posture.
+ * Diverges from iOS in being a single Compose composable rather
+ * than a UIViewControllerRepresentable wrapping a UIKit
+ * controller — Compose's nav-bar primitives + diffable LazyColumn
+ * cover what iOS needed UIKit for, with no SwiftUI/UIKit-bridge tax.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatThreadScreen(
+    viewModel: ChatThreadViewModel,
+    onBack: () -> Unit,
+    onShowMembers: () -> Unit,
+) {
+    val group by viewModel.group.collectAsStateWithLifecycle()
+    val messages by viewModel.messages.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = group?.name ?: "Chat",
+                        modifier = Modifier.testTag("chat_thread.title"),
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onBack,
+                        modifier = Modifier.testTag("chat_thread.back_button"),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = onShowMembers,
+                        modifier = Modifier.testTag("chat_thread.info_button"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = "Members",
+                        )
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        if (group == null) {
+            MissingGroup(padding = padding)
+        } else {
+            ChatThreadBody(
+                messageCount = messages.size,
+                padding = padding,
+            )
+        }
+    }
+}
+
+/** Empty placeholder body — message rendering + input panel land in
+ *  the next PR. Surfaces the message count so the data plumbing is
+ *  visibly wired through to the screen during the skeleton slice. */
+@Composable
+private fun ChatThreadBody(
+    messageCount: Int,
+    padding: PaddingValues,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .testTag("chat_thread.body"),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = if (messageCount == 0) {
+                    "No messages yet. Bubbles render in the next PR."
+                } else {
+                    "$messageCount message${if (messageCount == 1) "" else "s"} — rendering lands in the next PR."
+                },
+                fontSize = 13.sp,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .padding(horizontal = 32.dp)
+                    .testTag("chat_thread.placeholder_text"),
+            )
+        }
+        HorizontalDivider(thickness = 0.5.dp)
+        InputPanelPlaceholder()
+    }
+}
+
+@Composable
+private fun InputPanelPlaceholder() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 16.dp)
+            .testTag("chat_thread.input_panel_placeholder"),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = "Message input lands in the next PR",
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun MissingGroup(padding: PaddingValues) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .testTag("chat_thread.missing"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "This chat isn't on this device.",
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
@@ -1,0 +1,95 @@
+package app.onym.android.chats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Per-thread ViewModel for the chat screen. Subscribes to one
+ * group's message stream and exposes a `send(body)` action.
+ *
+ * The chat-message render pipeline (custom bubble cells, auto-scroll,
+ * keyboard avoidance) is a future PR's surface — today the screen
+ * only renders a placeholder. The VM ships the data plumbing so
+ * future work is a UI-only diff.
+ *
+ * Mirrors `ChatThreadView.swift`'s data dependencies from onym-ios
+ * PR #151 (iOS uses a UIKit controller; Android uses Compose with
+ * a VM the screen collects).
+ */
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class ChatThreadViewModel(
+    val groupId: String,
+    private val groupRepository: GroupRepository,
+    private val messageRepository: MessageRepository,
+    private val sendMessage: suspend (groupId: String, body: String) -> Unit,
+) : ViewModel() {
+
+    /** Latest snapshot of the [ChatGroup] this thread renders.
+     *  `null` when no group with [groupId] exists on this device
+     *  (deleted, or belongs to a different identity). UI surfaces
+     *  a "group not found" empty state in that case. */
+    val group: StateFlow<ChatGroup?> = groupRepository.snapshots
+        .map { groups -> groups.firstOrNull { it.id == groupId } }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = groupRepository.snapshots.value
+                .firstOrNull { it.id == groupId },
+        )
+
+    /** Hot stream of this group's messages, oldest first. Backed by
+     *  [MessageRepository.snapshots] — a `SharedFlow`-equivalent
+     *  resolves on first collection. */
+    val messages: StateFlow<List<ChatMessage>> = MutableStateFlow<List<ChatMessage>>(emptyList())
+        .also { initial ->
+            viewModelScope.launch {
+                messageRepository.snapshots(groupId).collect { initial.value = it }
+            }
+        }
+        .asStateFlow()
+
+    private val _sendInFlight = MutableStateFlow(false)
+    /** `true` while a send is queued through the interactor. UI uses
+     *  this to gray out the send button and disable the input. */
+    val sendInFlight: StateFlow<Boolean> = _sendInFlight.asStateFlow()
+
+    private val _lastSendError = MutableStateFlow<String?>(null)
+    /** Last-seen send error, surfaced as a banner / toast. Cleared
+     *  on the next successful send or via [clearError]. */
+    val lastSendError: StateFlow<String?> = _lastSendError.asStateFlow()
+
+    /**
+     * Fire-and-forget send. The interactor handles the optimistic
+     * insert + status flip; the UI gets pending → sent / failed
+     * transitions through [messages] without any extra wiring here.
+     */
+    fun send(body: String) {
+        val trimmed = body.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            _sendInFlight.value = true
+            try {
+                sendMessage(groupId, trimmed)
+                _lastSendError.value = null
+            } catch (e: SendMessageError) {
+                _lastSendError.value = e.message ?: e.javaClass.simpleName
+            } catch (e: Throwable) {
+                _lastSendError.value = e.message ?: e.javaClass.simpleName
+            } finally {
+                _sendInFlight.value = false
+            }
+        }
+    }
+
+    fun clearError() { _lastSendError.value = null }
+}

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
@@ -1,0 +1,256 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.MemberProfile
+import app.onym.android.identity.IdentityId
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryMessageStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Contract tests for [ChatThreadViewModel]. Verifies the data
+ * plumbing the screen depends on:
+ *  - `group` resolves the active group by id from
+ *    [GroupRepository.snapshots].
+ *  - `messages` mirrors [MessageRepository.snapshots] for the same id.
+ *  - `send(body)` delegates to the captured interactor closure and
+ *    routes errors into `lastSendError`; empty bodies short-circuit
+ *    without invoking the closure.
+ *  - `sendInFlight` flips around the closure execution.
+ *
+ * Mirrors `ChatThreadViewControllerTests.swift` from onym-ios PR #151
+ * in spirit — iOS tests verify the UIKit controller wiring; Android
+ * verifies the equivalent VM surface (the Compose screen is a thin
+ * `collectAsStateWithLifecycle` reader over this VM).
+ */
+class ChatThreadViewModelTest {
+
+    @Before fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val activeId = IdentityId("alice")
+    private val groupIdHex = "aa".repeat(32)
+
+    // ─── group resolution ────────────────────────────────────────
+
+    @Test
+    fun group_resolvesByGroupId_fromActiveIdentitySnapshots() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex, name = "Family")
+
+        val vm = fixture.makeViewModel()
+        assertEquals("Family", vm.group.first { it != null }?.name)
+    }
+
+    @Test
+    fun group_nullWhenGroupNotPresent() = runTest {
+        val fixture = newFixture()
+        // No group seeded.
+        val vm = fixture.makeViewModel()
+        assertNull(vm.group.value)
+    }
+
+    // ─── message stream wiring ───────────────────────────────────
+
+    @Test
+    fun messages_minorOfMessageRepositorySnapshots() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val msg = sampleMessage(groupIdHex, body = "hi")
+        fixture.messageStore.preload(listOf(msg))
+
+        val vm = fixture.makeViewModel()
+        val rows = vm.messages.first { it.isNotEmpty() }
+        assertEquals(1, rows.size)
+        assertEquals("hi", rows.single().body)
+    }
+
+    @Test
+    fun messages_emitsOnAppend() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val vm = fixture.makeViewModel()
+        // Subscribe so MessageRepository's lazy cache materializes.
+        assertEquals(0, vm.messages.first().size)
+
+        fixture.messageRepository.append(sampleMessage(groupIdHex, body = "new"))
+        val rows = vm.messages.first { it.isNotEmpty() }
+        assertEquals("new", rows.single().body)
+    }
+
+    // ─── send action ─────────────────────────────────────────────
+
+    @Test
+    fun send_invokesInteractorWithTrimmedBody() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val captured = mutableListOf<Pair<String, String>>()
+        val vm = fixture.makeViewModel(
+            send = { gid, body -> captured.add(gid to body) },
+        )
+
+        vm.send("  hello world  ")
+        assertEquals(1, captured.size)
+        assertEquals(groupIdHex to "hello world", captured.single())
+    }
+
+    @Test
+    fun send_emptyOrWhitespaceBody_isShortCircuited() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val captured = mutableListOf<Pair<String, String>>()
+        val vm = fixture.makeViewModel(
+            send = { gid, body -> captured.add(gid to body) },
+        )
+
+        vm.send("")
+        vm.send("   ")
+        assertTrue(
+            "empty / whitespace bodies must not reach the interactor",
+            captured.isEmpty(),
+        )
+    }
+
+    @Test
+    fun send_interactorThrows_routesIntoLastSendError() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val vm = fixture.makeViewModel(
+            send = { _, _ -> throw SendMessageError.SenderNotAMember },
+        )
+
+        vm.send("hi")
+        assertNotNull(vm.lastSendError.value)
+    }
+
+    @Test
+    fun clearError_resetsLastSendError() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val vm = fixture.makeViewModel(
+            send = { _, _ -> throw SendMessageError.EmptyBody },
+        )
+        vm.send("hi")
+        assertNotNull(vm.lastSendError.value)
+
+        vm.clearError()
+        assertNull(vm.lastSendError.value)
+    }
+
+    @Test
+    fun send_successClearsPreviousError() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        var shouldThrow = true
+        val vm = fixture.makeViewModel(
+            send = { _, _ ->
+                if (shouldThrow) throw SendMessageError.SenderNotAMember
+            },
+        )
+        vm.send("first")  // throws → error set
+        assertNotNull(vm.lastSendError.value)
+
+        shouldThrow = false
+        vm.send("second")  // succeeds → error cleared
+        assertNull(vm.lastSendError.value)
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────
+
+    private fun sampleMessage(groupIdHex: String, body: String): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = groupIdHex,
+        ownerIdentityId = activeId.value,
+        senderBlsPubkeyHex = "cc".repeat(48),
+        body = body,
+        sentAtMillis = 1_700_000_000_000L,
+        direction = MessageDirection.INCOMING,
+        status = MessageStatus.RECEIVED,
+        groupType = SepGroupType.TYRANNY,
+    )
+
+    private fun newFixture(): Fixture {
+        val activeProvider = FakeActiveIdentityProvider(initial = activeId)
+        val groupStore = InMemoryGroupStore()
+        val groupRepository = GroupRepository(
+            store = groupStore,
+            identity = activeProvider,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        groupRepository.start()
+        val messageStore = InMemoryMessageStore()
+        val messageRepository = MessageRepository(
+            store = messageStore,
+            identity = activeProvider,
+            scope = TestScope(UnconfinedTestDispatcher()),
+        )
+        return Fixture(groupStore, groupRepository, messageStore, messageRepository)
+    }
+
+    private inner class Fixture(
+        val groupStore: InMemoryGroupStore,
+        val groupRepository: GroupRepository,
+        val messageStore: InMemoryMessageStore,
+        val messageRepository: MessageRepository,
+    ) {
+        suspend fun seedGroup(id: String, name: String = "Group") {
+            groupStore.preload(
+                listOf(
+                    ChatGroup(
+                        id = id,
+                        name = name,
+                        groupSecret = ByteArray(32),
+                        createdAtMillis = 0L,
+                        members = emptyList(),
+                        memberProfiles = mapOf(
+                            "aa".repeat(48) to MemberProfile(
+                                alias = "Alice",
+                                inboxPublicKey = ByteArray(32) { 0x22 },
+                                sendingPubkey = ByteArray(32) { 0x33 },
+                            ),
+                        ),
+                        epoch = 0uL,
+                        salt = ByteArray(32),
+                        commitment = null,
+                        tier = SepTier.SMALL,
+                        groupType = SepGroupType.TYRANNY,
+                        adminPubkeyHex = null,
+                        isPublishedOnChain = true,
+                        ownerIdentityId = activeId.value,
+                    ),
+                ),
+            )
+            groupRepository.reload()
+        }
+
+        fun makeViewModel(
+            send: suspend (String, String) -> Unit = { _, _ -> },
+        ) = ChatThreadViewModel(
+            groupId = groupIdHex,
+            groupRepository = groupRepository,
+            messageRepository = messageRepository,
+            sendMessage = send,
+        )
+    }
+}


### PR DESCRIPTION
**Stacked on #144.** First user-visible PR of the Android chat stack. Tapping a group in the Chats tab now opens a Compose `ChatThreadScreen` instead of the members roster. The members list moves one tap deeper, behind the thread's info button. Mirrors [onym-ios PR #151](https://github.com/onymchat/onym-ios/pull/151).

## What's in here

**`ChatThreadScreen.kt`** (Compose, Material 3)
- `Scaffold` + `TopAppBar` mirroring `ChatMembersScreen`'s shape: back arrow on the left, group name (or `"Chat"` fallback) in the center, info action on the right.
- Empty body placeholder where the message list will render in the next PR.
- Input panel placeholder where the input field + send button will land in the next PR.
- Test tags on every interactive surface (`chat_thread.back_button`, `chat_thread.info_button`, `chat_thread.title`, `chat_thread.body`, `chat_thread.placeholder_text`, `chat_thread.input_panel_placeholder`, `chat_thread.missing`) so the future UI iteration has stable hooks.
- Missing-group state when the path-arg id doesn't resolve.

**`ChatThreadViewModel.kt`**
- `group: StateFlow<ChatGroup?>` resolves by id from `GroupRepository.snapshots`; `null` when missing.
- `messages: StateFlow<List<ChatMessage>>` drains `MessageRepository.snapshots(groupId)` into a hot flow the screen collects.
- `send(body)`: trims + dispatches through the captured `SendMessageInteractor`; routes errors into `lastSendError`; flips `sendInFlight` around the call. Empty / whitespace bodies short-circuit before reaching the interactor.
- `clearError()` / `sendInFlight` / `lastSendError` surface state the next PR's input panel will bind to without any VM changes.

**Wiring**
- `AppDependencies` gains `makeChatThreadViewModel: (groupId) -> ChatThreadViewModel`.
- `OnymApplication.buildDependencies()` constructs a fresh `SendMessageInteractor` per VM (interactor is stateless; the closure captures `identityRepository` / `messageRepository` / `inboxTransport` so the VM constructor stays narrow).
- `RootScreen.NavHost`: new `composable("chat_thread/{groupId}")` destination; `ChatsScreen.onOpenChat` rewired from `"chat_members/$groupId"` to `"chat_thread/$groupId"`. The info button on the thread navigates to the existing `chat_members` destination (one tap deeper, same screen as before).

## Divergence from iOS

iOS PR #151 wraps a UIKit `ChatThreadViewController` in a SwiftUI `UIViewControllerRepresentable` bridge because SwiftUI's nav primitives don't cover the diffable-data-source pattern UIKit needed for the message list. **Compose's `LazyColumn` + the existing M3 `TopAppBar` primitives cover what iOS reached for UIKit for, so the Android twin is a single Compose composable with no bridge.**

## Out of scope

- Message bubble rendering (next PR).
- Input panel + send button + keyboard handling (next PR).
- Auto-scroll to bottom on new message arrival (next PR).
- Routing the post-join-success callback from `JoinScreen` to the chat thread of the freshly-materialized group (separate polish PR — the existing `RootScreen` comment at the `join_invite` destination already calls out this future hook).

## Tests

- **`ChatThreadViewModelTest`** (9): group resolves by id, group `null` when missing, messages mirror `MessageRepository` snapshots, messages emit on `append`, send invokes interactor with trimmed body, send empty/whitespace short-circuited, send interactor throws routes into `lastSendError`, `clearError` resets, send success clears previous error.
- Full `:app:testDebugUnitTest` suite — **499 / 499 pass**, 0 failures, 0 errors, 0 regressions.
- `assembleDebug` builds cleanly (Compose code paths verified beyond unit-test compile).

## Visual correctness — NOT covered by tests

Layout, colors, and look-and-feel are not under test. Launch the app, tap a group: top bar shows the group name, back arrow pops, info button pushes the members screen, table view fills the body, input placeholder sits at the bottom safe area.

## Plan context

PR 5 of 5 in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor. Next slice (separate PR): message bubble rendering — Lazy column + custom bubble composable, subscribe to `messages` already exposed here, auto-scroll on append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)