### PR TITLE
feat(chats): message status indicator + retry on failed (PR 9/N chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -586,6 +586,7 @@ class OnymApplication : Application() {
                     groupRepository = groupRepository,
                     messageRepository = messageRepository,
                     sendMessage = sender::send,
+                    retryMessage = sender::retry,
                 )
             },
             makeIdentitiesViewModel = {

--- a/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
@@ -1,20 +1,30 @@
 package app.onym.android.chats
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
@@ -22,35 +32,38 @@ import androidx.compose.ui.unit.dp
  * Chat-thread bubble. Two visual modes driven by [ChatMessage.direction]:
  *
  *  - [MessageDirection.OUTGOING] — `colorScheme.primary` fill,
- *    `colorScheme.onPrimary` text, trailing-aligned.
+ *    `colorScheme.onPrimary` text, trailing-aligned. Status glyph
+ *    below the trailing edge (clock / check / red bang).
  *  - [MessageDirection.INCOMING] — `colorScheme.surfaceVariant`
  *    fill, `colorScheme.onSurfaceVariant` text, leading-aligned.
+ *    No status indicator (the message arriving is proof of
+ *    delivery).
  *
  * Bubble max width is capped at [maxWidthFraction] of the parent
  * row (default 75%) so a long monologue doesn't reach the opposite
- * edge. The cap is resolved via `BoxWithConstraints` so it tracks
- * the real parent measurement — no hardcoded `Dp` ceiling.
+ * edge.
+ *
+ * Failed outgoing bubbles register a tap target that fires [onRetry]
+ * (when provided). Non-failed bubbles are unclickable — the gate
+ * lives inside [canRetry] so a stale tap that arrives after the
+ * status flipped to SENT is a silent no-op, not a double-delivery.
  *
  * Compose's natural recomposition over the [ChatMessage] data class
  * means a status flip (PENDING → SENT / FAILED) re-renders the
- * bubble without any explicit diffable-identity widening — the
- * outer `LazyColumn(items, key = { it.id })` keeps the slot stable;
- * this body reads the latest fields.
+ * bubble (and swaps the glyph) without any explicit
+ * diffable-identity widening — the outer `LazyColumn(items, key =
+ * { it.id })` keeps the slot stable; this body reads the latest
+ * fields. iOS PR #155 had to call `snapshot.reconfigureItems(...)`
+ * to close the equivalent gap; Compose covers it for free.
  *
- * Status glyphs, timestamps, avatars, emoji rendering are out of
- * scope for the read-only scrollback PR — they land in later
- * polish slices.
- *
- * Mirrors `ChatBubbleCell.swift` from onym-ios PR #152, Compose-
- * idiomatic: no constraint pairs, no cell reuse, no diffable data
- * source — `BoxWithConstraints` + `LazyColumn(items, key = ...)`
- * cover all three concerns.
+ * Mirrors `ChatBubbleCell.swift` from onym-ios PR #155.
  */
 @Composable
 fun ChatBubble(
     message: ChatMessage,
     modifier: Modifier = Modifier,
     maxWidthFraction: Float = 0.75f,
+    onRetry: (() -> Unit)? = null,
 ) {
     val isOutgoing = message.direction == MessageDirection.OUTGOING
     val fill: Color = if (isOutgoing) {
@@ -63,6 +76,7 @@ fun ChatBubble(
     } else {
         MaterialTheme.colorScheme.onSurfaceVariant
     }
+    val retryEnabled = canRetry(message) && onRetry != null
 
     BoxWithConstraints(
         modifier = modifier
@@ -74,22 +88,134 @@ fun ChatBubble(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = if (isOutgoing) Arrangement.End else Arrangement.Start,
         ) {
-            Box(
-                modifier = Modifier
-                    .widthIn(max = bubbleMaxWidth)
-                    .clip(RoundedCornerShape(BUBBLE_RADIUS))
-                    .background(fill)
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
-                    .testTag("chat_thread.bubble.${message.id}"),
+            Column(
+                horizontalAlignment = if (isOutgoing) Alignment.End else Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                modifier = Modifier.widthIn(max = bubbleMaxWidth),
             ) {
-                Text(
-                    text = message.body,
-                    color = textColor,
-                    style = MaterialTheme.typography.bodyMedium,
+                BubbleBody(
+                    body = message.body,
+                    fill = fill,
+                    textColor = textColor,
+                    messageId = message.id,
+                    onClick = if (retryEnabled) onRetry else null,
                 )
+                if (isOutgoing) {
+                    val visual = statusVisualFor(message.status)
+                    if (visual != null) {
+                        StatusIndicator(
+                            visual = visual,
+                            messageId = message.id,
+                        )
+                    }
+                }
             }
         }
     }
 }
 
+@Composable
+private fun BubbleBody(
+    body: String,
+    fill: Color,
+    textColor: Color,
+    messageId: java.util.UUID,
+    onClick: (() -> Unit)?,
+) {
+    val baseModifier = Modifier
+        .clip(RoundedCornerShape(BUBBLE_RADIUS))
+        .background(fill)
+    val clickableModifier = if (onClick != null) {
+        baseModifier.clickable(onClick = onClick)
+    } else {
+        baseModifier
+    }
+    Box(
+        modifier = clickableModifier
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag("chat_thread.bubble.$messageId"),
+    ) {
+        Text(
+            text = body,
+            color = textColor,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun StatusIndicator(
+    visual: StatusVisual,
+    messageId: java.util.UUID,
+) {
+    val tint = when (visual.tint) {
+        ChatStatusTint.Muted -> MaterialTheme.colorScheme.onSurfaceVariant
+        ChatStatusTint.Error -> MaterialTheme.colorScheme.error
+    }
+    Icon(
+        imageVector = visual.icon,
+        contentDescription = visual.contentDescription,
+        tint = tint,
+        modifier = Modifier
+            .size(STATUS_ICON_SIZE)
+            .padding(end = 4.dp)
+            .testTag("chat_thread.status.$messageId"),
+    )
+}
+
+/**
+ * Pure-data view of the glyph + tint a given [MessageStatus] should
+ * surface on an outgoing bubble. Pure function so a unit test can
+ * pin the mapping without standing up Compose.
+ *
+ * Returns `null` for [MessageStatus.RECEIVED] — that combination
+ * (outgoing + received) shouldn't occur in practice, but a
+ * defensive `null` means the bubble silently skips the indicator
+ * rather than rendering a wrong glyph.
+ */
+internal fun statusVisualFor(status: MessageStatus): StatusVisual? = when (status) {
+    MessageStatus.PENDING -> StatusVisual(
+        icon = Icons.Outlined.Schedule,
+        tint = ChatStatusTint.Muted,
+        contentDescription = "Sending",
+    )
+    MessageStatus.SENT -> StatusVisual(
+        icon = Icons.Filled.Check,
+        tint = ChatStatusTint.Muted,
+        contentDescription = "Sent",
+    )
+    MessageStatus.FAILED -> StatusVisual(
+        icon = Icons.Filled.ErrorOutline,
+        tint = ChatStatusTint.Error,
+        contentDescription = "Failed — tap to retry",
+    )
+    MessageStatus.RECEIVED -> null
+}
+
+/**
+ * Retry-eligibility predicate. Pure function so the unit test can
+ * pin the gate without standing up Compose — the production
+ * composable consults this exact policy to decide whether to
+ * register a tap target on the bubble.
+ *
+ * Failed outgoing rows are retryable; everything else is a no-op.
+ * The interactor's [SendMessageInteractor.retry] enforces the same
+ * gate so a stale tap that arrives after a status flip can't
+ * double-deliver.
+ */
+internal fun canRetry(message: ChatMessage): Boolean =
+    message.direction == MessageDirection.OUTGOING &&
+        message.status == MessageStatus.FAILED
+
+/** Visual metadata for the status glyph that sits below an
+ *  outgoing bubble. */
+internal data class StatusVisual(
+    val icon: ImageVector,
+    val tint: ChatStatusTint,
+    val contentDescription: String,
+)
+
+internal enum class ChatStatusTint { Muted, Error }
+
 private val BUBBLE_RADIUS = 16.dp
+private val STATUS_ICON_SIZE = 14.dp

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -106,6 +106,7 @@ fun ChatThreadScreen(
                 messages = messages,
                 padding = padding,
                 onSend = viewModel::send,
+                onRetry = viewModel::retry,
             )
         }
     }
@@ -116,6 +117,7 @@ private fun ChatThreadBody(
     messages: List<ChatMessage>,
     padding: PaddingValues,
     onSend: (String) -> Unit,
+    onRetry: (java.util.UUID) -> Unit,
 ) {
     val listState = rememberLazyListState()
     // Defensive sort. The repository's contract is ascending by
@@ -189,7 +191,10 @@ private fun ChatThreadBody(
                     items = sortedMessages,
                     key = { it.id },
                 ) { message ->
-                    ChatBubble(message = message)
+                    ChatBubble(
+                        message = message,
+                        onRetry = { onRetry(message.id) },
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
@@ -32,6 +32,7 @@ class ChatThreadViewModel(
     private val groupRepository: GroupRepository,
     private val messageRepository: MessageRepository,
     private val sendMessage: suspend (groupId: String, body: String) -> Unit,
+    private val retryMessage: suspend (groupId: String, messageId: java.util.UUID) -> Unit = { _, _ -> },
 ) : ViewModel() {
 
     /** Latest snapshot of the [ChatGroup] this thread renders.
@@ -92,4 +93,23 @@ class ChatThreadViewModel(
     }
 
     fun clearError() { _lastSendError.value = null }
+
+    /**
+     * Fire-and-forget retry on a previously-failed outgoing message.
+     * No-op (silent) for unknown / non-failed / non-outgoing ids —
+     * the interactor's [SendMessageInteractor.retry] enforces the
+     * same gates. Failures during the retry's network round-trip
+     * land back as `MessageStatus.FAILED` on the same row, which the
+     * bubble's status glyph reflects naturally.
+     */
+    fun retry(messageId: java.util.UUID) {
+        viewModelScope.launch {
+            try {
+                retryMessage(groupId, messageId)
+            } catch (_: Throwable) {
+                // Retry is silent — any thrown error from the
+                // interactor surfaces as FAILED on the row instead.
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
@@ -94,6 +94,13 @@ class MessageRepository(
     }
 
     /**
+     * Look up one message by id. Goes through the store, not the
+     * cache, so the retry-on-failed path doesn't depend on the chat
+     * thread being currently subscribed.
+     */
+    suspend fun findById(id: UUID): ChatMessage? = store.findById(id)
+
+    /**
      * Persist [message] and emit on the corresponding group's
      * cached flow. Idempotent on [ChatMessage.id] — a re-delivery
      * (same wire `messageId`) is a no-op: returns `false`, skips the

--- a/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageStore.kt
@@ -19,6 +19,11 @@ interface MessageStore {
      *  the chat-thread read path. */
     suspend fun listForGroup(ownerIdentityId: String, groupId: String): List<ChatMessage>
 
+    /** Single-message lookup by id. Returns `null` for unknown ids.
+     *  Drives the retry-on-failed path on
+     *  [app.onym.android.chats.SendMessageInteractor.retry]. */
+    suspend fun findById(id: UUID): ChatMessage?
+
     /** Idempotent insert on [ChatMessage.id]. Returns `true` on a
      *  fresh write, `false` when the row already exists. Nostr
      *  re-delivery of the same wire `messageId` becomes a no-op at

--- a/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
@@ -31,6 +31,10 @@ class RoomMessageStore(
         dao.listForOwnerAndGroup(ownerIdentityId, groupId).mapNotNull(::decode)
     }
 
+    override suspend fun findById(id: UUID): ChatMessage? = withContext(ioDispatcher) {
+        dao.findById(id.toString())?.let(::decode)
+    }
+
     override suspend fun insert(message: ChatMessage): Boolean =
         withContext(ioDispatcher) {
             // OnConflictStrategy.IGNORE returns -1 on a PK clash.

--- a/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
@@ -113,22 +113,108 @@ class SendMessageInteractor(
         )
         messageRepository.append(pending)
 
+        val recipients = recipientInboxKeysFor(group, myBlsHex)
+        val finalStatus = try {
+            val successCount = fanOut(payload, recipients)
+            if (recipients.isEmpty() || successCount > 0) MessageStatus.SENT
+            else MessageStatus.FAILED
+        } catch (e: EncodingException) {
+            messageRepository.updateStatus(messageId, MessageStatus.FAILED)
+            throw SendMessageError.EncodingFailed(e.message ?: e.javaClass.simpleName)
+        }
+        messageRepository.updateStatus(messageId, finalStatus)
+
+        pending.copy(status = finalStatus)
+    }
+
+    /**
+     * Retry a previously-failed outgoing message. No-op (silent) for
+     * unknown / non-failed / non-outgoing rows — closes the
+     * double-delivery hole where a tap on a row that already flipped
+     * to SENT (status-flip race vs UI) would ship a second envelope.
+     *
+     * On a valid retry:
+     *  1. Flip status to PENDING immediately so the UI glyph swaps
+     *     to the in-flight clock before any network work.
+     *  2. Re-fan-out using the **original** payload fields (same
+     *     messageId + body + sentAtMillis) so receivers' dispatcher
+     *     dedup against any prior delivery
+     *     (`MessageRepository.append`'s id-keyed `IGNORE` strategy
+     *     handles this on the receive side).
+     *  3. Flip to SENT / FAILED on completion.
+     *
+     * Mirrors `SendMessageInteractor.retry(groupID:messageID:)` from
+     * onym-ios PR #155.
+     */
+    suspend fun retry(groupId: String, messageId: java.util.UUID) = withContext(ioDispatcher) {
+        val message = messageRepository.findById(messageId) ?: return@withContext
+        if (message.direction != MessageDirection.OUTGOING) return@withContext
+        if (message.status != MessageStatus.FAILED) return@withContext
+        if (message.groupId != groupId) return@withContext
+
+        val activeIdentityId = activeIdentity.currentIdentityId.value ?: return@withContext
+        val activeSummary = identitiesFlow.value.firstOrNull { it.id == activeIdentityId }
+            ?: return@withContext
+        val group = groupRepository.findForOwner(activeIdentityId.value, groupId)
+            ?: return@withContext
+        val myBlsHex = activeSummary.blsPublicKey.toHexLowercase()
+        if (group.memberProfiles[myBlsHex] == null) return@withContext
+
+        // Re-derive the variant from the message's stored group type.
+        // Same governance gating as send — anything but Tyranny is
+        // silently dropped today; retry follows the same posture.
+        val variant: ChatMessageVariant = when (message.groupType) {
+            SepGroupType.TYRANNY -> ChatMessageVariant.Tyranny(body = message.body)
+            else -> return@withContext
+        }
+
+        // Flip to PENDING immediately so the glyph swaps to the
+        // in-flight clock before the network round-trip.
+        messageRepository.updateStatus(messageId, MessageStatus.PENDING)
+
+        // Preserve the original messageId + sentAt so receivers
+        // dedup against any prior delivery via their dispatcher.
+        val payload = ChatMessagePayload(
+            version = 1,
+            messageId = messageId,
+            groupId = group.groupIdBytes,
+            senderBlsPubkeyHex = myBlsHex,
+            sentAtMillis = message.sentAtMillis,
+            variant = variant,
+        )
+        val recipients = recipientInboxKeysFor(group, myBlsHex)
+        val finalStatus = try {
+            val successCount = fanOut(payload, recipients)
+            if (recipients.isEmpty() || successCount > 0) MessageStatus.SENT
+            else MessageStatus.FAILED
+        } catch (_: EncodingException) {
+            MessageStatus.FAILED
+        }
+        messageRepository.updateStatus(messageId, finalStatus)
+    }
+
+    /**
+     * Encode the payload once and seal+ship per recipient. Returns
+     * the count of recipients whose envelope was accepted by at
+     * least one relay. Best-effort per recipient — a thrown
+     * seal/send for one peer is logged-by-silence and the loop
+     * moves on, mirroring [send]'s pre-extraction behavior.
+     *
+     * Throws [EncodingException] if the payload itself can't be
+     * encoded (a programmer error — `Data`-keyed fields can't fail
+     * at JSON encode). Callers flip the message's status to FAILED
+     * and surface the error appropriately.
+     */
+    private suspend fun fanOut(
+        payload: ChatMessagePayload,
+        recipients: List<ByteArray>,
+    ): Int {
         val payloadBytes = try {
             jsonFormat.encodeToString(ChatMessagePayload.serializer(), payload)
                 .toByteArray(Charsets.UTF_8)
         } catch (e: Throwable) {
-            messageRepository.updateStatus(messageId, MessageStatus.FAILED)
-            throw SendMessageError.EncodingFailed(e.message ?: e.javaClass.simpleName)
+            throw EncodingException(e.message ?: e.javaClass.simpleName)
         }
-
-        // Fan out to every member's inbox except our own. Best-effort
-        // per recipient — one failed send doesn't doom the whole
-        // message; we flip to SENT if at least one relay accepted
-        // any envelope.
-        val recipients = group.memberProfiles
-            .filterKeys { it != myBlsHex }
-            .map { (_, profile) -> profile.inboxPublicKey }
-
         var successCount = 0
         for (inboxKey in recipients) {
             val sealed = try {
@@ -144,14 +230,17 @@ class SendMessageInteractor(
             }
             if (receipt.acceptedBy >= 1) successCount++
         }
-
-        val finalStatus =
-            if (recipients.isEmpty() || successCount > 0) MessageStatus.SENT
-            else MessageStatus.FAILED
-        messageRepository.updateStatus(messageId, finalStatus)
-
-        pending.copy(status = finalStatus)
+        return successCount
     }
+
+    private fun recipientInboxKeysFor(
+        group: app.onym.android.group.ChatGroup,
+        selfBlsHex: String,
+    ): List<ByteArray> = group.memberProfiles
+        .filterKeys { it != selfBlsHex }
+        .map { (_, profile) -> profile.inboxPublicKey }
+
+    private class EncodingException(message: String) : Exception(message)
 
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true }

--- a/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
+++ b/app/src/sharedTest/kotlin/app/onym/android/support/InMemoryMessageStore.kt
@@ -34,6 +34,10 @@ class InMemoryMessageStore : MessageStore {
             .sortedBy { it.sentAtMillis }
     }
 
+    override suspend fun findById(id: UUID): ChatMessage? = mutex.withLock {
+        rows[id.toString()]
+    }
+
     override suspend fun insert(message: ChatMessage): Boolean = mutex.withLock {
         val key = message.id.toString()
         if (rows.containsKey(key)) return@withLock false

--- a/app/src/test/kotlin/app/onym/android/chats/ChatBubbleStatusTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatBubbleStatusTest.kt
@@ -1,0 +1,134 @@
+package app.onym.android.chats
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.outlined.Schedule
+import app.onym.android.chain.SepGroupType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Pure-policy tests for the chat-bubble status indicator and retry
+ * gate. Verifies the [statusVisualFor] and [canRetry] predicates
+ * the composable consults without standing up Compose.
+ *
+ * Mirrors `ChatBubbleCellTests`' status-glyph + retry-tap assertions
+ * from onym-ios PR #155 — different transport (pure functions vs
+ * UIImageView inspection / UITapGestureRecognizer simulation) but
+ * same policy.
+ */
+class ChatBubbleStatusTest {
+
+    // ─── statusVisualFor: glyph + tint mapping ────────────────────
+
+    @Test
+    fun statusVisualFor_pending_isMutedClock() {
+        val visual = statusVisualFor(MessageStatus.PENDING)
+        assertNotNull(visual)
+        assertEquals(Icons.Outlined.Schedule, visual!!.icon)
+        assertEquals(ChatStatusTint.Muted, visual.tint)
+    }
+
+    @Test
+    fun statusVisualFor_sent_isMutedCheck() {
+        val visual = statusVisualFor(MessageStatus.SENT)
+        assertNotNull(visual)
+        assertEquals(Icons.Filled.Check, visual!!.icon)
+        assertEquals(ChatStatusTint.Muted, visual.tint)
+    }
+
+    @Test
+    fun statusVisualFor_failed_isErrorTintedBang() {
+        val visual = statusVisualFor(MessageStatus.FAILED)
+        assertNotNull(visual)
+        assertEquals(Icons.Filled.ErrorOutline, visual!!.icon)
+        assertEquals(ChatStatusTint.Error, visual.tint)
+    }
+
+    @Test
+    fun statusVisualFor_received_isNull() {
+        // OUTGOING + RECEIVED is the impossible combination — the
+        // bubble defensively hides the indicator rather than render
+        // a wrong glyph.
+        assertNull(statusVisualFor(MessageStatus.RECEIVED))
+    }
+
+    // ─── canRetry: outgoing + failed only ─────────────────────────
+
+    @Test
+    fun canRetry_failedOutgoing_isTrue() {
+        assertTrue(
+            canRetry(
+                makeMessage(
+                    direction = MessageDirection.OUTGOING,
+                    status = MessageStatus.FAILED,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun canRetry_pendingOutgoing_isFalse() {
+        // Retrying a pending row would double-deliver if the
+        // in-flight send eventually succeeds.
+        assertFalse(
+            canRetry(
+                makeMessage(
+                    direction = MessageDirection.OUTGOING,
+                    status = MessageStatus.PENDING,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun canRetry_sentOutgoing_isFalse() {
+        // Retrying a sent row would double-deliver outright.
+        assertFalse(
+            canRetry(
+                makeMessage(
+                    direction = MessageDirection.OUTGOING,
+                    status = MessageStatus.SENT,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun canRetry_incomingFailed_isFalse() {
+        // Incoming rows have no send to retry; the only meaning of
+        // "failed incoming" would be a decode failure, which never
+        // lands in the message repository.
+        assertFalse(
+            canRetry(
+                makeMessage(
+                    direction = MessageDirection.INCOMING,
+                    status = MessageStatus.FAILED,
+                ),
+            ),
+        )
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun makeMessage(
+        direction: MessageDirection,
+        status: MessageStatus,
+    ): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = "aa".repeat(32),
+        ownerIdentityId = "owner",
+        senderBlsPubkeyHex = "cc".repeat(48),
+        body = "x",
+        sentAtMillis = 0L,
+        direction = direction,
+        status = status,
+        groupType = SepGroupType.TYRANNY,
+    )
+}

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
@@ -176,6 +176,36 @@ class ChatThreadViewModelTest {
         assertNull(vm.lastSendError.value)
     }
 
+    // ─── retry action ────────────────────────────────────────────
+
+    @Test
+    fun retry_delegatesToInteractorClosureWithGroupIdAndMessageId() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val captured = mutableListOf<Pair<String, UUID>>()
+        val vm = fixture.makeViewModel(
+            retry = { gid, id -> captured.add(gid to id) },
+        )
+
+        val targetId = UUID.randomUUID()
+        vm.retry(targetId)
+
+        assertEquals(1, captured.size)
+        assertEquals(groupIdHex to targetId, captured.single())
+    }
+
+    @Test
+    fun retry_swallowsInteractorErrors() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val vm = fixture.makeViewModel(
+            retry = { _, _ -> throw RuntimeException("transport down") },
+        )
+        // Must not propagate — retry surfaces failures as
+        // MessageStatus.FAILED on the row, not via thrown exceptions.
+        vm.retry(UUID.randomUUID())
+    }
+
     // ─── helpers ─────────────────────────────────────────────────
 
     private fun sampleMessage(groupIdHex: String, body: String): ChatMessage = ChatMessage(
@@ -246,11 +276,13 @@ class ChatThreadViewModelTest {
 
         fun makeViewModel(
             send: suspend (String, String) -> Unit = { _, _ -> },
+            retry: suspend (String, UUID) -> Unit = { _, _ -> },
         ) = ChatThreadViewModel(
             groupId = groupIdHex,
             groupRepository = groupRepository,
             messageRepository = messageRepository,
             sendMessage = send,
+            retryMessage = retry,
         )
     }
 }

--- a/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
@@ -218,6 +218,117 @@ class SendMessageInteractorTest {
         assertEquals(SepGroupType.ANARCHY, err.type)
     }
 
+    // ─── retry on FAILED ─────────────────────────────────────────
+
+    @Test
+    fun retry_failedMessage_flipsToSentOnRelayAcceptance() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val failed = makePersisted(status = MessageStatus.FAILED, body = "first try")
+        fixture.messageStore.preload(listOf(failed))
+
+        fixture.interactor.retry(groupIdHex, failed.id)
+
+        val refreshed = fixture.messageStore.findById(failed.id)!!
+        assertEquals(MessageStatus.SENT, refreshed.status)
+        // The wire payload re-used the original messageId so the
+        // receiver dedups against any prior delivery — assert the
+        // ConfigurableInboxTransport saw exactly one send for the
+        // peer (the retry shouldn't double-ship).
+        assertEquals(1, fixture.transport.sends().size)
+    }
+
+    @Test
+    fun retry_failedMessage_staysFailedWhenRelaysReject() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        fixture.transport.setReceiptAcceptedBy(0)  // every relay refuses
+        val failed = makePersisted(status = MessageStatus.FAILED, body = "x")
+        fixture.messageStore.preload(listOf(failed))
+
+        fixture.interactor.retry(groupIdHex, failed.id)
+        assertEquals(
+            MessageStatus.FAILED,
+            fixture.messageStore.findById(failed.id)!!.status,
+        )
+    }
+
+    @Test
+    fun retry_unknownMessageId_isNoOp() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        // Don't preload anything — retry on an unknown id must not
+        // throw and must not ship anything.
+        fixture.interactor.retry(groupIdHex, UUID.randomUUID())
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    @Test
+    fun retry_sentMessage_isNoOp_preventsDoubleDelivery() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val sent = makePersisted(status = MessageStatus.SENT, body = "already delivered")
+        fixture.messageStore.preload(listOf(sent))
+
+        fixture.interactor.retry(groupIdHex, sent.id)
+
+        // Status unchanged; no envelope shipped.
+        assertEquals(
+            MessageStatus.SENT,
+            fixture.messageStore.findById(sent.id)!!.status,
+        )
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    @Test
+    fun retry_pendingMessage_isNoOp_preventsDoubleDelivery() = runTest {
+        // An in-flight pending row could still resolve to SENT; retry
+        // would double-ship. Same gate as the SENT case.
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val pending = makePersisted(status = MessageStatus.PENDING, body = "in flight")
+        fixture.messageStore.preload(listOf(pending))
+
+        fixture.interactor.retry(groupIdHex, pending.id)
+        assertEquals(
+            MessageStatus.PENDING,
+            fixture.messageStore.findById(pending.id)!!.status,
+        )
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    @Test
+    fun retry_incomingMessage_isNoOp() = runTest {
+        // Incoming rows don't have an outgoing send to retry.
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val incoming = makePersisted(
+            status = MessageStatus.FAILED,
+            direction = MessageDirection.INCOMING,
+            body = "received but somehow failed",
+        )
+        fixture.messageStore.preload(listOf(incoming))
+
+        fixture.interactor.retry(groupIdHex, incoming.id)
+        assertTrue(fixture.transport.sends().isEmpty())
+    }
+
+    private fun makePersisted(
+        status: MessageStatus,
+        direction: MessageDirection = MessageDirection.OUTGOING,
+        body: String,
+    ): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = groupIdHex,
+        ownerIdentityId = activeId.value,
+        senderBlsPubkeyHex = selfBlsHex,
+        body = body,
+        sentAtMillis = 1_699_000_000_000L,
+        direction = direction,
+        status = status,
+        groupType = SepGroupType.TYRANNY,
+    )
+
     // ─── optimistic insert visible before fan-out completes ──────
 
     @Test


### PR DESCRIPTION
**Stacked on #148.** Status glyphs on outgoing bubbles + tap-to-retry on failed. Tapping a failed bubble retries the send with the original message id so receivers dedup against any prior delivery. Mirrors [onym-ios PR #155](https://github.com/onymchat/onym-ios/pull/155).

## `ChatBubble`

Status indicator below the bubble's trailing edge (outgoing only):

| Status | Glyph | Tint |
|---|---|---|
| `PENDING` | `Icons.Outlined.Schedule` | `onSurfaceVariant` (muted) |
| `SENT` | `Icons.Filled.Check` | `onSurfaceVariant` (muted) |
| `FAILED` | `Icons.Filled.ErrorOutline` | `error` (red) |

Incoming hides the indicator (the message arriving is proof of delivery).

**Retry tap**: `Modifier.clickable` on the bubble box only when `canRetry(message) == true` (i.e. `OUTGOING + FAILED`). Compose's conditional-modifier composition replaces iOS's add/remove-`UITapGestureRecognizer` dance on cell reuse.

`statusVisualFor(...)` + `canRetry(...)` are pure functions — unit tests pin the glyph mapping + retry gate without standing up Compose.

## `SendMessageInteractor`

- **Extracted private `fanOut(payload, recipients)`** helper. Same encode + per-recipient seal + transport flow used by both send and the new retry path; one source of truth for the best-effort per-recipient swallow.
- **New `retry(groupId, messageId)`** — silent no-op for unknown / non-failed / non-outgoing / non-Tyranny rows so a stale tap after a status flip can't double-deliver. On a valid retry:
  1. Flip status to `PENDING` immediately (glyph swaps to the in-flight clock).
  2. Re-fan-out with the **original** payload fields (`messageId`, `body`, `sentAtMillis`) so receivers dedup against any prior delivery via the dispatcher's existing `MessageRepository.append` idempotency (id-keyed `IGNORE` on the DAO from PR A4).
  3. Flip to `SENT` / `FAILED` on completion.

## `ChatThreadViewModel`

- Added `retryMessage` closure (defaults to no-op for tests that don't exercise it). Public `retry(messageId)` fires it from `viewModelScope`; errors are swallowed because retry surfaces failures as `MessageStatus.FAILED` on the row, not via thrown exceptions (same posture as the iOS twin).
- `OnymApplication.makeChatThreadViewModel` wires `retryMessage = sender::retry` — same `SendMessageInteractor` instance used for the send path.

## Persistence

Added `findById(id: UUID)` to `MessageStore` + `RoomMessageStore` + `InMemoryMessageStore` + `MessageRepository`. The retry path needs store access without depending on the chat thread being subscribed (the cached per-group flow might not be hot if the user just navigated back).

## Divergence from iOS

- **iOS needed `snapshot.reconfigureItems(...)`** to close the gap where their diffable data source's identity was just `UUID` and a status flip wouldn't repaint. **Compose's recomposition over the `ChatMessage` data class already handles this** — `LazyColumn(key = { it.id })` keeps the slot stable; the bubble body reads the latest fields. PR A6's docstring already called this out.
- **iOS uses a DEBUG-only `simulateBubbleTapForTest()` test seam** because `UITapGestureRecognizer` has no clean public "fire" API. Compose's `Modifier.clickable` is just a callback — no test seam needed for the analogue.

## Tests (16 new)

**`ChatBubbleStatusTest`** (9):
- `statusVisualFor`: pending → muted clock, sent → muted check, failed → error bang, received → null (defensive).
- `canRetry`: failed-outgoing `true`; pending-outgoing, sent-outgoing, failed-incoming all `false` (each gate has its own test).

**`SendMessageInteractorTest`** +6:
- retry failed → `SENT` on relay acceptance.
- retry failed → stays `FAILED` when relays reject.
- retry unknown `messageId` → no-op.
- retry `SENT` → no-op (prevents double-delivery).
- retry `PENDING` → no-op (prevents double-delivery on in-flight).
- retry `INCOMING` → no-op.

**`ChatThreadViewModelTest`** +2:
- retry delegates to interactor closure with `(groupId, messageId)`.
- retry swallows interactor errors.

Full `:app:testDebugUnitTest` suite — **529 / 529 pass**, 0 failures, 0 errors, 0 regressions. `assembleDebug` clean.

## Plan context

PR 9 of N in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor • **PR A5** (#145) Compose chat-thread shell • **PR A6** (#146) message list rendering • **PR A7** (#147) input panel + keyboard avoidance • **PR A8** (#148) wire Send button to viewModel.send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)