### PR TITLE
feat(chats): chat-thread nav subtitle (PR 10/N chat stack)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -68,9 +68,9 @@ fun ChatThreadScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(
-                        text = group?.name ?: "Chat",
-                        modifier = Modifier.testTag("chat_thread.title"),
+                    ChatThreadTitle(
+                        name = group?.name ?: "Chat",
+                        memberCount = group?.memberProfiles?.size ?: 0,
                     )
                 },
                 navigationIcon = {
@@ -250,6 +250,50 @@ private fun EmptyThread(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
+}
+
+/**
+ * Two-line nav title: group name on top, "N members" subtitle
+ * below. Subtitle is hidden when [memberCount] is `<= 1` — singleton
+ * groups (just the creator) and not-yet-loaded groups would render
+ * an awkward "0 members" / "1 member" otherwise. Same hide-gate as
+ * iOS PR #156.
+ */
+@Composable
+private fun ChatThreadTitle(
+    name: String,
+    memberCount: Int,
+) {
+    val subtitle = memberCountSubtitle(memberCount)
+    Column(
+        modifier = Modifier.testTag("chat_thread.title"),
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.titleMedium,
+        )
+        if (subtitle != null) {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.testTag("chat_thread.title_subtitle"),
+            )
+        }
+    }
+}
+
+/**
+ * Subtitle string for the chat-thread nav. Pluralized as "N members"
+ * because the `<= 1` gate guarantees we never render the singular
+ * form. Pure function so the unit test pins the gate + format
+ * without standing up Compose.
+ *
+ * Mirrors `subtitle(forMemberCount:)` from onym-ios PR #156.
+ */
+internal fun memberCountSubtitle(memberCount: Int): String? = when {
+    memberCount <= 1 -> null
+    else -> "$memberCount members"
 }
 
 @Composable

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadTitleTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadTitleTest.kt
@@ -1,0 +1,39 @@
+package app.onym.android.chats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-policy tests for the chat-thread nav-subtitle string. Pins
+ * the `<= 1` hide-gate + the "N members" format the composable
+ * surfaces below the group name.
+ *
+ * Mirrors `ChatThreadViewControllerTests`' memberCount subtitle
+ * assertions from onym-ios PR #156.
+ */
+class ChatThreadTitleTest {
+
+    @Test
+    fun memberCountSubtitle_zero_isNull() {
+        // Pre-load / not-yet-resolved group renders an awkward
+        // "0 members" subtitle otherwise. Hide it.
+        assertNull(memberCountSubtitle(0))
+    }
+
+    @Test
+    fun memberCountSubtitle_one_isNull() {
+        // Singleton group (just the creator) doesn't need the count.
+        assertNull(memberCountSubtitle(1))
+    }
+
+    @Test
+    fun memberCountSubtitle_two_isPluralized() {
+        assertEquals("2 members", memberCountSubtitle(2))
+    }
+
+    @Test
+    fun memberCountSubtitle_manyMembers_isPluralized() {
+        assertEquals("100 members", memberCountSubtitle(100))
+    }
+}


### PR DESCRIPTION
**Stacked on #149.** Mirrors the nav-subtitle piece of [onym-ios PR #156](https://github.com/onymchat/onym-ios/pull/156). The empty-state ("No messages yet. Say hi.") that iOS PR #156 also added already shipped on Android in PR A6's `EmptyThread` composable, so this PR is just the nav title.

## What's in here

`ChatThreadTitle` composable replaces the single `TopAppBar` title `Text` with a `Column`:
- Group name on top (`typography.titleMedium`).
- "N members" subtitle below (`typography.bodySmall`, `onSurfaceVariant`).
- Subtitle is hidden when `memberCount <= 1` — singleton groups (just the creator) and not-yet-loaded groups would render an awkward "0 members" / "1 member" otherwise. Same gate as iOS.

`memberCountSubtitle(memberCount)` is a pure helper — the `<= 1` gate + the "N members" pluralization live in one place and the unit test pins both without standing up Compose.

Member count comes straight from `group.memberProfiles.size` on the VM's existing `group: StateFlow<ChatGroup?>` — when an admin admits a new joiner and the dispatcher's `MemberAnnouncementPayload` fast path lands, the bar updates live without any new VM API surface.

## Divergence from iOS / out of scope

- **iOS bundled the empty-state into this PR**; on Android it landed in PR A6 because the Compose mirror of iOS PR #152's message-list rendering was a single-screen edit that naturally included the empty branch.
- **Group avatar in nav: deferred.** Would need either reaching into `OnymGroupAvatar` (a Create-Group surface today) or building a chat-tailored variant. iOS deferred for the same reason.
- **`ChatsScreen` last-message preview + unread dot: deferred** — needs a per-group "last message" query on `MessageRepository` plus a `PersistedGroup` schema bump for `lastReadMessageID`. Worth its own focused PR.

## Tests (4 new)

**`ChatThreadTitleTest`**:
- `memberCountSubtitle(0)` → `null` (hide on pre-load)
- `memberCountSubtitle(1)` → `null` (singleton group)
- `memberCountSubtitle(2)` → `"2 members"`
- `memberCountSubtitle(100)` → `"100 members"`

Full `:app:testDebugUnitTest` suite — **533 / 533 pass**, 0 failures, 0 errors, 0 regressions. `assembleDebug` clean.

## Plan context

PR 10 of N in the Android chat stack. **PR A1** (#141) payload • **PR A2** (#142) persistence • **PR A3** (#143) Ed25519 sender pubkey • **PR A4** (#144) dispatcher + send interactor • **PR A5** (#145) Compose chat-thread shell • **PR A6** (#146) message list rendering • **PR A7** (#147) input panel + keyboard avoidance • **PR A8** (#148) wire Send button • **PR A9** (#149) status indicator + retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)