### PR TITLE
feat(chats): input panel + keyboard avoidance (PR 7/N chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
@@ -1,0 +1,137 @@
+package app.onym.android.chats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+
+/**
+ * Chat-thread composer. A `TextField` that grows to a 3-line cap
+ * (then scrolls internally) with a trailing Send button. Tapping
+ * Send fires [onSend] with the body trimmed of leading and trailing
+ * whitespace, then clears the field. Whitespace-only input never
+ * fires the callback — the button stays disabled and the trim guard
+ * in [trimmedSendBody] is the belt-plus-braces check.
+ *
+ * Keyboard avoidance is the parent's responsibility: place this
+ * inside a `Modifier.imePadding()`-bounded layout. With no keyboard
+ * up the padding is zero; when the keyboard rises the parent
+ * automatically slides up — same affordance as iOS's
+ * `view.keyboardLayoutGuide.topAnchor`.
+ *
+ * Text state is held internally via `remember { mutableStateOf("") }`.
+ * The caller has no view on the in-flight body; it only sees the
+ * post-send callback. A future "draft persistence" surface (next PR
+ * or beyond) could hoist this state into the ViewModel.
+ *
+ * Mirrors `ChatInputPanelView.swift` from onym-ios PR #153. Diverges
+ * in two ways the platform invites:
+ *  - No manual `intrinsicContentSize` measurement — `OutlinedTextField`
+ *    + `maxLines = 3` natively grows-then-scrolls.
+ *  - No `keyboardLayoutGuide` plumbing — `Modifier.imePadding()` on
+ *    the parent does the same job declaratively.
+ */
+@Composable
+fun ChatInputPanel(
+    onSend: (body: String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    maxLines: Int = MAX_LINES,
+) {
+    var text by remember { mutableStateOf("") }
+    val sendBody = trimmedSendBody(text)
+    val canSend = enabled && sendBody != null
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag("chat_thread.input_panel"),
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it },
+            modifier = Modifier
+                .weight(1f)
+                .clip(RoundedCornerShape(BUBBLE_CORNER))
+                .testTag("chat_thread.input_field"),
+            enabled = enabled,
+            placeholder = { Text("Message") },
+            maxLines = maxLines,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Sentences,
+                imeAction = ImeAction.Default,
+            ),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+            shape = RoundedCornerShape(BUBBLE_CORNER),
+        )
+        FilledIconButton(
+            onClick = {
+                val body = trimmedSendBody(text) ?: return@FilledIconButton
+                onSend(body)
+                text = ""
+            },
+            enabled = canSend,
+            colors = IconButtonDefaults.filledIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+            modifier = Modifier.testTag("chat_thread.send_button"),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Send,
+                contentDescription = "Send",
+            )
+        }
+    }
+}
+
+/**
+ * Trims [text] of leading and trailing whitespace and returns the
+ * result if non-empty, or `null` otherwise. The send button's
+ * enabled state and the actual send invocation both consult this
+ * — UI never ships a whitespace-only body. Extracted as a pure
+ * function so the policy is unit-testable without standing up
+ * Compose.
+ */
+internal fun trimmedSendBody(text: String): String? =
+    text.trim().takeIf { it.isNotEmpty() }
+
+/** Max line count the composer grows to before scrolling internally.
+ *  3 matches the iOS twin. Exposed via the [ChatInputPanel.maxLines]
+ *  parameter so a future "fullscreen composer" mode can override. */
+internal const val MAX_LINES = 3
+
+private val BUBBLE_CORNER = 20.dp

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -31,7 +31,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -160,6 +159,7 @@ private fun ChatThreadBody(
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
+            .imePadding()  // slides the input panel above the soft keyboard
             .testTag("chat_thread.body"),
     ) {
         if (sortedMessages.isEmpty()) {
@@ -192,7 +192,11 @@ private fun ChatThreadBody(
             }
         }
         HorizontalDivider(thickness = 0.5.dp)
-        InputPanelPlaceholder()
+        // PR A7 wires the input panel UI but not the send path —
+        // tap clears the field, the body is discarded. Next PR
+        // swaps the closure for `viewModel.send` (already wired on
+        // the VM from PR A5).
+        ChatInputPanel(onSend = { _ -> })
     }
 }
 
