### PR TITLE
feat(chats): wire Send button to viewModel.send (PR 8/N chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -105,6 +105,7 @@ fun ChatThreadScreen(
             ChatThreadBody(
                 messages = messages,
                 padding = padding,
+                onSend = viewModel::send,
             )
         }
     }
@@ -114,6 +115,7 @@ fun ChatThreadScreen(
 private fun ChatThreadBody(
     messages: List<ChatMessage>,
     padding: PaddingValues,
+    onSend: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
     // Defensive sort. The repository's contract is ascending by
@@ -192,11 +194,14 @@ private fun ChatThreadBody(
             }
         }
         HorizontalDivider(thickness = 0.5.dp)
-        // PR A7 wires the input panel UI but not the send path —
-        // tap clears the field, the body is discarded. Next PR
-        // swaps the closure for `viewModel.send` (already wired on
-        // the VM from PR A5).
-        ChatInputPanel(onSend = { _ -> })
+        // PR A8 wires the Send button end-to-end. The VM's send
+        // does the trim guard + optimistic insert + status flip
+        // through SendMessageInteractor (PR A4). SendMessageError
+        // routes into viewModel.lastSendError, which the UI doesn't
+        // surface yet — network / fan-out failures land as
+        // MessageStatus.FAILED on the bubble (visual indicator
+        // lands in a later PR).
+        ChatInputPanel(onSend = onSend)
     }
 }
 


### PR DESCRIPTION
**Stacked on #147.** End-to-end. Type a message, tap Send, see it appear in the thread immediately and propagate to the other group members. Mirrors [onym-ios PR #154](https://github.com/onymchat/onym-ios/pull/154).

## What's in here

Three-line edit. PR A4 already built `SendMessageInteractor` with the full optimistic-insert / fan-out / status-flip lifecycle, and PR A5 wired it into `ChatThreadViewModel.send`. The body itself is internal to the input panel (PR A7's `remember { mutableStateOf("") }`), so this PR is just the lambda swap: `ChatInputPanel(onSend = onSend)` where `onSend` in the parent is `viewModel::send`. The heavy plumbing was done two PRs ago.

## UX flow

1. User types "hi" → Send button enables (PR A7 trim gate).
2. Tap Send → `ChatInputPanel` forwards the trimmed body to `onSend`.
3. `viewModel.send(body)` → `SendMessageInteractor` inserts a `PENDING` row into `MessageRepository` **before** the network await.
4. `MessageRepository.snapshots` emits → PR A6's `LazyColumn(key = id)` reconciles → bubble appears + auto-scroll triggers.
5. Input clears immediately (panel's own clear-after-onSend logic — snappier than waiting for the await).
6. Network round-trip resolves → interactor flips status to `SENT` / `FAILED`. The status visual indicator on the bubble lands in a later PR.

`SendMessageError` cases (no identity loaded, unknown group, not a member, empty body) all represent invariants that should hold mid-chat-screen and route into `viewModel.lastSendError`, which the UI doesn't surface yet. Network / fan-out failures land as `MessageStatus.FAILED` on the bubble — mirrors iOS PR #154's same swallow-and-defer-to-status posture.

## Divergence from iOS

iOS PR #154 threads `sendMessageInteractor` through `AppDependencies` → `RootView` → `ChatsView` → `ChatThreadView` and exposes `onSendTapped` on the `ChatThreadViewController`. Android's equivalent is already in place from PR A5: the `makeChatThreadViewModel` factory in `OnymApplication` captures the interactor in a closure; the VM exposes `send(body)`. **PR A8 is just the lambda swap in the screen.**

## Tests

The wire-up itself is a one-line lambda in a Compose composable; testing it directly requires Compose UI tests (androidTest). All three layers it composes are already tested by earlier PRs in this stack:

- `viewModel.send` is covered by **PR A5**'s `ChatThreadViewModelTest` (9 tests verify the trim + error routing).
- `SendMessageInteractor` is covered by **PR A4**'s `SendMessageInteractorTest` (9 tests verify optimistic insert + fan-out + status flip).
- `ChatInputPanel`'s trim policy is covered by **PR A7**'s `ChatInputPanelTest` (7 tests).
- Full `:app:testDebugUnitTest` suite — **513 / 513 pass**, 0 failures, 0 errors, 0 regressions.
- `assembleDebug` builds cleanly.

## Visual / end-to-end correctness — NOT covered by tests

Bubble appearance timing, status flip animation, table auto-scroll on send: verify in the emulator with two devices in the same Tyranny group to confirm the full round-trip works.

## Plan context

PR 8 of N in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor • **PR A5** (#145) Compose chat-thread shell • **PR A6** (#146) message list rendering • **PR A7** (#147) input panel + keyboard avoidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)