### PR TITLE
feat(chats): message list rendering (PR 6/N chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
@@ -1,0 +1,95 @@
+package app.onym.android.chats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Chat-thread bubble. Two visual modes driven by [ChatMessage.direction]:
+ *
+ *  - [MessageDirection.OUTGOING] — `colorScheme.primary` fill,
+ *    `colorScheme.onPrimary` text, trailing-aligned.
+ *  - [MessageDirection.INCOMING] — `colorScheme.surfaceVariant`
+ *    fill, `colorScheme.onSurfaceVariant` text, leading-aligned.
+ *
+ * Bubble max width is capped at [maxWidthFraction] of the parent
+ * row (default 75%) so a long monologue doesn't reach the opposite
+ * edge. The cap is resolved via `BoxWithConstraints` so it tracks
+ * the real parent measurement — no hardcoded `Dp` ceiling.
+ *
+ * Compose's natural recomposition over the [ChatMessage] data class
+ * means a status flip (PENDING → SENT / FAILED) re-renders the
+ * bubble without any explicit diffable-identity widening — the
+ * outer `LazyColumn(items, key = { it.id })` keeps the slot stable;
+ * this body reads the latest fields.
+ *
+ * Status glyphs, timestamps, avatars, emoji rendering are out of
+ * scope for the read-only scrollback PR — they land in later
+ * polish slices.
+ *
+ * Mirrors `ChatBubbleCell.swift` from onym-ios PR #152, Compose-
+ * idiomatic: no constraint pairs, no cell reuse, no diffable data
+ * source — `BoxWithConstraints` + `LazyColumn(items, key = ...)`
+ * cover all three concerns.
+ */
+@Composable
+fun ChatBubble(
+    message: ChatMessage,
+    modifier: Modifier = Modifier,
+    maxWidthFraction: Float = 0.75f,
+) {
+    val isOutgoing = message.direction == MessageDirection.OUTGOING
+    val fill: Color = if (isOutgoing) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+    val textColor: Color = if (isOutgoing) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+    ) {
+        val bubbleMaxWidth = maxWidth * maxWidthFraction
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = if (isOutgoing) Arrangement.End else Arrangement.Start,
+        ) {
+            Box(
+                modifier = Modifier
+                    .widthIn(max = bubbleMaxWidth)
+                    .clip(RoundedCornerShape(BUBBLE_RADIUS))
+                    .background(fill)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .testTag("chat_thread.bubble.${message.id}"),
+            ) {
+                Text(
+                    text = message.body,
+                    color = textColor,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+private val BUBBLE_RADIUS = 16.dp

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
@@ -19,36 +22,38 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 /**
  * Compose chat-thread screen. Tapping a group in the Chats tab
- * opens this destination; the members list moves one tap deeper
- * behind the info action in the top bar.
+ * opens this destination; the members list is one tap deeper behind
+ * the info action in the top bar.
  *
- * Skeleton only — the message list and input panel are placeholders
- * that the next PR fills in (custom bubble cells, auto-scroll,
- * keyboard avoidance, send wiring through [ChatThreadViewModel.send]).
+ * Read-only message scrollback lands in this PR: bubble-rendered
+ * messages stream from [ChatThreadViewModel.messages] through a
+ * `LazyColumn` keyed by message id, with cold-open scroll-to-bottom
+ * and only-when-near-bottom auto-scroll on new arrivals so reading
+ * older messages doesn't get hijacked. Input panel + send button
+ * stays a placeholder — that's the next PR.
  *
- * The data plumbing is already in place via [ChatThreadViewModel]:
- * the screen collects [ChatThreadViewModel.messages] and
- * [ChatThreadViewModel.group] so when the rendering lands later it's
- * a UI-only diff.
- *
- * Mirrors `ChatThreadView.swift` from onym-ios PR #151 — same nav
- * surface (back + group name + info), same placeholder posture.
- * Diverges from iOS in being a single Compose composable rather
- * than a UIViewControllerRepresentable wrapping a UIKit
- * controller — Compose's nav-bar primitives + diffable LazyColumn
- * cover what iOS needed UIKit for, with no SwiftUI/UIKit-bridge tax.
+ * Mirrors `ChatThreadView.swift` from onym-ios PR #152. iOS uses a
+ * UIKit controller + `UITableViewDiffableDataSource`; Compose's
+ * `LazyColumn(items, key = ...)` covers the same data-diff
+ * concerns. The "scroll on cold open + only when near bottom"
+ * heuristic mirrors the iOS controller's logic in
+ * [shouldAutoScrollOnAppend].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -99,49 +104,137 @@ fun ChatThreadScreen(
             MissingGroup(padding = padding)
         } else {
             ChatThreadBody(
-                messageCount = messages.size,
+                messages = messages,
                 padding = padding,
             )
         }
     }
 }
 
-/** Empty placeholder body — message rendering + input panel land in
- *  the next PR. Surfaces the message count so the data plumbing is
- *  visibly wired through to the screen during the skeleton slice. */
 @Composable
 private fun ChatThreadBody(
-    messageCount: Int,
+    messages: List<ChatMessage>,
     padding: PaddingValues,
 ) {
+    val listState = rememberLazyListState()
+    // Defensive sort. The repository's contract is ascending by
+    // sentAtMillis, but a future caller / test stub regressing
+    // the order shouldn't surface as a visibly-misordered chat.
+    // Mirrors the iOS PR #152 fixup that added the same guard at
+    // the controller boundary.
+    val sortedMessages = remember(messages) {
+        messages.sortedBy { it.sentAtMillis }
+    }
+
+    // Auto-scroll behavior:
+    //   - cold open: jump to the latest message (no animation).
+    //   - subsequent appends: only scroll if the user was already
+    //     near the bottom (otherwise reading older messages would
+    //     get hijacked).
+    var hasInitialScrolled by remember { mutableStateOf(false) }
+    val nearBottom by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val total = info.totalItemsCount
+            val lastVisibleIndex = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+            isNearBottom(
+                totalItems = total,
+                lastVisibleIndex = lastVisibleIndex,
+            )
+        }
+    }
+    LaunchedEffect(sortedMessages.size) {
+        if (sortedMessages.isEmpty()) return@LaunchedEffect
+        val lastIndex = sortedMessages.lastIndex
+        if (!hasInitialScrolled) {
+            listState.scrollToItem(lastIndex)
+            hasInitialScrolled = true
+            return@LaunchedEffect
+        }
+        if (nearBottom) {
+            listState.animateScrollToItem(lastIndex)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
             .testTag("chat_thread.body"),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = if (messageCount == 0) {
-                    "No messages yet. Bubbles render in the next PR."
-                } else {
-                    "$messageCount message${if (messageCount == 1) "" else "s"} — rendering lands in the next PR."
-                },
-                fontSize = 13.sp,
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        if (sortedMessages.isEmpty()) {
+            EmptyThread(
                 modifier = Modifier
-                    .padding(horizontal = 32.dp)
-                    .testTag("chat_thread.placeholder_text"),
+                    .fillMaxWidth()
+                    .weight(1f),
             )
+        } else {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .testTag("chat_thread.message_list"),
+                contentPadding = PaddingValues(vertical = 8.dp),
+            ) {
+                // key = { it.id } keeps slot identity stable across
+                // recompositions; status flips re-render the bubble
+                // body because ChatMessage's equals() compares all
+                // fields. The iOS twin needed an explicit
+                // diffable-identity widen via reconfigureItems for
+                // the same property — Compose gives it for free.
+                items(
+                    items = sortedMessages,
+                    key = { it.id },
+                ) { message ->
+                    ChatBubble(message = message)
+                }
+            }
         }
         HorizontalDivider(thickness = 0.5.dp)
         InputPanelPlaceholder()
+    }
+}
+
+/**
+ * Heuristic for "is the user effectively scrolled to the bottom"
+ * — true when the last visible item index is within the threshold
+ * of the last item, or when the list is empty. Pure function so a
+ * unit test exercises the policy without standing up a
+ * `LazyListState` (which requires Compose's compositor).
+ *
+ * Wire-equivalent to the iOS controller's
+ * `contentOffset.y + frame.height >= contentSize.height - 100`
+ * check — same threshold semantics, expressed in item indices
+ * since Compose's LazyListState doesn't expose pixel offsets at
+ * the public API.
+ */
+internal fun isNearBottom(
+    totalItems: Int,
+    lastVisibleIndex: Int,
+    nearBottomThreshold: Int = NEAR_BOTTOM_INDEX_THRESHOLD,
+): Boolean {
+    if (totalItems == 0) return true
+    if (lastVisibleIndex < 0) return false
+    return lastVisibleIndex >= totalItems - nearBottomThreshold
+}
+
+/** Items-from-bottom window that counts as "near the bottom" for
+ *  the auto-scroll heuristic. 2 = the user is reading the last or
+ *  second-to-last message. */
+internal const val NEAR_BOTTOM_INDEX_THRESHOLD = 2
+
+@Composable
+private fun EmptyThread(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.testTag("chat_thread.empty"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "No messages yet. Say hi.",
+            fontSize = 13.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
@@ -1,0 +1,80 @@
+package app.onym.android.chats
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-policy tests for the chat-thread auto-scroll heuristic.
+ * Verifies the `isNearBottom` predicate without standing up a
+ * Compose `LazyListState` — the production composable wires this
+ * same function to `listState.layoutInfo` via a `derivedStateOf`.
+ *
+ * Mirrors `ChatThreadViewControllerTests`' `isNearBottom`
+ * assertions from onym-ios PR #152 — different transport (item
+ * index vs pixel offset) but the same three cases: empty, at end,
+ * scrolled up.
+ */
+class ChatThreadAutoScrollTest {
+
+    // ─── iOS-parity cases ────────────────────────────────────────
+
+    @Test
+    fun isNearBottom_emptyListIsNearBottom() {
+        assertTrue(
+            "an empty list counts as 'at the bottom' so cold opens auto-scroll",
+            isNearBottom(totalItems = 0, lastVisibleIndex = -1),
+        )
+    }
+
+    @Test
+    fun isNearBottom_lastIndexIsVisible_isNearBottom() {
+        // 50 messages, last visible is index 49 — user is reading
+        // the latest message.
+        assertTrue(isNearBottom(totalItems = 50, lastVisibleIndex = 49))
+    }
+
+    @Test
+    fun isNearBottom_scrolledUp_isFalse() {
+        // 50 messages, last visible is somewhere in the middle.
+        assertFalse(isNearBottom(totalItems = 50, lastVisibleIndex = 10))
+    }
+
+    // ─── threshold edges ─────────────────────────────────────────
+
+    @Test
+    fun isNearBottom_oneItemFromEnd_isNearBottom() {
+        // Threshold = 2 → "last index OR second-to-last index"
+        // counts as near. lastVisibleIndex = 48 with 50 total →
+        // 48 >= 50 - 2 = 48, true.
+        assertTrue(isNearBottom(totalItems = 50, lastVisibleIndex = 48))
+    }
+
+    @Test
+    fun isNearBottom_twoItemsFromEnd_isNotNearBottom() {
+        // lastVisibleIndex = 47 with 50 total → 47 < 48, false.
+        // User is reading the third-to-last message — far enough
+        // away that a new arrival shouldn't hijack their scroll.
+        assertFalse(isNearBottom(totalItems = 50, lastVisibleIndex = 47))
+    }
+
+    @Test
+    fun isNearBottom_noVisibleIndexYet_isFalse() {
+        // lastVisibleIndex = -1 means the list has items but the
+        // layout pass hasn't measured anything yet. We only auto-
+        // scroll on a known-stable measurement, so this is
+        // conservative-false.
+        assertFalse(isNearBottom(totalItems = 5, lastVisibleIndex = -1))
+    }
+
+    // ─── threshold knob ──────────────────────────────────────────
+
+    @Test
+    fun isNearBottom_customThreshold() {
+        // With a threshold of 5, the "near bottom" window widens:
+        // lastVisibleIndex = 44 with 50 total → 44 >= 45, false;
+        // lastVisibleIndex = 45 → 45 >= 45, true.
+        assertFalse(isNearBottom(totalItems = 50, lastVisibleIndex = 44, nearBottomThreshold = 5))
+        assertTrue(isNearBottom(totalItems = 50, lastVisibleIndex = 45, nearBottomThreshold = 5))
+    }
+}


### PR DESCRIPTION
**Stacked on #145.** Read-only chat scrollback. Messages from `MessageRepository` flow through the VM into a `LazyColumn` and render as direction-styled bubbles. **No input or send yet** — that's the next PR. Mirrors [onym-ios PR #152](https://github.com/onymchat/onym-ios/pull/152).

## What's in here

### `ChatBubble.kt` (new Compose composable)

Two visual modes driven by `ChatMessage.direction`:
- `OUTGOING` → `colorScheme.primary` fill, `onPrimary` text, trailing-aligned.
- `INCOMING` → `colorScheme.surfaceVariant` fill, `onSurfaceVariant` text, leading-aligned.

Bubble max width is capped at 75% of the parent row via `BoxWithConstraints` — tracks the real measurement, no hardcoded `Dp` ceiling.

### `ChatThreadScreen.kt`

Body placeholder replaced with a real `LazyColumn(items, key = { it.id })`. Compose's stable-key `items()` covers the same data-diff concerns iOS reached for `UITableViewDiffableDataSource` for; status flips (`PENDING → SENT / FAILED`) re-render the bubble naturally because `ChatMessage.equals` compares all fields — no explicit diffable-identity widening needed.

**Auto-scroll** mirrors iOS:
- **Cold open** (first render with any messages): non-animated jump to the latest message via `scrollToItem(lastIndex)`. Guarded by a remembered `hasInitialScrolled` flag.
- **Subsequent appends**: only `animateScrollToItem(lastIndex)` if the user was already near the bottom (threshold = 2 items from the end). Reading older messages doesn't get hijacked.

The near-bottom check rides on a `derivedStateOf` over `listState.layoutInfo` so it only recomputes when the visible window or item count changes.

**Defensive sort** at the body composable level — `sortedBy { it.sentAtMillis }`. The repository's contract is ascending, but a defensive sort protects against a future caller / test stub regressing the order. Mirrors the iOS PR #152 fixup.

Empty-thread state ("No messages yet. Say hi.") replaces the prior PR's "Bubbles render in the next PR" placeholder. Input panel stays a placeholder — that's the next PR.

## Divergence from iOS

- **UIKit `ChatBubbleCell` + diffable data source → Compose `LazyColumn(items, key = { it.id })`.** No cell reuse, no Auto-Layout constraint pairs, no diffable-identity reconfigure for status flips — Compose's recomposition over the data class handles all three for free. The iOS fixup commit's biggest item (resolving the Auto-Layout conflict between always-active gap constraints and toggled-pin alignment) doesn't exist as a problem on Compose.
- **iOS `preferredFont(forTextStyle: .body)` → `MaterialTheme.typography.bodyMedium`.** Both pick up the system text-size accessibility setting; same a11y posture by default.
- **Pixel-offset `contentOffset` near-bottom check → item-index near-bottom check.** Compose's `LazyListState` doesn't expose pixel offsets at the public API, so the heuristic is expressed in item indices. Threshold = 2 items ≈ the iOS 100pt threshold for a typical bubble row height.

## What's NOT in here

- Input UI / send wiring (next PR).
- Keyboard avoidance (next PR).
- "↓ new messages" pill — deferred polish; for now, messages that arrive while the user is scrolled up appear without disrupting their position (matches iOS's same deferral).
- Avatars, timestamps, status glyphs, emoji rendering (later PRs).

## Tests

- **`ChatThreadAutoScrollTest`** (7): pure-policy tests for `isNearBottom` — empty list is true, last index visible is true, scrolled up is false, threshold edges (one-from-end is near; two-from-end is not), no-visible-index-yet is conservative-false, custom-threshold knob.
- The visual rendering and auto-scroll integration are NOT under test (matches iOS's "Visual correctness — verify in simulator" posture); the unit-testable policy lives in the pure `isNearBottom` function which the composable wires via `derivedStateOf`.
- Full `:app:testDebugUnitTest` suite — **506 / 506 pass**, 0 failures, 0 errors, 0 regressions.
- `assembleDebug` builds cleanly.

## Visual correctness — NOT covered by tests

Bubble shape, colors, scroll behavior: launch the app, open a chat. Easiest end-to-end demo: two devices in the same Tyranny group, send a message from one, watch it land on the other. The receive path is already covered by `IncomingMessageDispatcherChatMessageTest` in #144.

## Plan context

PR 6 of N in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor • **PR A5** (#145) Compose chat-thread shell. **Next PR**: input panel + send wiring — `TextField` + send button + keyboard handling, hook the Send button to the `ChatThreadViewModel.send` method which already routes through `SendMessageInteractor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)