@@ -233,25 +237,6 @@ private fun EmptyThread(modifier: Modifier = Modifier) {
         Text(
             text = "No messages yet. Say hi.",
             fontSize = 13.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@Composable
-private fun InputPanelPlaceholder() {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(56.dp)
-            .padding(horizontal = 16.dp)
-            .testTag("chat_thread.input_panel_placeholder"),
-        contentAlignment = Alignment.CenterStart,
-    ) {
-        Text(
-            text = "Message input lands in the next PR",
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Medium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }

--- a/app/src/test/kotlin/app/onym/android/chats/ChatInputPanelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatInputPanelTest.kt
@@ -1,0 +1,77 @@
+package app.onym.android.chats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-policy tests for the chat-input panel's send-enable +
+ * trimming logic. Verifies the [trimmedSendBody] predicate without
+ * standing up Compose — the production composable calls this same
+ * function to derive both the Send button's `enabled` state and
+ * the actual body it hands to the `onSend` callback.
+ *
+ * Mirrors `ChatInputPanelViewTests`' send-enable + whitespace
+ * assertions from onym-ios PR #153 (`initialState_sendDisabled`,
+ * `setText_*_send*`, `tapSend_whitespace_isNoOp`). The auto-grow
+ * cap is handled natively by `OutlinedTextField(maxLines = 3)` on
+ * Compose, so there's no Android equivalent of iOS's
+ * `intrinsicHeight(forLines: N)` test.
+ */
+class ChatInputPanelTest {
+
+    // ─── send-enable policy ──────────────────────────────────────
+
+    @Test
+    fun trimmedSendBody_emptyString_isNull() {
+        assertNull(trimmedSendBody(""))
+    }
+
+    @Test
+    fun trimmedSendBody_whitespaceOnly_isNull() {
+        assertNull(trimmedSendBody("   "))
+        assertNull(trimmedSendBody("\t"))
+        assertNull(trimmedSendBody("\n  \t  \n"))
+    }
+
+    @Test
+    fun trimmedSendBody_nonEmptyAfterTrim_returnsTrimmedBody() {
+        assertEquals("hi", trimmedSendBody("hi"))
+        assertEquals("hi", trimmedSendBody("  hi  "))
+        assertEquals("hi world", trimmedSendBody("\thi world\n"))
+    }
+
+    @Test
+    fun trimmedSendBody_internalWhitespace_isPreserved() {
+        // Only leading + trailing whitespace is trimmed; spaces
+        // inside the body are user content and ride through.
+        assertEquals("hello   world", trimmedSendBody("  hello   world  "))
+    }
+
+    @Test
+    fun trimmedSendBody_unicodeBody_roundTrips() {
+        assertEquals("héllo 🌍", trimmedSendBody("  héllo 🌍  "))
+    }
+
+    // ─── enabled flag derivation (same predicate, asserted via
+    //     the not-null shape that ChatInputPanel uses) ────────────
+
+    @Test
+    fun isSendEnabled_emptyAndWhitespace_isFalse() {
+        assertFalse(isSendEnabled(""))
+        assertFalse(isSendEnabled("   "))
+    }
+
+    @Test
+    fun isSendEnabled_nonEmpty_isTrue() {
+        assertTrue(isSendEnabled("hi"))
+        assertTrue(isSendEnabled("  hi  "))
+    }
+
+    /** Sugar over [trimmedSendBody] — the Send button enables iff
+     *  the trim leaves a non-empty body. Lives in the test so the
+     *  policy assertion reads the same way the composable does. */
+    private fun isSendEnabled(text: String): Boolean = trimmedSendBody(text) != null
+}


### PR DESCRIPTION
**Stacked on #146.** Composer is real now. An `OutlinedTextField` that grows to a 3-line cap, a trailing Send button, and `Modifier.imePadding()` on the body column so the panel rides with the soft keyboard. **No real send wiring yet** — tap clears the field; the body is discarded. Next PR swaps the no-op closure for `viewModel.send` (already wired through `SendMessageInteractor` in PR A4). Mirrors [onym-ios PR #153](https://github.com/onymchat/onym-ios/pull/153).

## `ChatInputPanel`

- `OutlinedTextField` + `FilledIconButton`. Material 3 throughout.
- `"Message"` placeholder via `TextField`'s built-in `placeholder` slot — no manual overlay label needed.
- **Auto-grow** up to `maxLines = 3`, then scrolls internally. Compose's `TextField` does this natively; no intrinsic-size measurement, no `layoutIfNeeded()` flushes (no TextKit-2 staleness bug to fight).
- `onSend(body)` fires with the body trimmed of leading + trailing whitespace. Whitespace-only input never reaches the callback:
  - the `FilledIconButton` is `enabled = canSend` where `canSend` consults the trim, and
  - the click handler re-runs the trim as belt-plus-braces and returns early if the body is `null`.
- Text state is internal via `remember { mutableStateOf("") }`. The composable clears itself after firing `onSend`. A future "draft persistence" PR can hoist the state into the VM.

## `ChatThreadScreen` wire-up

- Replaced `InputPanelPlaceholder()` with `ChatInputPanel(onSend = { _ -> })`.
- Added `Modifier.imePadding()` to the body column. With no keyboard up the padding is zero; when the keyboard rises the panel slides automatically. Same affordance as iOS's `keyboardLayoutGuide`.
- `enableEdgeToEdge()` was already on in `MainActivity` (existing setup); `imePadding()` relies on that.

## Divergence from iOS

- **`UITextView` + manual `intrinsicContentSize` measurement → `OutlinedTextField(maxLines = 3)`.** Compose's `TextField` grows then scrolls natively.
- **`view.keyboardLayoutGuide.topAnchor` → `Modifier.imePadding()`.** Declarative; no notification observers, no frame math.
- **Manual placeholder `UILabel` overlay → `TextField`'s `placeholder` slot.**
- **TextKit-2 `layoutIfNeeded()` workaround doesn't apply** — Compose has no equivalent stale-measurement issue.

## Tests

- **`ChatInputPanelTest`** (7): pure-policy tests for `trimmedSendBody`. Empty / whitespace-only returns `null`; non-empty after trim returns the trimmed body; internal whitespace preserved; unicode round-trips. Plus a small wrapper-test that asserts the Send-enabled derivation matches the `trimmedSendBody-is-non-null` shape the composable uses.
- The visual rendering, keyboard slide animation, and 3-line cap are NOT under test (matches iOS's "Visual correctness — verify in simulator" posture). The unit-testable policy lives in the pure `trimmedSendBody` function.
- Full `:app:testDebugUnitTest` suite — **513 / 513 pass**, 0 failures, 0 errors, 0 regressions.
- `assembleDebug` builds cleanly.

## Visual correctness — NOT covered by tests

Type-while-keyboard-shown layout, keyboard slide animation, the 3-line growth cap before scrolling, Dynamic Type scaling: launch the app, tap a group, tap the field, type, hit Send → the field should clear and the keyboard stays up.

## Plan context

PR 7 of N in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor • **PR A5** (#145) Compose chat-thread shell • **PR A6** (#146) message list rendering. **Next PR**: swap `onSend = { _ -> }` for `viewModel.send(body)` — single-line change; the VM already plumbs the call through `SendMessageInteractor` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)