### PR TITLE
feat(inbox): create-time invite-offer handshake + verify-at-current group state

### DIFF
--- a/app/src/androidTest/kotlin/app/onym/android/group/CreateGroupInteractorTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/group/CreateGroupInteractorTest.kt
@@ -22,6 +22,7 @@ import app.onym.android.support.FakeContractsManifestFetcher
 import app.onym.android.support.FakeKnownRelayersFetcher
 import app.onym.android.support.InMemoryAnchorSelectionStore
 import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryIntroKeyStore
 import app.onym.android.support.InMemoryRelayerSelectionStore
 import app.onym.android.support.StubGroupProofGenerator
 import kotlinx.coroutines.runBlocking
@@ -219,6 +220,7 @@ class CreateGroupInteractorTest {
             ),
             proofGenerator = StubGroupProofGenerator(),
             inboxTransport = inboxTransport,
+            introducer = InviteIntroducer(InMemoryIntroKeyStore()),
             makeContractTransport = { contractTransport },
         )
 
@@ -251,6 +253,7 @@ class CreateGroupInteractorTest {
             ),
             proofGenerator = StubGroupProofGenerator(),
             inboxTransport = inboxTransport,
+            introducer = InviteIntroducer(InMemoryIntroKeyStore()),
             makeContractTransport = { contractTransport },
         )
 
@@ -529,6 +532,7 @@ class CreateGroupInteractorTest {
         networkPreference = networkPreference,
         proofGenerator = StubGroupProofGenerator(),
         inboxTransport = inboxTransport,
+        introducer = InviteIntroducer(InMemoryIntroKeyStore()),
         makeContractTransport = { contractTransport },
     )
 

--- a/app/src/androidTest/kotlin/app/onym/android/inbox/IncomingMessageDispatcherConvergeForwardFfiTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/inbox/IncomingMessageDispatcherConvergeForwardFfiTest.kt
@@ -1,0 +1,179 @@
+package app.onym.android.inbox
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.onym.android.chain.ChainStateReading
+import app.onym.android.chain.SepCommitmentEntry
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.group.GovernanceMember
+import app.onym.android.group.GroupCommitmentBuilder
+import app.onym.android.group.GroupInvitationPayload
+import app.onym.android.group.GroupRepository
+import app.onym.android.identity.IdentityId
+import app.onym.android.persistence.InMemoryInvitationStore
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.FakeInvitationEnvelopeDecrypter
+import app.onym.android.support.InMemoryGroupStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.Instant
+
+/**
+ * FFI-backed verify-at-current tests for [IncomingMessageDispatcher]
+ * (PR 159). Lives in `androidTest/` because the Tyranny invitation
+ * verifier recomputes the Poseidon commitment via [GroupCommitmentBuilder],
+ * whose native `.so` only loads on the device runtime.
+ *
+ *  - exact epoch + matching commitment → materializes (the salt-gated
+ *    forgery gate).
+ *  - chain ahead of the snapshot → deferred to the verifier, NOT
+ *    materialized (an unverifiable snapshot must not become a chat).
+ *
+ * Mirrors `test_invitation_tyranny_chainAhead_defersAndDoesNotMaterialize`
+ * from onym-ios PR #159.
+ */
+@RunWith(AndroidJUnit4::class)
+class IncomingMessageDispatcherConvergeForwardFfiTest {
+
+    private val owner = IdentityId("owner")
+    private val groupId = ByteArray(32) { 0x42 }
+    private val salt = ByteArray(32) { 0x66 }
+
+    @Test
+    fun invitation_tyranny_exactEpoch_materializes() = runBlocking {
+        val env = environment()
+        val realCommitment = realCommitment(epoch = 0uL)
+        val plaintext = encode(invitation(commitment = realCommitment, epoch = 0uL))
+        val refresher = SpyRefresher()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = FakeInvitationEnvelopeDecrypter(
+                FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext),
+            ),
+            groupRepository = env.groups,
+            invitationsRepository = env.invitations,
+            // Chain EXACTLY at the snapshot epoch with the SAME commitment.
+            chainState = FakeChainStateFor(SepCommitmentEntry(commitment = realCommitment, epoch = 0uL)),
+            groupStateRefresher = refresher,
+        )
+
+        dispatcher.dispatch("m-exact", owner, byteArrayOf(), Instant.EPOCH)
+
+        assertNotNull(
+            "exact-epoch byte-verified snapshot should materialize",
+            env.groups.snapshots.value.firstOrNull { it.groupIdBytes.contentEquals(groupId) },
+        )
+        assertTrue(refresher.deferred.isEmpty())
+    }
+
+    @Test
+    fun invitation_tyranny_chainAhead_defersAndDoesNotMaterialize() = runBlocking {
+        val env = environment()
+        // Snapshot at epoch 0; chain advanced to epoch 5 (different
+        // commitment). Can't be byte-verified → defer, don't materialize.
+        val plaintext = encode(invitation(commitment = realCommitment(epoch = 0uL), epoch = 0uL))
+        val refresher = SpyRefresher()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = FakeInvitationEnvelopeDecrypter(
+                FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext),
+            ),
+            groupRepository = env.groups,
+            invitationsRepository = env.invitations,
+            chainState = FakeChainStateFor(
+                SepCommitmentEntry(commitment = ByteArray(32) { 0x99.toByte() }, epoch = 5uL),
+            ),
+            groupStateRefresher = refresher,
+        )
+
+        dispatcher.dispatch("m-stale", owner, byteArrayOf(), Instant.EPOCH)
+
+        assertTrue(
+            "a stale snapshot must not materialize",
+            env.groups.snapshots.value.none { it.groupIdBytes.contentEquals(groupId) },
+        )
+        assertEquals(
+            "stale invitation should be deferred to the verifier",
+            listOf(groupId.toList()),
+            refresher.deferred.map { it.toList() },
+        )
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private class Env(val groups: GroupRepository, val invitations: IncomingInvitationsRepository)
+
+    private fun environment(): Env {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        return Env(
+            groups = GroupRepository(
+                store = InMemoryGroupStore(),
+                identity = FakeActiveIdentityProvider(owner),
+                scope = scope,
+            ),
+            invitations = IncomingInvitationsRepository(
+                store = InMemoryInvitationStore(),
+                identity = FakeActiveIdentityProvider(owner),
+                scope = scope,
+            ),
+        )
+    }
+
+    private val members = listOf(
+        GovernanceMember(
+            publicKeyCompressed = GroupCommitmentBuilder.computePublicKey(ByteArray(32) { 0x42 }),
+            leafHash = GroupCommitmentBuilder.computeLeafHash(ByteArray(32) { 0x42 }),
+        ),
+    )
+
+    private fun realCommitment(epoch: ULong): ByteArray =
+        GroupCommitmentBuilder.computePoseidonCommitment(
+            poseidonRoot = GroupCommitmentBuilder.computeMerkleRoot(members, SepTier.SMALL),
+            epoch = epoch,
+            salt = salt,
+        )
+
+    private fun invitation(commitment: ByteArray, epoch: ULong) = GroupInvitationPayload(
+        version = 1,
+        groupId = groupId,
+        groupSecret = ByteArray(32) { 0x33 },
+        name = "Family",
+        members = members,
+        epoch = epoch,
+        salt = salt,
+        commitment = commitment,
+        tierRaw = SepTier.SMALL.rawValue,
+        groupTypeRaw = SepGroupType.TYRANNY.wireValue,
+        adminPubkeyHex = members.first().publicKeyCompressed
+            .joinToString("") { "%02x".format(it.toInt() and 0xFF) },
+    )
+
+    private fun encode(invitation: GroupInvitationPayload): ByteArray =
+        Json.encodeToString(GroupInvitationPayload.serializer(), invitation)
+            .toByteArray(Charsets.UTF_8)
+}
+
+private class FakeChainStateFor(private val entry: SepCommitmentEntry) : ChainStateReading {
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry = entry
+}
+
+private class SpyRefresher : GroupStateRefreshing {
+    val deferred = mutableListOf<ByteArray>()
+    override suspend fun deferVerification(
+        invitation: GroupInvitationPayload,
+        ownerIdentityId: IdentityId,
+    ) {
+        deferred.add(invitation.groupId)
+    }
+
+    override suspend fun handleRefreshRequest(
+        request: app.onym.android.group.GroupStateRefreshRequest,
+        ownerIdentityId: IdentityId,
+        requesterEd25519: ByteArray?,
+    ) {}
+}

--- a/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupAnarchyE2ETest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupAnarchyE2ETest.kt
@@ -22,6 +22,7 @@ import app.onym.android.chain.SepGroupType
 import app.onym.android.chain.SepNetwork
 import app.onym.android.chain.StaticNetworkPreferenceProvider
 import app.onym.android.group.CreateGroupInteractor
+import app.onym.android.group.InviteIntroducer
 import app.onym.android.group.GroupRepository
 import app.onym.android.identity.IdentityRepository
 import app.onym.android.identity.IdentitySecretStore
@@ -29,6 +30,7 @@ import app.onym.android.support.ConfigurableInboxTransport
 import app.onym.android.support.FakeKnownRelayersFetcher
 import app.onym.android.support.InMemoryAnchorSelectionStore
 import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryIntroKeyStore
 import app.onym.android.support.InMemoryRelayerSelectionStore
 import app.onym.android.transport.InboxTransport
 import kotlinx.coroutines.runBlocking
@@ -224,6 +226,7 @@ class CreateGroupAnarchyE2ETest {
                 networkPreference = networkPreference,
                 proofGenerator = proofGenerator,
                 inboxTransport = inboxTransport,
+                introducer = InviteIntroducer(InMemoryIntroKeyStore()),
                 makeContractTransport = makeContractTransport,
             )
     }

--- a/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupOneOnOneE2ETest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupOneOnOneE2ETest.kt
@@ -23,6 +23,7 @@ import app.onym.android.chain.SepNetwork
 import app.onym.android.chain.StaticNetworkPreferenceProvider
 import app.onym.android.group.CreateGroupError
 import app.onym.android.group.CreateGroupInteractor
+import app.onym.android.group.InviteIntroducer
 import app.onym.android.group.GroupRepository
 import app.onym.android.identity.IdentityRepository
 import app.onym.android.identity.IdentitySecretStore
@@ -30,6 +31,7 @@ import app.onym.android.support.ConfigurableInboxTransport
 import app.onym.android.support.FakeKnownRelayersFetcher
 import app.onym.android.support.InMemoryAnchorSelectionStore
 import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryIntroKeyStore
 import app.onym.android.support.InMemoryRelayerSelectionStore
 import app.onym.android.transport.InboxTransport
 import kotlinx.coroutines.runBlocking
@@ -264,6 +266,7 @@ class CreateGroupOneOnOneE2ETest {
                 networkPreference = networkPreference,
                 proofGenerator = proofGenerator,
                 inboxTransport = inboxTransport,
+                introducer = InviteIntroducer(InMemoryIntroKeyStore()),
                 makeContractTransport = makeContractTransport,
             )
     }

--- a/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupTyrannyE2ETest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/integration/CreateGroupTyrannyE2ETest.kt
@@ -23,6 +23,7 @@ import app.onym.android.chain.SepNetwork
 import app.onym.android.chain.SepTier
 import app.onym.android.chain.StaticNetworkPreferenceProvider
 import app.onym.android.group.CreateGroupInteractor
+import app.onym.android.group.InviteIntroducer
 import app.onym.android.group.GroupRepository
 import app.onym.android.identity.IdentityRepository
 import app.onym.android.identity.IdentitySecretStore
@@ -30,6 +31,7 @@ import app.onym.android.support.ConfigurableInboxTransport
 import app.onym.android.support.FakeKnownRelayersFetcher
 import app.onym.android.support.InMemoryAnchorSelectionStore
 import app.onym.android.support.InMemoryGroupStore
+import app.onym.android.support.InMemoryIntroKeyStore
 import app.onym.android.support.InMemoryRelayerSelectionStore
 import app.onym.android.transport.InboxTransport
 import kotlinx.coroutines.runBlocking
@@ -230,6 +232,7 @@ class CreateGroupTyrannyE2ETest {
                 networkPreference = networkPreference,
                 proofGenerator = proofGenerator,
                 inboxTransport = inboxTransport,
+                introducer = InviteIntroducer(InMemoryIntroKeyStore()),
                 makeContractTransport = makeContractTransport,
             )
     }

--- a/app/src/main/kotlin/app/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/app/onym/android/AppDependencies.kt
@@ -66,6 +66,11 @@ class AppDependencies(
      *  lands on the relay shows up in the badge before the modal
      *  is opened. */
     val approveRequestsViewModel: app.onym.android.group.ApproveRequestsViewModel,
+    /** Invitee-side push-invitation surface (PR 158). Single shared
+     *  instance — the Chats toolbar "Invitations" badge and the modal
+     *  list both consume the same flow, so an offer that lands on the
+     *  relay shows up in the badge before the modal is opened. */
+    val pendingInvitesViewModel: app.onym.android.inbox.PendingInvitesViewModel,
     /** Settings → Transport → Nostr Relays. */
     val makeNostrRelaySettingsViewModel: () -> app.onym.android.settings.NostrRelaySettingsViewModel,
     /** Live snapshot of configured Nostr relays — drives the

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -411,6 +411,29 @@ class OnymApplication : Application() {
                 OkHttpSepContractTransport(httpClient = httpClient, endpointUrl = url)
             },
         )
+        // PR 158: invitee-side push invitations. The dispatcher records
+        // decoded GroupInviteOfferPayloads here (never materializing a
+        // group); the PendingInvitesViewModel drives the Chats
+        // "Invitations" surface and, on explicit Accept, ships a
+        // JoinRequestPayload to the offer's intro key via the same
+        // JoinRequestSender the deeplink join path uses.
+        val pendingInvitesStore = app.onym.android.inbox.PendingInvitesStore()
+        // PR 159 verify-at-current: a stale Tyranny snapshot defers here;
+        // the verifier asks the admin for the current state and surfaces
+        // a "couldn't verify" state if the admin is offline.
+        val pendingVerificationStore = app.onym.android.inbox.PendingVerificationStore()
+        val groupStateVerifier = app.onym.android.inbox.GroupStateVerifier(
+            sealer = identityRepository,
+            inboxTransport = inboxTransport,
+            groupRepository = groupRepository,
+            store = pendingVerificationStore,
+            identities = identityRepository.identities,
+            activeIdentityId = identityRepository.currentIdentityId,
+            scope = applicationScope,
+        )
+        // Resolve a pending verification the moment its fresh snapshot
+        // materializes its group (and cancel the timeout).
+        groupStateVerifier.start()
         val incomingDispatcher = app.onym.android.inbox.IncomingMessageDispatcher(
             envelopeDecrypter = identityRepository,
             groupRepository = groupRepository,
@@ -418,7 +441,22 @@ class OnymApplication : Application() {
             messageRepository = messageRepository,
             identitiesFlow = identityRepository.identities,
             chainState = chainStateReader,
+            pendingInvites = pendingInvitesStore,
+            groupStateRefresher = groupStateVerifier,
         )
+        // Filter the invites surface to the active identity, and cascade
+        // a wipe on identity removal — mirrors the per-identity wiring
+        // GroupRepository / IncomingInvitationsRepository already do.
+        applicationScope.launch {
+            identityRepository.currentIdentityId.collect { id ->
+                pendingInvitesStore.setCurrentIdentity(id)
+                pendingVerificationStore.setCurrentIdentity(id)
+            }
+        }
+        identityRepository.registerRemovalListener { id ->
+            pendingInvitesStore.removeForOwner(id)
+            pendingVerificationStore.removeForOwner(id)
+        }
         val invitationsInteractor = app.onym.android.inbox.IncomingInvitationsInteractor(
             inboxTransport = inboxTransport,
             repository = invitationsRepository,
@@ -444,6 +482,12 @@ class OnymApplication : Application() {
         // re-subscribes for the new one.
         val introKeyStore: app.onym.android.group.IntroKeyStore =
             app.onym.android.group.EncryptedPrefsIntroKeyStore(applicationContext)
+        // Shared minter for both the deeplink share-invite flow and the
+        // create-time invite-offer handshake (PR 158). Both persist into
+        // the same per-identity IntroKeyStore so the admin's IntroInboxPump
+        // listens on every minted intro tag regardless of which path
+        // produced it.
+        val inviteIntroducer = app.onym.android.group.InviteIntroducer(introKeyStore)
         val introRequestStore: app.onym.android.group.IntroRequestStore =
             app.onym.android.group.InMemoryIntroRequestStore()
         val introInboxPump = app.onym.android.group.IntroInboxPump(
@@ -513,6 +557,27 @@ class OnymApplication : Application() {
         // the chats screen isn't open still drive the badge count.
         approveRequestsViewModel.start()
 
+        // Invitee-side counterpart (PR 158). On explicit Accept it ships
+        // a JoinRequestPayload to the offer's intro key via the same
+        // shared JoinRequestSender; the admin still has to explicitly
+        // approve before anyone is anchored. Started eagerly so the
+        // Chats "Invitations" badge reflects offers from app start.
+        val pendingInvitesViewModel = app.onym.android.inbox.PendingInvitesViewModel(
+            store = pendingInvitesStore,
+            verificationStore = pendingVerificationStore,
+            groupRepository = groupRepository,
+            submitJoin = joinRequestSender::send,
+            displayLabel = {
+                val activeId = identityRepository.currentIdentityId.value
+                identityRepository.identities.value
+                    .firstOrNull { it.id == activeId }
+                    ?.name
+                    .orEmpty()
+            },
+            retryVerification = { groupIdHex -> groupStateVerifier.retry(groupIdHex) },
+        )
+        pendingInvitesViewModel.start()
+
         return AppDependencies(
             nostrSignerProvider = nostrSignerProvider,
             makeRecoveryPhraseBackupViewModel = { activityProvider ->
@@ -552,6 +617,7 @@ class OnymApplication : Application() {
                         )
                     },
                     inboxTransport = inboxTransport,
+                    introducer = inviteIntroducer,
                 )
                 CreateGroupViewModel(
                     createGroup = { name, invitees, groupType, onProgress ->
@@ -595,11 +661,12 @@ class OnymApplication : Application() {
             makeShareInviteViewModel = {
                 app.onym.android.group.ShareInviteViewModel(
                     identity = identityRepository,
-                    introducer = app.onym.android.group.InviteIntroducer(introKeyStore),
+                    introducer = inviteIntroducer,
                     groupRepository = groupRepository,
                 )
             },
             approveRequestsViewModel = approveRequestsViewModel,
+            pendingInvitesViewModel = pendingInvitesViewModel,
             makeNostrRelaySettingsViewModel = {
                 app.onym.android.settings.NostrRelaySettingsViewModel(
                     repository = nostrRelaysRepository,

--- a/app/src/main/kotlin/app/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/RootScreen.kt
@@ -164,6 +164,8 @@ fun RootScreen(
                     onCreateGroup = { navController.navigate(ROUTE_CREATE_GROUP) },
                     approveRequestsViewModel = dependencies.approveRequestsViewModel,
                     onOpenApproveRequests = { navController.navigate(ROUTE_APPROVE_REQUESTS) },
+                    pendingInvitesViewModel = dependencies.pendingInvitesViewModel,
+                    onOpenInvitations = { navController.navigate(ROUTE_PENDING_INVITES) },
                     onOpenChat = { groupId ->
                         // PR A5: chats list now opens the thread,
                         // not the members roster. Members move one
@@ -216,6 +218,12 @@ fun RootScreen(
             composable(ROUTE_APPROVE_REQUESTS) {
                 app.onym.android.group.ApproveRequestsScreen(
                     viewModel = dependencies.approveRequestsViewModel,
+                    onClose = { navController.popBackStack() },
+                )
+            }
+            composable(ROUTE_PENDING_INVITES) {
+                app.onym.android.inbox.PendingInvitesScreen(
+                    viewModel = dependencies.pendingInvitesViewModel,
                     onClose = { navController.popBackStack() },
                 )
             }
@@ -540,4 +548,5 @@ private const val ROUTE_RUN_RELAYER = "run_relayer"
 private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"
 private const val ROUTE_APPROVE_REQUESTS = "approve_requests"
+private const val ROUTE_PENDING_INVITES = "pending_invites"
 private val TAB_ROUTES = setOf(Tab.Chats.route, Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.offset
+import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.runtime.collectAsState
 import app.onym.android.R
@@ -57,6 +58,8 @@ import app.onym.android.group.ApproveRequestsViewModel
 import app.onym.android.group.ChatGroup
 import app.onym.android.group.OnymAccent
 import app.onym.android.group.OnymGroupAvatar
+import app.onym.android.inbox.PendingInvitesToolbarBadge
+import app.onym.android.inbox.PendingInvitesViewModel
 
 /**
  * Chats tab — root list of groups the user has created. PR-C only
@@ -75,11 +78,18 @@ fun ChatsScreen(
     onCreateGroup: () -> Unit,
     approveRequestsViewModel: ApproveRequestsViewModel? = null,
     onOpenApproveRequests: (() -> Unit)? = null,
+    pendingInvitesViewModel: PendingInvitesViewModel? = null,
+    onOpenInvitations: (() -> Unit)? = null,
     onOpenChat: (groupId: String) -> Unit = {},
 ) {
     val groups by viewModel.groups.collectAsStateWithLifecycle()
     val pending by (approveRequestsViewModel?.pending?.collectAsStateWithLifecycle()
         ?: remember { mutableStateOf(emptyList<app.onym.android.group.JoinRequestApprover.PendingRequest>()) })
+    val pendingInvites by (pendingInvitesViewModel?.pending?.collectAsStateWithLifecycle()
+        ?: remember { mutableStateOf(emptyList<app.onym.android.inbox.PendingInvite>()) })
+    val verifyingInvites by (pendingInvitesViewModel?.verifying?.collectAsStateWithLifecycle()
+        ?: remember { mutableStateOf(emptyList<app.onym.android.inbox.PendingGroupVerification>()) })
+    val inviteBadgeCount = pendingInvites.size + verifyingInvites.size
 
     Scaffold(
         topBar = {
@@ -107,6 +117,31 @@ fun ChatsScreen(
                                         .offset(x = (-4).dp, y = 6.dp),
                                 ) {
                                     ApproveRequestsToolbarBadge(pending.size)
+                                }
+                            }
+                        }
+                    }
+                    // Invitations received by this identity (push offers).
+                    // Same always-rendered + badge-on-nonempty treatment as
+                    // the join-requests button.
+                    if (pendingInvitesViewModel != null && onOpenInvitations != null) {
+                        Box(modifier = Modifier.padding(end = 4.dp)) {
+                            IconButton(
+                                onClick = onOpenInvitations,
+                                modifier = Modifier.testTag("pending_invites.toolbar_button"),
+                            ) {
+                                Icon(
+                                    Icons.Filled.MailOutline,
+                                    contentDescription = "Invitations",
+                                )
+                            }
+                            if (inviteBadgeCount > 0) {
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.TopEnd)
+                                        .offset(x = (-4).dp, y = 6.dp),
+                                ) {
+                                    PendingInvitesToolbarBadge(inviteBadgeCount)
                                 }
                             }
                         }

--- a/app/src/main/kotlin/app/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/app/onym/android/group/CreateGroupInteractor.kt
@@ -21,6 +21,7 @@ import app.onym.android.chain.SepGroupType
 import app.onym.android.chain.SepTier
 import app.onym.android.chain.TyrannyCreateGroupPayload
 import app.onym.android.identity.Identity
+import app.onym.android.identity.IdentityId
 import app.onym.android.identity.IdentityRepository
 import app.onym.android.transport.InboxTransport
 import app.onym.android.transport.TransportInboxId
@@ -53,14 +54,20 @@ import java.security.SecureRandom
  *  7. Insert the group locally via [GroupRepository.insert] then
  *     [GroupRepository.markPublished] so a subscriber sees
  *     `isPublishedOnChain = true` immediately.
- *  8. For each invitee: encode + seal the [GroupInvitationPayload],
- *     send via [InboxTransport.send], require `acceptedBy >= 1`. The
- *     group is already saved on disk at this point — invitation
- *     failures throw [CreateGroupError.InvitationSendFailed] but
- *     leave the group durable so a future "retry invites" UI can
- *     pick it up.
+ *  8. Reach each invitee. **Tyranny** ships a durable
+ *     [GroupInviteOfferPayload] (a fresh per-invite intro key + display
+ *     context) instead of an epoch-pinned snapshot: the creator stays
+ *     the only on-chain member until the invitee explicitly accepts
+ *     (ships a [JoinRequestPayload]) and the admin explicitly approves
+ *     (`update_commitment`). **OneOnOne / Anarchy** keep shipping the
+ *     [GroupInvitationPayload] membership grant — OneOnOne bakes both
+ *     parties into the founding commitment at epoch 0 (the snapshot is
+ *     valid forever) and Anarchy has no admin-approval anchor flow.
+ *     Either way the group is already saved on disk — send failures
+ *     throw [CreateGroupError.InvitationSendFailed] but leave the
+ *     group durable so a future "retry invites" UI can pick it up.
  *
- * Mirrors `CreateGroupInteractor` from onym-ios PR #26.
+ * Mirrors `CreateGroupInteractor` from onym-ios PR #26 + #158.
  */
 open class CreateGroupInteractor(
     private val identity: IdentityRepository,
@@ -70,6 +77,11 @@ open class CreateGroupInteractor(
     private val networkPreference: NetworkPreferenceProvider,
     private val proofGenerator: GroupProofGenerator = OnymGroupProofGenerator(),
     private val inboxTransport: InboxTransport,
+    /** Mints a per-invitee intro key for each create-time invite offer
+     *  (Tyranny). That intro key is the reply channel the invitee seals
+     *  their [JoinRequestPayload] to when they accept — the same
+     *  machinery the deeplink share-invite flow uses, just pushed. */
+    private val introducer: InviteIntroducer,
     /** Builds a [SepContractTransport] from the relayer URL chosen
      *  per-call. Injected so tests can swap in a fake without
      *  touching OkHttp. */
@@ -302,56 +314,36 @@ open class CreateGroupInteractor(
         groups.insert(group)
         groups.markPublished(group.id, proof.commitment)
 
-        // 8. Send invitations. For OneOnOne the (sole) invitee gets
-        //    the ephemeral `secondaryBlsSecret` so they can act as
-        //    the second party of the immutable group.
+        // 8. Reach each invitee. Tyranny pushes durable invite offers;
+        //    every other type ships the membership-grant snapshot
+        //    (OneOnOne's sole invitee gets the ephemeral
+        //    `secondaryBlsSecret` so they can act as the second party
+        //    of the immutable group).
         if (invitees.isNotEmpty()) {
             onProgress(CreateGroupProgress.SendingInvitations(invitees.size))
-            for ((index, inboxKey) in invitees.withIndex()) {
-                val invitePayload = GroupInvitationPayload(
-                    version = 1,
+            if (groupType == SepGroupType.TYRANNY) {
+                sendOffers(
+                    invitees = invitees,
+                    ownerIdentityId = ownerId,
+                    groupId = groupId,
+                    groupName = trimmedName,
+                    inviterAlias = creatorAlias,
+                )
+            } else {
+                sendInvitations(
+                    invitees = invitees,
                     groupId = groupId,
                     groupSecret = groupSecret,
                     name = trimmedName,
                     members = members,
-                    epoch = 0uL,
                     salt = salt,
                     commitment = proof.commitment,
-                    tierRaw = tier.rawValue,
-                    groupTypeRaw = groupType.wireValue,
+                    tier = tier,
+                    groupType = groupType,
                     adminPubkeyHex = adminPubkeyHex,
                     inviteeBlsSecretKey = secondaryBlsSecret,
-                    // Ship the creator's directory so the invitee
-                    // sees the inviter by alias from the moment the
-                    // group materializes (PR 83). takeIf-not-empty
-                    // matches iOS; pre-PR-82 senders shipped null.
                     memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
                 )
-                val payloadBytes = try {
-                    jsonFormat.encodeToString(
-                        GroupInvitationPayload.serializer(),
-                        invitePayload,
-                    ).toByteArray(Charsets.UTF_8)
-                } catch (_: Throwable) {
-                    throw CreateGroupError.InvitationEncodingFailed
-                }
-                val sealed = try {
-                    identity.sealInvitation(payloadBytes, inboxKey)
-                } catch (e: Throwable) {
-                    throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
-                }
-                val tag = inboxTagFor(inboxKey)
-                val receipt = try {
-                    inboxTransport.send(sealed, TransportInboxId(tag))
-                } catch (e: Throwable) {
-                    throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
-                }
-                if (receipt.acceptedBy < 1) {
-                    throw CreateGroupError.InvitationSendFailed(
-                        index,
-                        "no relay accepted the invitation",
-                    )
-                }
             }
         }
 
@@ -359,6 +351,142 @@ open class CreateGroupInteractor(
         // the caller sees `isPublishedOnChain = true`.
         return groups.snapshots.value.firstOrNull { it.id == group.id }
             ?: group.copy(isPublishedOnChain = true)
+    }
+
+    /**
+     * Tyranny invite-offer send loop. Mint a per-invitee intro key and
+     * ship a durable [GroupInviteOfferPayload] to each invitee's inbox.
+     * Reuses the inbox seal+send path, but the payload grants nothing:
+     * it carries only the reply channel + display context, so it never
+     * expires and never anchors anyone. The invitee turns it into a
+     * join request on accept; the admin anchors only on explicit
+     * approve.
+     *
+     * Mirrors `CreateGroupInteractor.sendOffers` from onym-ios PR #158.
+     */
+    private suspend fun sendOffers(
+        invitees: List<ByteArray>,
+        ownerIdentityId: IdentityId,
+        groupId: ByteArray,
+        groupName: String,
+        inviterAlias: String,
+    ) {
+        for ((index, inboxKey) in invitees.withIndex()) {
+            // One fresh intro key per invitee → granular revoke and a
+            // clean 1:1 mapping from an inbound join request back to the
+            // person the admin meant to invite.
+            val capability = try {
+                introducer.mint(
+                    ownerIdentityId = ownerIdentityId,
+                    groupId = groupId,
+                    groupName = groupName,
+                )
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, "mint intro key: ${e.message ?: e}")
+            }
+            val offer = try {
+                GroupInviteOfferPayload(
+                    introPublicKey = capability.introPublicKey,
+                    groupId = groupId,
+                    groupName = groupName,
+                    inviterAlias = inviterAlias,
+                )
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, "build offer: ${e.message ?: e}")
+            }
+            val payloadBytes = try {
+                jsonFormat.encodeToString(GroupInviteOfferPayload.serializer(), offer)
+                    .toByteArray(Charsets.UTF_8)
+            } catch (_: Throwable) {
+                throw CreateGroupError.InvitationEncodingFailed
+            }
+            val sealed = try {
+                identity.sealInvitation(payloadBytes, inboxKey)
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
+            }
+            val tag = inboxTagFor(inboxKey)
+            val receipt = try {
+                inboxTransport.send(sealed, TransportInboxId(tag))
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
+            }
+            if (receipt.acceptedBy < 1) {
+                throw CreateGroupError.InvitationSendFailed(
+                    index,
+                    "no relay accepted the invite offer",
+                )
+            }
+        }
+    }
+
+    /**
+     * Membership-grant send loop for non-Tyranny groups (OneOnOne /
+     * Anarchy). Encode + seal the [GroupInvitationPayload] and send via
+     * [InboxTransport.send]. OneOnOne's invitee receives the ephemeral
+     * [inviteeBlsSecretKey] so they can act as the immutable group's
+     * second party.
+     */
+    private suspend fun sendInvitations(
+        invitees: List<ByteArray>,
+        groupId: ByteArray,
+        groupSecret: ByteArray,
+        name: String,
+        members: List<GovernanceMember>,
+        salt: ByteArray,
+        commitment: ByteArray,
+        tier: SepTier,
+        groupType: SepGroupType,
+        adminPubkeyHex: String?,
+        inviteeBlsSecretKey: ByteArray?,
+        memberProfiles: Map<String, MemberProfile>?,
+    ) {
+        for ((index, inboxKey) in invitees.withIndex()) {
+            val invitePayload = GroupInvitationPayload(
+                version = 1,
+                groupId = groupId,
+                groupSecret = groupSecret,
+                name = name,
+                members = members,
+                epoch = 0uL,
+                salt = salt,
+                commitment = commitment,
+                tierRaw = tier.rawValue,
+                groupTypeRaw = groupType.wireValue,
+                adminPubkeyHex = adminPubkeyHex,
+                inviteeBlsSecretKey = inviteeBlsSecretKey,
+                // Ship the creator's directory so the invitee sees the
+                // inviter by alias from the moment the group
+                // materializes (PR 83). takeIf-not-empty matches iOS;
+                // pre-PR-82 senders shipped null.
+                memberProfiles = memberProfiles,
+            )
+            val payloadBytes = try {
+                jsonFormat.encodeToString(
+                    GroupInvitationPayload.serializer(),
+                    invitePayload,
+                ).toByteArray(Charsets.UTF_8)
+            } catch (_: Throwable) {
+                throw CreateGroupError.InvitationEncodingFailed
+            }
+            val sealed = try {
+                identity.sealInvitation(payloadBytes, inboxKey)
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
+            }
+            val tag = inboxTagFor(inboxKey)
+            val receipt = try {
+                inboxTransport.send(sealed, TransportInboxId(tag))
+            } catch (e: Throwable) {
+                throw CreateGroupError.InvitationSendFailed(index, e.message ?: e.toString())
+            }
+            if (receipt.acceptedBy < 1) {
+                throw CreateGroupError.InvitationSendFailed(
+                    index,
+                    "no relay accepted the invitation",
+                )
+            }
+        }
     }
 
     /** Bridge the wire-typed [SepGroupType] to the binding-key

--- a/app/src/main/kotlin/app/onym/android/group/GroupInviteOfferPayload.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupInviteOfferPayload.kt
@@ -1,0 +1,115 @@
+package app.onym.android.group
+
+import app.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Admin → invitee "you've been invited" offer, sealed to the
+ * invitee's X25519 inbox key and delivered over the normal inbox
+ * transport (NOT an intro tag — the invitee doesn't have one yet).
+ *
+ * ## Why this is not a [GroupInvitationPayload]
+ *
+ * A [GroupInvitationPayload] is a *membership grant*: it pins
+ * `(members, epoch, commitment, salt)` for one on-chain epoch, and
+ * the receiver auto-materializes a group from it. Shipping that at
+ * create time is wrong on two counts:
+ *   1. The invitee isn't on chain yet — they have no BLS leaf in the
+ *      committed roster, so the snapshot is a lie.
+ *   2. It's epoch-pinned, so the moment any *other* invitee is
+ *      anchored the snapshot goes stale and the receiver drops it.
+ *
+ * The offer instead carries only what the invitee needs to *ask* to
+ * join: a fresh per-invite intro public key (the reply channel the
+ * admin minted via [InviteIntroducer]) plus enough context to render
+ * "Alice invited you to Maple Garden". It contains **no** epoch,
+ * commitment, members, or group secret — so it never expires and
+ * grants nothing. Membership only happens later, when the invitee
+ * explicitly accepts (ships a [JoinRequestPayload] to [introPublicKey])
+ * and the admin explicitly approves (anchors via `update_commitment`).
+ *
+ * ## Wire disambiguation
+ *
+ * The receive-side dispatcher trial-decodes inbound plaintext against
+ * several payload types. [version] (`offer_version`) + [inviterAlias]
+ * (`inviter_alias`) + [introPublicKey] (`intro_pub`) are all required
+ * (no defaults) and unique to this type, so a successful decode is
+ * unambiguous — no other inbox payload carries `inviter_alias`, and a
+ * [JoinRequestPayload] (the other intro-keyed payload) lacks
+ * `intro_pub` + `offer_version` so it can't be mistaken for an offer.
+ *
+ * Mirrors `GroupInviteOfferPayload` from onym-ios PR #158.
+ */
+@Serializable
+data class GroupInviteOfferPayload(
+    @SerialName("offer_version")
+    val version: Int = 1,
+
+    /** 32-byte X25519 public key of the admin's freshly-minted intro
+     *  key for this invite. The invitee seals their [JoinRequestPayload]
+     *  to this and the admin's [IntroInboxPump] picks it up. */
+    @SerialName("intro_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val introPublicKey: ByteArray,
+
+    /** 32-byte on-chain `group_id` the invite is for. Lets the invitee
+     *  verify the group exists on chain before responding. */
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+
+    /** Optional plaintext group name for the invitee's preview.
+     *  Mirrors [IntroCapability.groupName] — treat as low-sensitivity
+     *  (it's sealed here, but it transits cleartext-ish channels in
+     *  the deeplink form). */
+    @SerialName("group_name")
+    val groupName: String? = null,
+
+    /** Admin's self-asserted display name, surfaced in the invitee's
+     *  "X invited you" prompt. Untrusted text — render, don't trust. */
+    @SerialName("inviter_alias")
+    val inviterAlias: String,
+) {
+    init {
+        require(introPublicKey.size == 32) {
+            "introPublicKey: expected 32 bytes, got ${introPublicKey.size}"
+        }
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    /**
+     * Rebuild the [IntroCapability] the invitee feeds to
+     * [JoinRequestSender.send] on accept. Throws if the offer's bytes
+     * don't satisfy [IntroCapability]'s shape invariants (can't happen
+     * for an offer that decoded successfully, but [IntroCapability]'s
+     * `init` is the single source of truth for the sizes).
+     */
+    fun introCapability(): IntroCapability =
+        IntroCapability(
+            introPublicKey = introPublicKey,
+            groupId = groupId,
+            groupName = groupName,
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GroupInviteOfferPayload) return false
+        return version == other.version &&
+            introPublicKey.contentEquals(other.introPublicKey) &&
+            groupId.contentEquals(other.groupId) &&
+            groupName == other.groupName &&
+            inviterAlias == other.inviterAlias
+    }
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + introPublicKey.contentHashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + (groupName?.hashCode() ?: 0)
+        h = 31 * h + inviterAlias.hashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/group/GroupStateRefreshRequest.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupStateRefreshRequest.kt
@@ -1,0 +1,100 @@
+package app.onym.android.group
+
+import app.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Member → admin "send me the current group state" request, sealed to
+ * the admin's inbox and signed by the requester's Ed25519.
+ *
+ * ## Why this exists
+ *
+ * A Tyranny invitation is a snapshot pinned to one epoch. The receiver
+ * verifies it by recomputing `Poseidon(Poseidon(merkleRoot(members),
+ * epoch), salt)` and matching the on-chain commitment — but the chain
+ * only stores the *latest* `(commitment, epoch)`. If another invitee
+ * was anchored between the snapshot being sealed and it landing, the
+ * snapshot is from a past epoch the chain no longer holds, so it can't
+ * be byte-verified (and we refuse to materialize an unverifiable group
+ * — see [app.onym.android.inbox.GroupStateVerifier]).
+ *
+ * To recover, the receiver asks the admin for the *current* state. The
+ * admin replies with a fresh [GroupInvitationPayload] at the current
+ * `(epoch, salt, members, commitment)`, which the receiver verifies at
+ * an exact epoch match. This is the "verify at current state" leg of
+ * the converge-forward design (Option 2).
+ *
+ * ## Privacy
+ *
+ * The reply carries `salt` (the on-chain roster-privacy blinding
+ * factor), so the admin MUST only answer requesters that are in the
+ * *current* roster — [app.onym.android.inbox.GroupStateVerifier.handleRefreshRequest]
+ * gates on membership + an Ed25519-signer check before replying, and
+ * seals to the member's *stored* inbox so a forged request can't
+ * redirect the salt. The request itself reveals only that the
+ * requester wants to resync a group it was invited to.
+ *
+ * ## Wire disambiguation
+ *
+ * [groupId] (`refresh_group_id`) + [requesterInboxPublicKey]
+ * (`requester_inbox_pub`) are required and unique to this type — no
+ * other inbox payload carries `refresh_group_id`, so a successful
+ * decode is unambiguous.
+ *
+ * Mirrors `GroupStateRefreshRequest` from onym-ios PR #159.
+ */
+@Serializable
+data class GroupStateRefreshRequest(
+    @SerialName("refresh_version")
+    val version: Int = 1,
+
+    /** 32-byte on-chain `group_id` the requester wants the current
+     *  state for. */
+    @SerialName("refresh_group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+
+    /** Requester's 32-byte X25519 inbox key — where the admin seals the
+     *  fresh snapshot reply (cross-checked against the stored member
+     *  profile's inbox, never trusted blindly). */
+    @SerialName("requester_inbox_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val requesterInboxPublicKey: ByteArray,
+
+    /** Requester's 48-byte compressed BLS pubkey — used by the admin to
+     *  confirm the requester is in the current roster before disclosing
+     *  the salt. */
+    @SerialName("requester_bls_pub")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val requesterBlsPublicKey: ByteArray,
+) {
+    init {
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+        require(requesterInboxPublicKey.size == 32) {
+            "requesterInboxPublicKey: expected 32 bytes, got ${requesterInboxPublicKey.size}"
+        }
+        require(requesterBlsPublicKey.size == 48) {
+            "requesterBlsPublicKey: expected 48 bytes, got ${requesterBlsPublicKey.size}"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GroupStateRefreshRequest) return false
+        return version == other.version &&
+            groupId.contentEquals(other.groupId) &&
+            requesterInboxPublicKey.contentEquals(other.requesterInboxPublicKey) &&
+            requesterBlsPublicKey.contentEquals(other.requesterBlsPublicKey)
+    }
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + requesterInboxPublicKey.contentHashCode()
+        h = 31 * h + requesterBlsPublicKey.contentHashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/GroupStateVerifier.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/GroupStateVerifier.kt
@@ -1,0 +1,280 @@
+package app.onym.android.inbox
+
+import app.onym.android.group.GroupInvitationPayload
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.GroupStateRefreshRequest
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.IdentityRepository
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.transport.InboxTransport
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.Json
+import java.time.Instant
+
+/**
+ * Seam the dispatcher delegates Tyranny group-state verification to.
+ * Two roles, because any device is both a potential invitee and a
+ * potential admin:
+ *   - [deferVerification] (invitee): a snapshot couldn't be verified at
+ *     an exact epoch (chain advanced past it) — ask the admin for the
+ *     current state instead of materializing an unverifiable group.
+ *   - [handleRefreshRequest] (admin): reply to such a request with the
+ *     current snapshot, gated on the requester being a current member.
+ *
+ * Mirrors `GroupStateRefreshing` from onym-ios PR #159.
+ */
+interface GroupStateRefreshing {
+    suspend fun deferVerification(invitation: GroupInvitationPayload, ownerIdentityId: IdentityId)
+    suspend fun handleRefreshRequest(
+        request: GroupStateRefreshRequest,
+        ownerIdentityId: IdentityId,
+        requesterEd25519: ByteArray?,
+    )
+}
+
+/** No-op conformer — the dispatcher's default so existing dispatcher
+ *  tests that don't exercise verification keep their construction sites
+ *  unchanged. Mirrors `NoopGroupStateRefresher`. */
+class NoopGroupStateRefresher : GroupStateRefreshing {
+    override suspend fun deferVerification(invitation: GroupInvitationPayload, ownerIdentityId: IdentityId) {}
+    override suspend fun handleRefreshRequest(
+        request: GroupStateRefreshRequest,
+        ownerIdentityId: IdentityId,
+        requesterEd25519: ByteArray?,
+    ) {}
+}
+
+/**
+ * Drives the "verify at current state" leg of the converge-forward
+ * design (Option 2). When an invitation snapshot is stale, the invitee
+ * asks the admin for the current `(epoch, salt, members, commitment)`;
+ * the admin replies with a fresh [GroupInvitationPayload] that verifies
+ * at an exact epoch. If the admin can't be reached, the group is left
+ * in an [PendingGroupVerification.Status.UNREACHABLE] pending state and
+ * surfaced to the user — never silently materialized or dropped.
+ *
+ * Depends on narrow seams ([InvitationEnvelopeSealer], the identities +
+ * active-id flows) rather than the concrete [IdentityRepository] so it's
+ * exercisable on the JVM unit-test path.
+ *
+ * Mirrors the `GroupStateVerifier` actor from onym-ios PR #159 — a
+ * [Mutex] stands in for the actor's isolation.
+ */
+class GroupStateVerifier(
+    private val sealer: InvitationEnvelopeSealer,
+    private val inboxTransport: InboxTransport,
+    private val groupRepository: GroupRepository,
+    private val store: PendingVerificationStore,
+    /** All local identities; the invitee-side refresh is built from the
+     *  active one's summary (V1 single-active assumption). */
+    private val identities: StateFlow<List<IdentitySummary>>,
+    private val activeIdentityId: StateFlow<IdentityId?>,
+    /** Scope owning the per-group timeout tasks + the resolve watcher. */
+    private val scope: CoroutineScope,
+    private val refreshTimeoutMillis: Long = 30_000,
+) : GroupStateRefreshing {
+
+    private data class RefreshTarget(
+        val groupId: ByteArray,
+        val adminInboxKey: ByteArray,
+        val ownerIdentityId: IdentityId,
+    )
+
+    private val mutex = Mutex()
+    private val targets = mutableMapOf<String, RefreshTarget>()
+    private val timeouts = mutableMapOf<String, Job>()
+    private var watchJob: Job? = null
+
+    /**
+     * Watch the group repo so a pending verification is resolved (and
+     * its timeout cancelled) the moment the fresh snapshot materializes
+     * its group. Idempotent.
+     */
+    fun start() {
+        watchJob?.cancel()
+        watchJob = scope.launch {
+            groupRepository.snapshots.collect { groups ->
+                resolve(groups.mapTo(mutableSetOf()) { it.id })
+            }
+        }
+    }
+
+    // ─── Invitee side ────────────────────────────────────────────────
+
+    override suspend fun deferVerification(
+        invitation: GroupInvitationPayload,
+        ownerIdentityId: IdentityId,
+    ) {
+        val groupIdHex = invitation.groupId.toHexLowercase()
+        if (store.contains(groupIdHex)) return
+
+        // We can only ask the admin if the snapshot told us their inbox.
+        val adminInbox = invitation.adminPubkeyHex?.lowercase()
+            ?.let { invitation.memberProfiles?.get(it)?.inboxPublicKey }
+        if (adminInbox == null) {
+            store.record(
+                PendingGroupVerification(
+                    groupIdHex = groupIdHex,
+                    ownerIdentityId = ownerIdentityId,
+                    groupName = invitation.name,
+                    status = PendingGroupVerification.Status.UNREACHABLE,
+                    receivedAt = Instant.now(),
+                ),
+            )
+            return
+        }
+
+        store.record(
+            PendingGroupVerification(
+                groupIdHex = groupIdHex,
+                ownerIdentityId = ownerIdentityId,
+                groupName = invitation.name,
+                status = PendingGroupVerification.Status.VERIFYING,
+                receivedAt = Instant.now(),
+            ),
+        )
+        mutex.withLock {
+            targets[groupIdHex] = RefreshTarget(
+                groupId = invitation.groupId.copyOf(),
+                adminInboxKey = adminInbox.copyOf(),
+                ownerIdentityId = ownerIdentityId,
+            )
+        }
+        sendRefresh(groupIdHex)
+    }
+
+    /** Re-send a refresh for a still-pending group (manual Retry). No-op
+     *  if the group resolved or we have no target for it. */
+    suspend fun retry(groupIdHex: String) {
+        val hasTarget = mutex.withLock { targets.containsKey(groupIdHex) }
+        if (!hasTarget) return
+        store.updateStatus(groupIdHex, PendingGroupVerification.Status.VERIFYING)
+        sendRefresh(groupIdHex)
+    }
+
+    private suspend fun sendRefresh(groupIdHex: String) {
+        val target = mutex.withLock { targets[groupIdHex] } ?: return
+        // Build the request from the *active* identity. V1 assumes the
+        // owner is the selected identity (matching the single-active
+        // assumption elsewhere); if it isn't, the admin's membership
+        // check simply won't match and we fall through to UNREACHABLE.
+        val me = identities.value.firstOrNull { it.id == activeIdentityId.value }
+        val request = me?.let {
+            runCatching {
+                GroupStateRefreshRequest(
+                    groupId = target.groupId,
+                    requesterInboxPublicKey = it.inboxPublicKey,
+                    requesterBlsPublicKey = it.blsPublicKey,
+                )
+            }.getOrNull()
+        }
+        if (request == null) {
+            store.updateStatus(groupIdHex, PendingGroupVerification.Status.UNREACHABLE)
+            return
+        }
+        val sealed = runCatching {
+            sealer.sealInvitation(
+                jsonFormat.encodeToString(GroupStateRefreshRequest.serializer(), request)
+                    .toByteArray(Charsets.UTF_8),
+                target.adminInboxKey,
+            )
+        }.getOrNull()
+        if (sealed == null) {
+            store.updateStatus(groupIdHex, PendingGroupVerification.Status.UNREACHABLE)
+            return
+        }
+        val tag = TransportInboxId(IdentityRepository.inboxTag(target.adminInboxKey))
+        val receipt = runCatching { inboxTransport.send(sealed, tag) }.getOrNull()
+        if (receipt == null || receipt.acceptedBy < 1) {
+            store.updateStatus(groupIdHex, PendingGroupVerification.Status.UNREACHABLE)
+            return
+        }
+        scheduleTimeout(groupIdHex)
+    }
+
+    private suspend fun scheduleTimeout(groupIdHex: String) = mutex.withLock {
+        timeouts[groupIdHex]?.cancel()
+        timeouts[groupIdHex] = scope.launch {
+            delay(refreshTimeoutMillis)  // throws on cancel → marker won't run
+            markUnreachableIfStillVerifying(groupIdHex)
+        }
+    }
+
+    private suspend fun markUnreachableIfStillVerifying(groupIdHex: String) {
+        if (!store.contains(groupIdHex)) return
+        store.updateStatus(groupIdHex, PendingGroupVerification.Status.UNREACHABLE)
+    }
+
+    private suspend fun resolve(materializedHexes: Set<String>) {
+        mutex.withLock {
+            val resolved = targets.keys.filter { materializedHexes.contains(it) }
+            for (hex in resolved) {
+                timeouts[hex]?.cancel()
+                timeouts.remove(hex)
+                targets.remove(hex)
+            }
+        }
+        store.resolveMaterialized(materializedHexes)
+    }
+
+    // ─── Admin side ──────────────────────────────────────────────────
+
+    override suspend fun handleRefreshRequest(
+        request: GroupStateRefreshRequest,
+        ownerIdentityId: IdentityId,
+        requesterEd25519: ByteArray?,
+    ) {
+        val groupIdHex = request.groupId.toHexLowercase()
+        val group = groupRepository.findForOwner(ownerIdentityId.value, groupIdHex) ?: return
+
+        // Membership gate — the reply carries `salt`, so only answer a
+        // requester that is a current member, and only after confirming
+        // the envelope's signer matches that member's stored Ed25519
+        // (insider-spoof defense). The sealing target is pinned to the
+        // member's *stored* inbox key, not the request's claimed one, so
+        // a forged request can't redirect the salt elsewhere.
+        val key = request.requesterBlsPublicKey.toHexLowercase()
+        val profile = group.memberProfiles[key] ?: return
+        if (requesterEd25519 == null || !requesterEd25519.contentEquals(profile.sendingPubkey)) return
+        if (!request.requesterInboxPublicKey.contentEquals(profile.inboxPublicKey)) return
+
+        val invite = GroupInvitationPayload(
+            version = 1,
+            groupId = group.groupIdBytes,
+            groupSecret = group.groupSecret,
+            name = group.name,
+            members = group.members,
+            epoch = group.epoch,
+            salt = group.salt,
+            commitment = group.commitment,
+            tierRaw = group.tier.rawValue,
+            groupTypeRaw = group.groupType.wireValue,
+            adminPubkeyHex = group.adminPubkeyHex,
+            memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
+        )
+        val sealed = runCatching {
+            sealer.sealInvitation(
+                jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invite)
+                    .toByteArray(Charsets.UTF_8),
+                profile.inboxPublicKey,
+            )
+        }.getOrNull() ?: return
+        val tag = TransportInboxId(IdentityRepository.inboxTag(profile.inboxPublicKey))
+        runCatching { inboxTransport.send(sealed, tag) }
+    }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true }
+
+        private fun ByteArray.toHexLowercase(): String =
+            buildString(size * 2) { for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF)) }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -12,7 +12,9 @@ import app.onym.android.chats.MessageStatus
 import app.onym.android.group.ChatGroup
 import app.onym.android.group.GroupCommitmentBuilder
 import app.onym.android.group.GroupInvitationPayload
+import app.onym.android.group.GroupInviteOfferPayload
 import app.onym.android.group.GroupRepository
+import app.onym.android.group.GroupStateRefreshRequest
 import app.onym.android.group.MemberAnnouncementPayload
 import app.onym.android.group.MemberProfile
 import app.onym.android.identity.DecryptedEnvelope
@@ -71,6 +73,23 @@ class IncomingMessageDispatcher(
      *  When null (test / V1 best-effort), Tyranny payloads still
      *  apply with admin-Ed25519 + envelope-signature gating only. */
     private val chainState: ChainStateReading? = null,
+    /** Receive-side sink for decoded [GroupInviteOfferPayload]s — the
+     *  push counterpart to the deeplink join flow. An offer lands here
+     *  as a [PendingInvite] awaiting the user's explicit Accept (which
+     *  ships a [app.onym.android.group.JoinRequestPayload]) or dismiss.
+     *  It grants nothing and never materializes a group: membership
+     *  only follows the invitee's accept + the admin's explicit
+     *  on-chain approve. Defaulted to a fresh store so the many
+     *  existing dispatcher tests that don't exercise the offer path
+     *  keep their construction sites unchanged; production
+     *  ([app.onym.android.OnymApplication]) passes the shared store. */
+    private val pendingInvites: PendingInvitesRecording = PendingInvitesStore(),
+    /** Seam for the verify-at-current state machine (Option 2, PR 159).
+     *  A stale Tyranny snapshot (chain advanced past its epoch) is
+     *  deferred here on the invitee side; inbound
+     *  [GroupStateRefreshRequest]s are answered here on the admin side.
+     *  Defaulted to a no-op for the same reason as [pendingInvites]. */
+    private val groupStateRefresher: GroupStateRefreshing = NoopGroupStateRefresher(),
 ) {
 
     suspend fun dispatch(
@@ -93,6 +112,35 @@ class IncomingMessageDispatcher(
             // (ciphertext might be addressed to a different identity
             // and decryptable later).
             fallThrough(messageId, ownerIdentityId, payload, receivedAt)
+            return
+        }
+
+        // Fast path 0: GroupInviteOfferPayload — a push invitation.
+        // Decoded + queued for the user's explicit Accept; it carries
+        // no epoch / commitment / roster, so it never materializes a
+        // group or touches the on-chain commitment. Tried first because
+        // its required `inviter_alias` + `intro_pub` + `offer_version`
+        // keys are unique to this type — no other inbox payload decodes
+        // as one.
+        val offer = tryDecodeOffer(envelope.plaintext)
+        if (offer != null) {
+            recordOffer(offer, messageId, ownerIdentityId, receivedAt)
+            return
+        }
+
+        // Fast path 0.5: GroupStateRefreshRequest — a member asking the
+        // admin for the current group state (Option 2 verify-at-current,
+        // PR 159). Admin-side; delegated to the verifier, which gates on
+        // the requester being a current member before disclosing the
+        // salt. Its required `refresh_group_id` + `requester_inbox_pub`
+        // keys are unique, so the trial-decode is unambiguous.
+        val refresh = tryDecodeRefreshRequest(envelope.plaintext)
+        if (refresh != null) {
+            groupStateRefresher.handleRefreshRequest(
+                refresh,
+                ownerIdentityId,
+                envelope.senderEd25519PublicKey,
+            )
             return
         }
 
@@ -158,15 +206,26 @@ class IncomingMessageDispatcher(
         val tier = SepTier.entries.firstOrNull { it.rawValue == invitation.tierRaw } ?: return
         val groupType = SepGroupType.fromWire(invitation.groupTypeRaw) ?: return
 
-        // PR 89: receiver-side commitment verification. For Tyranny
-        // groups, the payload's `commitment` MUST match both the
-        // recomputed Poseidon root over the wire-shipped members AND
-        // the on-chain state. Either mismatch is treated as a forged
-        // invitation — drop silently.
-        if (groupType == SepGroupType.TYRANNY &&
-            !verifyTyrannyInvitation(invitation, tier)
-        ) {
-            return
+        // Receiver-side verification (Option 2, PR 159). For Tyranny
+        // groups the snapshot's commitment must match the recomputed
+        // Poseidon root AND the on-chain commitment at an EXACT epoch.
+        // When the chain has advanced past the snapshot, we can't
+        // byte-verify it — so rather than trust an unverifiable snapshot
+        // (which would let a self-consistent fake of a young group
+        // materialize) we defer to the verifier, which asks the admin
+        // for the current state and surfaces a "couldn't verify" state
+        // if the admin is unreachable. Non-Tyranny groups skip
+        // verification (no admin-anchored update path; trust falls back
+        // to the sender's envelope signature).
+        if (groupType == SepGroupType.TYRANNY) {
+            when (verifyTyrannyInvitation(invitation, tier)) {
+                TyrannyInvitationVerification.VERIFIED -> {} // materialize below
+                TyrannyInvitationVerification.REJECT -> return
+                TyrannyInvitationVerification.STALE_NEEDS_REFRESH -> {
+                    groupStateRefresher.deferVerification(invitation, ownerIdentityId)
+                    return
+                }
+            }
         }
 
         // Wire-shipped profiles first; receiver's own entry overwrites
@@ -230,6 +289,50 @@ class IncomingMessageDispatcher(
         )
     } catch (_: Throwable) {
         null
+    }
+
+    private fun tryDecodeOffer(bytes: ByteArray): GroupInviteOfferPayload? = try {
+        permissiveJson.decodeFromString(
+            GroupInviteOfferPayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    private fun tryDecodeRefreshRequest(bytes: ByteArray): GroupStateRefreshRequest? = try {
+        permissiveJson.decodeFromString(
+            GroupStateRefreshRequest.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    /**
+     * Queue a decoded push offer for the user's explicit Accept. Keyed
+     * by the inbound Nostr event id so a re-delivered offer (replaceable
+     * events are re-fetched on every relaunch) is idempotent in the
+     * store. Never materializes a group — that only follows the
+     * invitee's accept + the admin's explicit on-chain approve.
+     */
+    private suspend fun recordOffer(
+        offer: GroupInviteOfferPayload,
+        messageId: String,
+        ownerIdentityId: IdentityId,
+        receivedAt: Instant,
+    ) {
+        pendingInvites.record(
+            PendingInvite(
+                id = messageId,
+                ownerIdentityId = ownerIdentityId,
+                introPublicKey = offer.introPublicKey,
+                groupId = offer.groupId,
+                groupName = offer.groupName,
+                inviterAlias = offer.inviterAlias,
+                receivedAt = receivedAt,
+            ),
+        )
     }
 
     private suspend fun fallThrough(
@@ -412,21 +515,20 @@ class IncomingMessageDispatcher(
      * the chain anchor verification still catches forgeries via the
      * second branch.
      *
-     * Mirrors `verifyTyrannyInvitation` from onym-ios PR #89.
+     * Mirrors `verifyTyrannyInvitation` from onym-ios PR #159.
      */
     private suspend fun verifyTyrannyInvitation(
         invitation: app.onym.android.group.GroupInvitationPayload,
         tier: SepTier,
-    ): Boolean {
+    ): TyrannyInvitationVerification {
         // Without a chain reader we treat Tyranny as best-effort;
         // V1 never reaches the on-chain branch in tests.
-        val reader = chainState ?: return true
-        val claimed = invitation.commitment ?: return false
-        // Internal consistency: recompute the FULL Poseidon
-        // commitment from `(members, epoch, salt)` and compare. The
-        // commitment is `Poseidon(Poseidon(root, epoch), salt)` —
-        // NOT just the merkle root. PR 89's original implementation
-        // compared the root, which always failed; PR 91 fixes that.
+        val reader = chainState ?: return TyrannyInvitationVerification.VERIFIED
+        val claimed = invitation.commitment ?: return TyrannyInvitationVerification.REJECT
+        // Internal consistency: recompute the FULL Poseidon commitment
+        // from `(members, epoch, salt)` and compare. The commitment is
+        // `Poseidon(Poseidon(root, epoch), salt)` — NOT just the merkle
+        // root.
         val recomputed = try {
             val root = GroupCommitmentBuilder.computeMerkleRoot(invitation.members, tier)
             GroupCommitmentBuilder.computePoseidonCommitment(
@@ -435,18 +537,51 @@ class IncomingMessageDispatcher(
                 salt = invitation.salt,
             )
         } catch (_: Throwable) {
-            return false
+            return TyrannyInvitationVerification.REJECT
         }
-        if (!recomputed.contentEquals(claimed)) return false
-        // External anchor.
+        if (!recomputed.contentEquals(claimed)) return TyrannyInvitationVerification.REJECT
+        // Verify at current chain state (Option 2). The chain stores only
+        // the LATEST (commitment, epoch), so a snapshot is only
+        // byte-verifiable when the chain is exactly at its epoch.
+        //   - chain behind the snapshot → impossible for a real anchored
+        //     snapshot; reject.
+        //   - chain EXACTLY at the snapshot's epoch → byte-verify the
+        //     committed roster. Strong anti-forgery: reproducing
+        //     `Poseidon(Poseidon(root, epoch), salt)` needs the random
+        //     `salt`, which is never on chain — only a legitimate
+        //     invitation carries it.
+        //   - chain AHEAD → can't byte-verify here; defer and ask the
+        //     admin for the current state rather than trusting (and
+        //     thereby letting a self-consistent fake materialize).
         val onchain = try {
             reader.tyrannyCommitment(invitation.groupId)
         } catch (_: Throwable) {
-            return false
+            return TyrannyInvitationVerification.REJECT
         }
-        if (!onchain.commitment.contentEquals(claimed)) return false
-        if (onchain.epoch != invitation.epoch) return false
-        return true
+        if (onchain.epoch < invitation.epoch) return TyrannyInvitationVerification.REJECT
+        if (onchain.epoch == invitation.epoch) {
+            return if (onchain.commitment.contentEquals(claimed)) {
+                TyrannyInvitationVerification.VERIFIED
+            } else {
+                TyrannyInvitationVerification.REJECT
+            }
+        }
+        return TyrannyInvitationVerification.STALE_NEEDS_REFRESH
+    }
+
+    /** Outcome of receiver-side Tyranny invitation verification (PR 159). */
+    private enum class TyrannyInvitationVerification {
+        /** Internally consistent AND matches the on-chain commitment at
+         *  an exact epoch — safe to materialize. */
+        VERIFIED,
+
+        /** Internally consistent and the group exists on chain, but the
+         *  chain has advanced past the snapshot's epoch, so it can't be
+         *  byte-verified. Needs a current-state refresh from the admin. */
+        STALE_NEEDS_REFRESH,
+
+        /** Forged / unverifiable — drop. */
+        REJECT,
     }
 
     /**
@@ -475,8 +610,18 @@ class IncomingMessageDispatcher(
         } catch (_: Throwable) {
             return false
         }
-        if (!onchain.commitment.contentEquals(claimedCommitment)) return false
-        if (onchain.epoch != claimedEpoch) return false
+        // Same converge-forward gate as the invitation verifier. The
+        // announcement is already admin-Ed25519-signed (checked by the
+        // caller), so a stale-but-signed roster delta is a legitimate
+        // update we may have missed — accept when the chain is at or
+        // ahead of the claimed epoch, byte-verifying only on an exact
+        // epoch match.
+        if (onchain.epoch < claimedEpoch) return false
+        if (onchain.epoch == claimedEpoch &&
+            !onchain.commitment.contentEquals(claimedCommitment)
+        ) {
+            return false
+        }
         return true
     }
 

--- a/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesScreen.kt
@@ -1,0 +1,324 @@
+package app.onym.android.inbox
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.MailOutline
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+/**
+ * Invitee-side "you've been invited" list — the push counterpart to the
+ * deeplink [app.onym.android.group.JoinScreen]. Mirrors
+ * [app.onym.android.group.ApproveRequestsScreen]: a modal of cards, each
+ * offering Accept (ship a join request) or Dismiss. Accept is the
+ * explicit step; the group only appears once the admin approves the
+ * resulting request on chain.
+ *
+ * Mirrors `PendingInvitesView` from onym-ios PR #158.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PendingInvitesScreen(
+    viewModel: PendingInvitesViewModel,
+    onClose: () -> Unit,
+) {
+    LaunchedEffect(viewModel) { viewModel.start() }
+
+    val pending by viewModel.pending.collectAsStateWithLifecycle()
+    val verifying by viewModel.verifying.collectAsStateWithLifecycle()
+    val inFlight by viewModel.inFlightIds.collectAsStateWithLifecycle()
+    val requested by viewModel.requestedIds.collectAsStateWithLifecycle()
+    val lastError by viewModel.lastError.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Invitations") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onClose,
+                        modifier = Modifier.testTag("pending_invites.close_button"),
+                    ) {
+                        Icon(Icons.Filled.Close, contentDescription = "Close")
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) { padding ->
+        Column(modifier = Modifier.padding(padding).fillMaxSize()) {
+            lastError?.let { ErrorBanner(message = it, onDismiss = viewModel::dismissError) }
+            if (pending.isEmpty() && verifying.isEmpty()) {
+                EmptyState()
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(16.dp),
+                ) {
+                    items(pending, key = { it.id }) { invite ->
+                        InviteCard(
+                            invite = invite,
+                            inFlight = inFlight.contains(invite.id),
+                            requested = requested.contains(invite.id),
+                            onAccept = { viewModel.accept(invite.id) },
+                            onDismiss = { viewModel.dismiss(invite.id) },
+                        )
+                    }
+                    items(verifying, key = { it.id }) { entry ->
+                        VerifyingCard(entry = entry, onRetry = { viewModel.retry(entry.groupIdHex) })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xFFFDECEC))
+            .padding(12.dp)
+            .testTag("pending_invites.error_banner"),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(Icons.Filled.Warning, contentDescription = null, tint = Color(0xFFD0011B))
+        Text(text = message, modifier = Modifier.weight(1f), fontSize = 13.sp)
+        IconButton(
+            onClick = onDismiss,
+            modifier = Modifier.size(24.dp).testTag("pending_invites.error_dismiss"),
+        ) {
+            Icon(Icons.Filled.Close, contentDescription = "Dismiss", modifier = Modifier.size(14.dp))
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier.fillMaxSize().testTag("pending_invites.empty"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Filled.MailOutline,
+            contentDescription = null,
+            modifier = Modifier.size(44.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(14.dp))
+        Text("No invitations", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "Group invites you receive show up here for you to accept.",
+            fontSize = 13.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 32.dp),
+        )
+    }
+}
+
+@Composable
+private fun InviteCard(
+    invite: PendingInvite,
+    inFlight: Boolean,
+    requested: Boolean,
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(14.dp)
+            .testTag("pending_invites.card.${invite.id}"),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(
+                text = displayAlias(invite.inviterAlias),
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+            )
+            Text(
+                text = "invited you to “${invite.groupName ?: "a group"}”",
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = onDismiss,
+                enabled = !inFlight,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("pending_invites.dismiss_button.${invite.id}"),
+            ) {
+                Text("Dismiss")
+            }
+            Button(
+                onClick = onAccept,
+                enabled = !inFlight && !requested,
+                colors = ButtonDefaults.buttonColors(),
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("pending_invites.accept_button.${invite.id}"),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    if (inFlight) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                    Text(acceptLabel(inFlight = inFlight, requested = requested))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A group accepted but not yet verifiable against the current on-chain
+ * state — kept out of the chats list. Shows progress while waiting for
+ * the admin's current-state reply, and a Retry when the admin couldn't
+ * be reached.
+ */
+@Composable
+private fun VerifyingCard(
+    entry: PendingGroupVerification,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(14.dp)
+            .testTag("pending_invites.verifying.${entry.groupIdHex}"),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = entry.groupName.ifEmpty { "Group" },
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 16.sp,
+        )
+        when (entry.status) {
+            PendingGroupVerification.Status.VERIFYING -> {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+                    Text(
+                        "Verifying group state…",
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            PendingGroupVerification.Status.UNREACHABLE -> {
+                Text(
+                    "Couldn’t verify — the admin is offline. The group stays hidden until it can be verified on chain.",
+                    fontSize = 13.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(
+                    onClick = onRetry,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("pending_invites.verifying_retry.${entry.groupIdHex}"),
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
+    }
+}
+
+private fun acceptLabel(inFlight: Boolean, requested: Boolean): String = when {
+    requested -> "Requested — awaiting approval"
+    inFlight -> "Sending…"
+    else -> "Accept"
+}
+
+private fun displayAlias(raw: String): String {
+    val trimmed = raw.trim()
+    return if (trimmed.isEmpty()) "Someone" else trimmed
+}
+
+/**
+ * Chats-toolbar entry point: an envelope with a count badge. Always
+ * rendered (like the join-requests button) so the surface is
+ * discoverable; the badge only shows when there's at least one pending
+ * invite. Pure composable — the chats screen owns the modal state.
+ */
+@Composable
+fun PendingInvitesToolbarBadge(pendingCount: Int) {
+    if (pendingCount > 0) {
+        Box(
+            modifier = Modifier
+                .size(16.dp)
+                .clip(RoundedCornerShape(50))
+                .background(Color(0xFFD0011B))
+                .testTag("pending_invites.toolbar_badge"),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = pendingCount.toString(),
+                color = Color.White,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesStore.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesStore.kt
@@ -1,0 +1,140 @@
+package app.onym.android.inbox
+
+import app.onym.android.identity.IdentityId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+
+/**
+ * One decoded [app.onym.android.group.GroupInviteOfferPayload] awaiting
+ * the user's explicit Accept / Dismiss. Unlike the opaque ciphertext
+ * the legacy invitations queue holds, the offer is decrypted + decoded
+ * at receive time by [IncomingMessageDispatcher], so this record
+ * carries the structured fields the UI needs to render "X invited you
+ * to Y" and the intro public key the Accept action replies to.
+ *
+ * Mirrors `PendingInvite` from onym-ios PR #158.
+ */
+data class PendingInvite(
+    /** Nostr event id of the inbound offer — the dedupe + consume key. */
+    val id: String,
+    /** Identity the offer was delivered to (the inbox tag it arrived
+     *  on). The Accept action replies *as* this identity. */
+    val ownerIdentityId: IdentityId,
+    /** Admin's per-invite intro pubkey — the reply channel the join
+     *  request is sealed to. */
+    val introPublicKey: ByteArray,
+    val groupId: ByteArray,
+    val groupName: String?,
+    val inviterAlias: String,
+    val receivedAt: Instant,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PendingInvite) return false
+        return id == other.id &&
+            ownerIdentityId == other.ownerIdentityId &&
+            introPublicKey.contentEquals(other.introPublicKey) &&
+            groupId.contentEquals(other.groupId) &&
+            groupName == other.groupName &&
+            inviterAlias == other.inviterAlias &&
+            receivedAt == other.receivedAt
+    }
+
+    override fun hashCode(): Int {
+        var h = id.hashCode()
+        h = 31 * h + ownerIdentityId.hashCode()
+        h = 31 * h + introPublicKey.contentHashCode()
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + (groupName?.hashCode() ?: 0)
+        h = 31 * h + inviterAlias.hashCode()
+        h = 31 * h + receivedAt.hashCode()
+        return h
+    }
+}
+
+/**
+ * Receive-side seam the dispatcher writes decoded offers into. Kept
+ * minimal (one method) so the dispatcher depends on a narrow interface
+ * rather than the concrete store — and existing dispatcher tests that
+ * don't exercise the offer path can pass a fresh default store.
+ *
+ * Mirrors `PendingInvitesRecording` from onym-ios PR #158.
+ */
+interface PendingInvitesRecording {
+    /** Idempotent on [PendingInvite.id]. Re-delivery of the same offer
+     *  (replaceable Nostr event re-fetched on relaunch) is a no-op. */
+    suspend fun record(invite: PendingInvite)
+}
+
+/**
+ * Process-lifetime store of pending invites, filtered by the
+ * currently-selected identity. In-memory by design: the offer itself
+ * is a retained Nostr event, so the inbox fan-out re-delivers it on
+ * every launch — exactly like [app.onym.android.group.InMemoryIntroRequestStore]
+ * for join requests. [snapshots] mirrors the per-identity filtering the
+ * group / invitations repositories use, so the list flips when the
+ * user switches identity.
+ *
+ * Android analogue of the iOS `PendingInvitesStore` actor — a [Mutex]
+ * guards the mutable list and a [StateFlow] publishes the filtered
+ * snapshot.
+ */
+class PendingInvitesStore : PendingInvitesRecording {
+    private val mutex = Mutex()
+    private val all = mutableListOf<PendingInvite>()
+    private var currentIdentity: IdentityId? = null
+
+    private val _snapshots = MutableStateFlow<List<PendingInvite>>(emptyList())
+
+    /** Hot stream of pending invites for the current identity, newest
+     *  first. Empty until an identity is selected via
+     *  [setCurrentIdentity]. */
+    val snapshots: StateFlow<List<PendingInvite>> = _snapshots.asStateFlow()
+
+    override suspend fun record(invite: PendingInvite) = mutex.withLock {
+        if (all.any { it.id == invite.id }) return@withLock
+        all.add(invite)
+        publishLocked()
+    }
+
+    /** Drop an invite after the user accepted or dismissed it. */
+    suspend fun consume(id: String) = mutex.withLock {
+        if (all.removeAll { it.id == id }) publishLocked()
+    }
+
+    /** Cascade for the identity-removal flow. */
+    suspend fun removeForOwner(id: IdentityId) = mutex.withLock {
+        if (all.removeAll { it.ownerIdentityId == id }) publishLocked()
+    }
+
+    /**
+     * Drop every pending invite whose group now exists locally — the
+     * admin approved + the [app.onym.android.group.GroupInvitationPayload]
+     * materialized the group, so the offer has served its purpose.
+     * Called by the view-model when [app.onym.android.group.GroupRepository]
+     * emits.
+     */
+    suspend fun consumeForMaterializedGroups(groupIds: Set<List<Byte>>) = mutex.withLock {
+        if (groupIds.isEmpty()) return@withLock
+        if (all.removeAll { groupIds.contains(it.groupId.toList()) }) publishLocked()
+    }
+
+    suspend fun setCurrentIdentity(id: IdentityId?) = mutex.withLock {
+        currentIdentity = id
+        publishLocked()
+    }
+
+    private fun publishLocked() {
+        val active = currentIdentity
+        _snapshots.value = if (active == null) {
+            emptyList()
+        } else {
+            all.filter { it.ownerIdentityId == active }
+                .sortedByDescending { it.receivedAt }
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/PendingInvitesViewModel.kt
@@ -1,0 +1,169 @@
+package app.onym.android.inbox
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.IntroCapability
+import app.onym.android.group.JoinRequestSender
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * View-model for the invitee-side "you've been invited" surface — the
+ * push counterpart to [app.onym.android.group.JoinViewModel] (which
+ * handles deeplink joins). Mirrors [app.onym.android.group.ApproveRequestsViewModel]'s
+ * shape: a shared instance whose [pending] list backs both the Chats
+ * toolbar badge and the modal list.
+ *
+ * Accept is the *explicit* step the design requires: it turns a
+ * [PendingInvite] (an offer) into a [app.onym.android.group.JoinRequestPayload]
+ * shipped to the admin's intro key via the same [JoinRequestSender] the
+ * deeplink path uses. Nothing here anchors the roster — the admin still
+ * has to explicitly approve the resulting request. The group appears on
+ * accept only after that approval lands and materializes it, at which
+ * point [start]'s group watcher consumes the spent invite.
+ *
+ * Mirrors `PendingInvitesFlow` from onym-ios PR #158.
+ */
+class PendingInvitesViewModel(
+    private val store: PendingInvitesStore,
+    private val verificationStore: PendingVerificationStore,
+    private val groupRepository: GroupRepository,
+    /** Mirrors [app.onym.android.group.JoinViewModel]'s injected
+     *  `submitRequest` — seals + sends a join request for the given
+     *  capability. Returns the sender outcome so the VM can surface
+     *  errors. */
+    private val submitJoin: suspend (IntroCapability, String) -> JoinRequestSender.Outcome,
+    /** Resolves the joiner's display label at accept time (the active
+     *  identity's alias). Read lazily so an identity rename is picked
+     *  up without re-wiring. */
+    private val displayLabel: () -> String,
+    /** Re-send a stuck verification's refresh request (Retry button).
+     *  Backed by [GroupStateVerifier.retry]. */
+    private val retryVerification: suspend (String) -> Unit,
+) : ViewModel() {
+
+    /** Pending invites for the current identity, newest first. */
+    private val _pending = MutableStateFlow<List<PendingInvite>>(emptyList())
+    val pending: StateFlow<List<PendingInvite>> = _pending.asStateFlow()
+
+    /** Groups that were accepted but couldn't be verified at an exact
+     *  epoch yet — awaiting (or unable to get) the current state from
+     *  the admin. Hidden from the chats list until verified; surfaced
+     *  here so the user knows a join is in flight or stuck. */
+    private val _verifying = MutableStateFlow<List<PendingGroupVerification>>(emptyList())
+    val verifying: StateFlow<List<PendingGroupVerification>> = _verifying.asStateFlow()
+
+    /** IDs whose accept call is in flight (drives the per-row spinner). */
+    private val _inFlightIds = MutableStateFlow<Set<String>>(emptySet())
+    val inFlightIds: StateFlow<Set<String>> = _inFlightIds.asStateFlow()
+
+    /** IDs whose join request has been sent and is awaiting the admin's
+     *  approval. Relabels the row and disables Accept so the user
+     *  doesn't double-request. */
+    private val _requestedIds = MutableStateFlow<Set<String>>(emptySet())
+    val requestedIds: StateFlow<Set<String>> = _requestedIds.asStateFlow()
+
+    private val _lastError = MutableStateFlow<String?>(null)
+    val lastError: StateFlow<String?> = _lastError.asStateFlow()
+
+    private var streamJob: Job? = null
+    private var verifyingJob: Job? = null
+    private var groupWatchJob: Job? = null
+
+    fun isInFlight(id: String): Boolean = _inFlightIds.value.contains(id)
+    fun isRequested(id: String): Boolean = _requestedIds.value.contains(id)
+
+    /**
+     * Mirror the store's snapshot into [pending] and watch groups so a
+     * spent invite is dropped once its group materializes. Idempotent.
+     */
+    fun start() {
+        if (streamJob != null) return
+        streamJob = viewModelScope.launch {
+            store.snapshots.collect { snapshot ->
+                _pending.value = snapshot
+                // Forget request / in-flight bookkeeping for invites
+                // that are no longer present (consumed / identity
+                // switch).
+                val live = snapshot.mapTo(mutableSetOf()) { it.id }
+                _requestedIds.value = _requestedIds.value.intersect(live)
+                _inFlightIds.value = _inFlightIds.value.intersect(live)
+            }
+        }
+        verifyingJob = viewModelScope.launch {
+            verificationStore.snapshots.collect { snapshot -> _verifying.value = snapshot }
+        }
+        groupWatchJob = viewModelScope.launch {
+            groupRepository.snapshots.collect { groups ->
+                store.consumeForMaterializedGroups(
+                    groups.mapTo(mutableSetOf()) { it.groupIdBytes.toList() },
+                )
+            }
+        }
+    }
+
+    fun stop() {
+        streamJob?.cancel()
+        streamJob = null
+        verifyingJob?.cancel()
+        verifyingJob = null
+        groupWatchJob?.cancel()
+        groupWatchJob = null
+    }
+
+    /** Retry a verification that got stuck because the admin was
+     *  unreachable for the current-state refresh. */
+    fun retry(groupIdHex: String) {
+        viewModelScope.launch { retryVerification(groupIdHex) }
+    }
+
+    /**
+     * Explicit Accept: ship a join request to the offer's intro key.
+     * No-op while already in flight or already requested.
+     */
+    fun accept(id: String) {
+        if (_inFlightIds.value.contains(id) || _requestedIds.value.contains(id)) return
+        val invite = _pending.value.firstOrNull { it.id == id } ?: return
+        val capability = try {
+            IntroCapability(
+                introPublicKey = invite.introPublicKey,
+                groupId = invite.groupId,
+                groupName = invite.groupName,
+            )
+        } catch (_: Throwable) {
+            _lastError.value = "This invite is malformed and can't be accepted."
+            return
+        }
+        _inFlightIds.value = _inFlightIds.value + id
+        _lastError.value = null
+        val label = displayLabel()
+        viewModelScope.launch {
+            val outcome = submitJoin(capability, label)
+            _inFlightIds.value = _inFlightIds.value - id
+            when (outcome) {
+                is JoinRequestSender.Outcome.Sent ->
+                    _requestedIds.value = _requestedIds.value + id
+                is JoinRequestSender.Outcome.NoIdentityLoaded ->
+                    _lastError.value = "Sign in first."
+                is JoinRequestSender.Outcome.TransportFailed ->
+                    _lastError.value = "Couldn’t send request: ${outcome.reason}"
+            }
+        }
+    }
+
+    /**
+     * Drop an invite the user doesn't want. Local-only — no NACK to the
+     * admin (their outstanding intro key just goes unused).
+     */
+    fun dismiss(id: String) {
+        viewModelScope.launch { store.consume(id) }
+    }
+
+    fun dismissError() {
+        _lastError.value = null
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/PendingVerificationStore.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/PendingVerificationStore.kt
@@ -1,0 +1,106 @@
+package app.onym.android.inbox
+
+import app.onym.android.identity.IdentityId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+
+/**
+ * A Tyranny group whose invitation snapshot couldn't be verified at an
+ * exact epoch (the chain had advanced past it), so it's awaiting a
+ * fresh snapshot from the admin before it may materialize. Kept OUT of
+ * the chats list — an unverifiable snapshot must never look like a real
+ * chat — and surfaced in the Invitations UI so the user knows a join is
+ * in flight (or stuck because the admin is offline).
+ *
+ * Mirrors `PendingGroupVerification` from onym-ios PR #159.
+ */
+data class PendingGroupVerification(
+    /** Dedupe key — one pending verification per group. Lowercase hex of
+     *  the 32-byte on-chain `group_id` (matches [app.onym.android.group.ChatGroup.id]). */
+    val groupIdHex: String,
+    val ownerIdentityId: IdentityId,
+    val groupName: String,
+    val status: Status,
+    val receivedAt: Instant,
+) {
+    val id: String get() = groupIdHex
+
+    enum class Status {
+        /** Refresh request sent; waiting for the admin's reply. */
+        VERIFYING,
+
+        /** No reply within the timeout (or no admin inbox to ask) —
+         *  surfaced to the user with a Retry. */
+        UNREACHABLE,
+    }
+}
+
+/**
+ * In-memory, per-identity-filtered store of groups awaiting
+ * verification. In-memory by design: the stale invitation is a retained
+ * Nostr event re-delivered on every launch, so the verifier re-defers
+ * and re-requests on relaunch — same model as [PendingInvitesStore].
+ *
+ * Android analogue of the iOS `PendingVerificationStore` actor — a
+ * [Mutex] guards the list and a [StateFlow] publishes the filtered
+ * snapshot.
+ */
+class PendingVerificationStore {
+    private val mutex = Mutex()
+    private val all = mutableListOf<PendingGroupVerification>()
+    private var currentIdentity: IdentityId? = null
+
+    private val _snapshots = MutableStateFlow<List<PendingGroupVerification>>(emptyList())
+    val snapshots: StateFlow<List<PendingGroupVerification>> = _snapshots.asStateFlow()
+
+    /** Idempotent on [PendingGroupVerification.groupIdHex]. A re-deferred
+     *  snapshot (re-delivery) keeps the existing entry/status rather than
+     *  resetting it. */
+    suspend fun record(entry: PendingGroupVerification) = mutex.withLock {
+        if (all.any { it.groupIdHex == entry.groupIdHex }) return@withLock
+        all.add(entry)
+        publishLocked()
+    }
+
+    suspend fun updateStatus(groupIdHex: String, status: PendingGroupVerification.Status) =
+        mutex.withLock {
+            val idx = all.indexOfFirst { it.groupIdHex == groupIdHex }
+            if (idx < 0 || all[idx].status == status) return@withLock
+            all[idx] = all[idx].copy(status = status)
+            publishLocked()
+        }
+
+    suspend fun contains(groupIdHex: String): Boolean = mutex.withLock {
+        all.any { it.groupIdHex == groupIdHex }
+    }
+
+    /** Remove entries whose group now exists locally — the fresh
+     *  snapshot verified + materialized, so verification is done. */
+    suspend fun resolveMaterialized(groupIdHexes: Set<String>) = mutex.withLock {
+        if (groupIdHexes.isEmpty()) return@withLock
+        if (all.removeAll { groupIdHexes.contains(it.groupIdHex) }) publishLocked()
+    }
+
+    suspend fun removeForOwner(id: IdentityId) = mutex.withLock {
+        if (all.removeAll { it.ownerIdentityId == id }) publishLocked()
+    }
+
+    suspend fun setCurrentIdentity(id: IdentityId?) = mutex.withLock {
+        currentIdentity = id
+        publishLocked()
+    }
+
+    private fun publishLocked() {
+        val active = currentIdentity
+        _snapshots.value = if (active == null) {
+            emptyList()
+        } else {
+            all.filter { it.ownerIdentityId == active }
+                .sortedByDescending { it.receivedAt }
+        }
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/group/GroupInviteOfferPayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/GroupInviteOfferPayloadTest.kt
@@ -1,0 +1,120 @@
+package app.onym.android.group
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Codec + wire-disambiguation tests for [GroupInviteOfferPayload].
+ *
+ * Mirrors `GroupInviteOfferPayloadTests.swift` from onym-ios PR #158.
+ */
+class GroupInviteOfferPayloadTest {
+
+    // Mirror the dispatcher's permissive decode — the disambiguation
+    // guarantee has to hold even when unknown keys are ignored.
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private fun makeValid() = GroupInviteOfferPayload(
+        introPublicKey = ByteArray(32) { 0x11 },
+        groupId = ByteArray(32) { 0x22 },
+        groupName = "Maple Garden",
+        inviterAlias = "Alice",
+    )
+
+    @Test
+    fun roundTrip_preservesAllFields() {
+        val offer = makeValid()
+        val encoded = json.encodeToString(GroupInviteOfferPayload.serializer(), offer)
+        val decoded = json.decodeFromString(GroupInviteOfferPayload.serializer(), encoded)
+        assertEquals(offer, decoded)
+        assertEquals(1, decoded.version)
+        assertEquals("Maple Garden", decoded.groupName)
+        assertEquals("Alice", decoded.inviterAlias)
+    }
+
+    @Test
+    fun nilGroupName_roundTrips() {
+        val offer = GroupInviteOfferPayload(
+            introPublicKey = ByteArray(32) { 0x01 },
+            groupId = ByteArray(32) { 0x02 },
+            groupName = null,
+            inviterAlias = "",
+        )
+        val decoded = json.decodeFromString(
+            GroupInviteOfferPayload.serializer(),
+            json.encodeToString(GroupInviteOfferPayload.serializer(), offer),
+        )
+        assertNull(decoded.groupName)
+        assertEquals(offer, decoded)
+    }
+
+    @Test
+    fun wrongIntroKeyLength_throws() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GroupInviteOfferPayload(
+                introPublicKey = ByteArray(31) { 0x11 },
+                groupId = ByteArray(32) { 0x22 },
+                groupName = null,
+                inviterAlias = "A",
+            )
+        }
+    }
+
+    @Test
+    fun wrongGroupIdLength_throws() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GroupInviteOfferPayload(
+                introPublicKey = ByteArray(32) { 0x11 },
+                groupId = ByteArray(16) { 0x22 },
+                groupName = null,
+                inviterAlias = "A",
+            )
+        }
+    }
+
+    /**
+     * The dispatcher relies on `inviter_alias` + `intro_pub` being
+     * unique to this type. A [JoinRequestPayload] (the other
+     * intro-keyed payload) must NOT decode as an offer.
+     */
+    @Test
+    fun joinRequestPayload_doesNotDecodeAsOffer() {
+        val join = JoinRequestPayload(
+            joinerInboxPublicKey = ByteArray(32) { 0x01 },
+            joinerBlsPublicKey = ByteArray(48) { 0x02 },
+            joinerLeafHash = ByteArray(32) { 0x03 },
+            joinerSendingPublicKey = ByteArray(32) { 0x04 },
+            joinerDisplayLabel = "Bob",
+            groupId = ByteArray(32) { 0x05 },
+        )
+        val bytes = json.encodeToString(JoinRequestPayload.serializer(), join)
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupInviteOfferPayload.serializer(), bytes)
+        }
+    }
+
+    /**
+     * Conversely, an encoded offer must NOT decode as the membership
+     * grant — a stray `group_id` shared between the two types isn't
+     * enough to materialize a group from an offer.
+     */
+    @Test
+    fun offer_doesNotDecodeAsInvitation() {
+        val bytes = json.encodeToString(GroupInviteOfferPayload.serializer(), makeValid())
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupInvitationPayload.serializer(), bytes)
+        }
+    }
+
+    @Test
+    fun introCapability_rebuildsFromOffer() {
+        val offer = makeValid()
+        val cap = offer.introCapability()
+        assertEquals(offer.introPublicKey.toList(), cap.introPublicKey.toList())
+        assertEquals(offer.groupId.toList(), cap.groupId.toList())
+        assertEquals(offer.groupName, cap.groupName)
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/group/GroupStateRefreshRequestTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/GroupStateRefreshRequestTest.kt
@@ -1,0 +1,86 @@
+package app.onym.android.group
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Codec + wire-disambiguation tests for [GroupStateRefreshRequest].
+ *
+ * Mirrors `GroupStateRefreshRequestCodecTests` from onym-ios PR #159.
+ */
+class GroupStateRefreshRequestTest {
+
+    // Mirror the dispatcher's permissive decode — disambiguation must
+    // hold even when unknown keys are ignored.
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private fun makeValid() = GroupStateRefreshRequest(
+        groupId = ByteArray(32) { 0x42 },
+        requesterInboxPublicKey = ByteArray(32) { 0x11 },
+        requesterBlsPublicKey = ByteArray(48) { 0x22 },
+    )
+
+    @Test
+    fun roundTrip_preservesAllFields() {
+        val req = makeValid()
+        val decoded = json.decodeFromString(
+            GroupStateRefreshRequest.serializer(),
+            json.encodeToString(GroupStateRefreshRequest.serializer(), req),
+        )
+        assertEquals(req, decoded)
+        assertEquals(1, decoded.version)
+    }
+
+    @Test
+    fun wrongGroupIdLength_throws() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GroupStateRefreshRequest(
+                groupId = ByteArray(31) { 0x42 },
+                requesterInboxPublicKey = ByteArray(32) { 0x11 },
+                requesterBlsPublicKey = ByteArray(48) { 0x22 },
+            )
+        }
+    }
+
+    @Test
+    fun wrongBlsLength_throws() {
+        assertThrows(IllegalArgumentException::class.java) {
+            GroupStateRefreshRequest(
+                groupId = ByteArray(32) { 0x42 },
+                requesterInboxPublicKey = ByteArray(32) { 0x11 },
+                requesterBlsPublicKey = ByteArray(32) { 0x22 },  // BLS must be 48
+            )
+        }
+    }
+
+    /** An invite offer must NOT decode as a refresh request — disjoint
+     *  required keys keep the dispatcher's trial-decode unambiguous. */
+    @Test
+    fun offer_doesNotDecodeAsRefresh() {
+        val offer = GroupInviteOfferPayload(
+            introPublicKey = ByteArray(32) { 0x11 },
+            groupId = ByteArray(32) { 0x42 },
+            groupName = "G",
+            inviterAlias = "A",
+        )
+        val bytes = json.encodeToString(GroupInviteOfferPayload.serializer(), offer)
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupStateRefreshRequest.serializer(), bytes)
+        }
+    }
+
+    /** Conversely a refresh request must NOT decode as an offer or as a
+     *  membership-grant invitation. */
+    @Test
+    fun refresh_doesNotDecodeAsOfferOrInvitation() {
+        val bytes = json.encodeToString(GroupStateRefreshRequest.serializer(), makeValid())
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupInviteOfferPayload.serializer(), bytes)
+        }
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupInvitationPayload.serializer(), bytes)
+        }
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/inbox/GroupStateVerifierTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/GroupStateVerifierTest.kt
@@ -1,0 +1,295 @@
+package app.onym.android.inbox
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupInvitationPayload
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.GroupStateRefreshRequest
+import app.onym.android.group.MemberProfile
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.support.ConfigurableInboxTransport
+import app.onym.android.support.FakeActiveIdentityProvider
+import app.onym.android.support.InMemoryGroupStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Behavioral tests for [GroupStateVerifier] — the verify-at-current
+ * state machine (PR 159). Exercises the salt-non-disclosure gates on
+ * the admin side and the unreachable fallback on the invitee side.
+ * (The exact-epoch byte-verify itself is FFI-backed and lives in the
+ * androidTest dispatcher test.)
+ *
+ * Mirrors `GroupStateVerifierTests` from onym-ios PR #159.
+ */
+class GroupStateVerifierTest {
+
+    private val owner = IdentityId("owner")
+    private val meBls = ByteArray(48) { 0x33 }
+    private val meInbox = ByteArray(32) { 0x34 }
+    private val meSending = ByteArray(32) { 0x35 }
+
+    private lateinit var active: FakeActiveIdentityProvider
+    private lateinit var groups: GroupRepository
+    private lateinit var transport: ConfigurableInboxTransport
+    private lateinit var store: PendingVerificationStore
+    private lateinit var identities: MutableStateFlow<List<IdentitySummary>>
+    private lateinit var verifierScope: CoroutineScope
+
+    @Before
+    fun setUp() = runTest {
+        active = FakeActiveIdentityProvider(owner)
+        groups = GroupRepository(
+            store = InMemoryGroupStore(),
+            identity = active,
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        transport = ConfigurableInboxTransport()
+        store = PendingVerificationStore()
+        store.setCurrentIdentity(owner)
+        identities = MutableStateFlow(
+            listOf(
+                IdentitySummary(
+                    id = owner,
+                    name = "Me",
+                    blsPublicKey = meBls,
+                    inboxPublicKey = meInbox,
+                    sendingPublicKey = meSending,
+                ),
+            ),
+        )
+        // Real (non-test-scheduler) scope + long timeout so the launched
+        // timeout never fires during the assertions.
+        verifierScope = CoroutineScope(Dispatchers.Default)
+    }
+
+    private fun makeVerifier() = GroupStateVerifier(
+        sealer = FakeSealer(),
+        inboxTransport = transport,
+        groupRepository = groups,
+        store = store,
+        identities = identities,
+        activeIdentityId = active.currentIdentityId,
+        scope = verifierScope,
+        refreshTimeoutMillis = 10 * 60 * 1000,
+    )
+
+    /** A snapshot whose admin we can't reach (no admin entry in the
+     *  shipped roster) is recorded as UNREACHABLE and surfaced — not
+     *  silently dropped, never materialized. */
+    @Test
+    fun deferVerification_noAdminInbox_marksUnreachable() = runTest {
+        val verifier = makeVerifier()
+        val invitation = invitation(
+            groupId = ByteArray(32) { 0x42 },
+            adminPubkeyHex = "aa".repeat(48),
+            memberProfiles = null,  // admin not reachable
+        )
+
+        verifier.deferVerification(invitation, owner)
+
+        val snapshot = store.snapshots.value
+        assertEquals(1, snapshot.size)
+        assertEquals(PendingGroupVerification.Status.UNREACHABLE, snapshot.first().status)
+        assertTrue("deferral must not materialize a group", groups.snapshots.value.isEmpty())
+        assertEquals("no admin inbox → nothing to send", 0, transport.sends().size)
+    }
+
+    /** With a reachable admin, defer sends a refresh and marks the group
+     *  VERIFYING (hidden from the chats list until verified). */
+    @Test
+    fun deferVerification_withAdminInbox_sendsRefreshAndMarksVerifying() = runTest {
+        val verifier = makeVerifier()
+        val adminBlsHex = "cc".repeat(48)
+        val adminInbox = ByteArray(32) { 0x10 }
+        val invitation = invitation(
+            groupId = ByteArray(32) { 0x42 },
+            adminPubkeyHex = adminBlsHex,
+            memberProfiles = mapOf(
+                adminBlsHex to MemberProfile(
+                    alias = "Admin",
+                    inboxPublicKey = adminInbox,
+                    sendingPubkey = ByteArray(32) { 0x20 },
+                ),
+            ),
+        )
+
+        verifier.deferVerification(invitation, owner)
+
+        assertEquals("a refresh request must be sent to the admin", 1, transport.sends().size)
+        val snapshot = store.snapshots.value
+        assertEquals(1, snapshot.size)
+        assertEquals(PendingGroupVerification.Status.VERIFYING, snapshot.first().status)
+        assertTrue("deferral must not materialize a group", groups.snapshots.value.isEmpty())
+    }
+
+    /** The admin must not answer a refresh request from a non-member —
+     *  the reply carries the salt. */
+    @Test
+    fun handleRefreshRequest_nonMember_doesNotReply() = runTest {
+        val verifier = makeVerifier()
+        val groupId = ByteArray(32) { 0x42 }
+        val memberBlsHex = "bb".repeat(48)
+        groups.insert(
+            seededGroup(
+                groupId = groupId,
+                memberProfiles = mapOf(
+                    memberBlsHex to MemberProfile(
+                        alias = "Member",
+                        inboxPublicKey = ByteArray(32) { 0x10 },
+                        sendingPubkey = ByteArray(32) { 0xEE.toByte() },
+                    ),
+                ),
+            ),
+        )
+
+        // Requester whose BLS isn't in the roster.
+        verifier.handleRefreshRequest(
+            GroupStateRefreshRequest(
+                groupId = groupId,
+                requesterInboxPublicKey = ByteArray(32) { 0x01 },
+                requesterBlsPublicKey = ByteArray(48) { 0x02 },
+            ),
+            ownerIdentityId = owner,
+            requesterEd25519 = ByteArray(32) { 0xAB.toByte() },
+        )
+
+        assertEquals(
+            "non-member must not receive the current snapshot (salt)",
+            0,
+            transport.sends().size,
+        )
+    }
+
+    /** A current member whose envelope-signer + inbox match their stored
+     *  profile gets the current snapshot. */
+    @Test
+    fun handleRefreshRequest_member_repliesWithSnapshot() = runTest {
+        val verifier = makeVerifier()
+        val groupId = ByteArray(32) { 0x42 }
+        val reqBls = ByteArray(48) { 0x07 }
+        val reqBlsHex = reqBls.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        val reqInbox = ByteArray(32) { 0x08 }
+        val reqEd = ByteArray(32) { 0x09 }
+        groups.insert(
+            seededGroup(
+                groupId = groupId,
+                memberProfiles = mapOf(
+                    reqBlsHex to MemberProfile(
+                        alias = "Member",
+                        inboxPublicKey = reqInbox,
+                        sendingPubkey = reqEd,
+                    ),
+                ),
+            ),
+        )
+
+        verifier.handleRefreshRequest(
+            GroupStateRefreshRequest(
+                groupId = groupId,
+                requesterInboxPublicKey = reqInbox,
+                requesterBlsPublicKey = reqBls,
+            ),
+            ownerIdentityId = owner,
+            requesterEd25519 = reqEd,
+        )
+
+        assertEquals("current member should receive the snapshot", 1, transport.sends().size)
+    }
+
+    /** Even a member is refused when the envelope's Ed25519 signer
+     *  doesn't match their stored sending key (insider-spoof defense). */
+    @Test
+    fun handleRefreshRequest_memberButSignerMismatch_doesNotReply() = runTest {
+        val verifier = makeVerifier()
+        val groupId = ByteArray(32) { 0x42 }
+        val reqBls = ByteArray(48) { 0x07 }
+        val reqBlsHex = reqBls.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        val reqInbox = ByteArray(32) { 0x08 }
+        groups.insert(
+            seededGroup(
+                groupId = groupId,
+                memberProfiles = mapOf(
+                    reqBlsHex to MemberProfile(
+                        alias = "Member",
+                        inboxPublicKey = reqInbox,
+                        sendingPubkey = ByteArray(32) { 0x09 },
+                    ),
+                ),
+            ),
+        )
+
+        verifier.handleRefreshRequest(
+            GroupStateRefreshRequest(
+                groupId = groupId,
+                requesterInboxPublicKey = reqInbox,
+                requesterBlsPublicKey = reqBls,
+            ),
+            ownerIdentityId = owner,
+            requesterEd25519 = ByteArray(32) { 0xFF.toByte() },  // wrong signer
+        )
+
+        assertEquals(0, transport.sends().size)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun invitation(
+        groupId: ByteArray,
+        adminPubkeyHex: String?,
+        memberProfiles: Map<String, MemberProfile>?,
+    ) = GroupInvitationPayload(
+        version = 1,
+        groupId = groupId,
+        groupSecret = ByteArray(32) { 0x55 },
+        name = "Family",
+        members = emptyList(),
+        epoch = 0uL,
+        salt = ByteArray(32) { 0x66 },
+        commitment = ByteArray(32) { 0x77 },
+        tierRaw = SepTier.SMALL.rawValue,
+        groupTypeRaw = SepGroupType.TYRANNY.wireValue,
+        adminPubkeyHex = adminPubkeyHex,
+        memberProfiles = memberProfiles,
+    )
+
+    private fun seededGroup(
+        groupId: ByteArray,
+        memberProfiles: Map<String, MemberProfile>,
+    ): ChatGroup {
+        val hex = groupId.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        return ChatGroup(
+            id = hex,
+            name = "Family",
+            groupSecret = ByteArray(32) { 0x55 },
+            createdAtMillis = 0L,
+            members = emptyList(),
+            memberProfiles = memberProfiles,
+            epoch = 1uL,
+            salt = ByteArray(32) { 0x66 },
+            commitment = ByteArray(32) { 0x77 },
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = "aa".repeat(48),
+            isPublishedOnChain = true,
+            ownerIdentityId = owner.value,
+        )
+    }
+}
+
+/** Trivial sealer — the verifier only needs *some* bytes to ship; the
+ *  envelope crypto is exercised elsewhere. */
+private class FakeSealer : InvitationEnvelopeSealer {
+    override suspend fun sealInvitation(payload: ByteArray, recipientInboxPublicKey: ByteArray): ByteArray =
+        payload
+}

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherTest.kt
@@ -1,11 +1,15 @@
 package app.onym.android.inbox
 
+import app.onym.android.chain.ChainStateReading
+import app.onym.android.chain.SepCommitmentEntry
 import app.onym.android.chain.SepGroupType
 import app.onym.android.chain.SepTier
 import app.onym.android.group.ChatGroup
 import app.onym.android.group.GovernanceMember
 import app.onym.android.group.GroupInvitationPayload
+import app.onym.android.group.GroupInviteOfferPayload
 import app.onym.android.group.GroupRepository
+import app.onym.android.group.GroupStateRefreshRequest
 import app.onym.android.group.GroupStore
 import app.onym.android.group.MemberAnnouncementPayload
 import app.onym.android.group.MemberProfile
@@ -332,6 +336,175 @@ class IncomingMessageDispatcherTest {
         assertEquals(1, invitationsRepository.invitations.value.size)
     }
 
+    // ─── Invite offers (PR 158 handshake) ────────────────────────
+
+    @Test
+    fun offer_isQueuedForAcceptAndDoesNotMaterializeGroup() = runTest {
+        // A push offer must NOT materialize a group or land in the
+        // opaque invitations queue — it's queued as a structured
+        // PendingInvite for the user's explicit Accept. Membership only
+        // follows accept + the admin's explicit approve.
+        val offerGroupId = ByteArray(32) { 0x42 }
+        val offer = GroupInviteOfferPayload(
+            introPublicKey = ByteArray(32) { 0x44 },
+            groupId = offerGroupId,
+            groupName = "Maple Garden",
+            inviterAlias = "Alice",
+        )
+        val plaintext = Json.encodeToString(GroupInviteOfferPayload.serializer(), offer)
+            .toByteArray(Charsets.UTF_8)
+        val spy = SpyPendingInvites()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32)),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            pendingInvites = spy,
+        )
+
+        dispatcher.dispatch("msg-offer", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        // No group materialized for the offer's group id.
+        assertNull(
+            "an offer must NOT materialize a group",
+            groupRepository.snapshots.value.firstOrNull {
+                it.groupIdBytes.contentEquals(offerGroupId)
+            },
+        )
+        // Not an opaque invitation either.
+        invitationsRepository.bootstrap()
+        assertTrue(invitationsRepository.invitations.value.isEmpty())
+        // Queued as a structured pending invite.
+        assertEquals(1, spy.recorded.size)
+        val rec = spy.recorded.single()
+        assertEquals("msg-offer", rec.id)
+        assertEquals(ownerIdentity, rec.ownerIdentityId)
+        assertEquals("Alice", rec.inviterAlias)
+        assertEquals("Maple Garden", rec.groupName)
+        assertTrue(rec.introPublicKey.contentEquals(ByteArray(32) { 0x44 }))
+        assertTrue(rec.groupId.contentEquals(offerGroupId))
+    }
+
+    // ─── Verify-at-current refresh routing (PR 159) ───────────────
+
+    @Test
+    fun refreshRequest_routedToVerifier() = runTest {
+        // An inbound GroupStateRefreshRequest is delegated to the
+        // verifier (admin side) and never materializes / queues anything.
+        val refreshGroupId = ByteArray(32) { 0x42 }
+        val req = GroupStateRefreshRequest(
+            groupId = refreshGroupId,
+            requesterInboxPublicKey = ByteArray(32) { 0x01 },
+            requesterBlsPublicKey = ByteArray(48) { 0x02 },
+        )
+        val plaintext = Json.encodeToString(GroupStateRefreshRequest.serializer(), req)
+            .toByteArray(Charsets.UTF_8)
+        val refresher = SpyGroupStateRefresher()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = ByteArray(32) { 0xAB.toByte() }),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            groupStateRefresher = refresher,
+        )
+
+        dispatcher.dispatch("msg-refresh", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        assertEquals(listOf(refreshGroupId.toList()), refresher.handled.map { it.toList() })
+        assertTrue(refresher.deferred.isEmpty())
+        // Only the seeded group remains; nothing materialized.
+        assertEquals(1, groupRepository.snapshots.value.size)
+        invitationsRepository.bootstrap()
+        assertTrue(invitationsRepository.invitations.value.isEmpty())
+    }
+
+    // ─── Converge-forward verification (PR 158) ───────────────────
+
+    @Test
+    fun announcement_convergeForward_appliedWhenChainEpochAheadOfClaim() = runTest {
+        // Converge-forward: a stale-but-signed roster delta (claimed
+        // epoch 0) must still apply when the chain has moved past it
+        // (another join anchored first → chain at epoch 5 with a
+        // different commitment). Pre-relaxation `== epoch` dropped this.
+        val storedAdmin = ByteArray(32) { 0x10 }
+        val storedAdminHex = storedAdmin.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        groupStore.replaceForTest(makeGroup(groupId).copy(adminEd25519PubkeyHex = storedAdminHex))
+        groupRepository.reload()
+
+        val payload = MemberAnnouncementPayload(
+            version = 1,
+            groupId = groupId,
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = newMemberBlsPub,
+                inboxPub = newMemberInbox,
+                alias = "Bob",
+                sendingPub = ByteArray(32) { 0x77 },
+            ),
+            adminAlias = "Alice",
+            commitment = ByteArray(32) { 0x01 },  // snapshot commitment
+            epoch = 0uL,
+        )
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = storedAdmin),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            // Chain ahead (epoch 5) with a DIFFERENT commitment.
+            chainState = FakeChainState(
+                SepCommitmentEntry(commitment = ByteArray(32) { 0x99.toByte() }, epoch = 5uL),
+            ),
+        )
+
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        assertEquals(
+            "stale-but-valid announcement should still apply when the chain is ahead",
+            1,
+            groupRepository.snapshots.value.single().memberProfiles.size,
+        )
+    }
+
+    @Test
+    fun announcement_droppedWhenChainEpochBehindClaim() = runTest {
+        // The mirror case: a claimed epoch the chain hasn't reached is
+        // impossible for a real anchored update — drop it.
+        val storedAdmin = ByteArray(32) { 0x10 }
+        val storedAdminHex = storedAdmin.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        groupStore.replaceForTest(makeGroup(groupId).copy(adminEd25519PubkeyHex = storedAdminHex))
+        groupRepository.reload()
+
+        val payload = MemberAnnouncementPayload(
+            version = 1,
+            groupId = groupId,
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = newMemberBlsPub,
+                inboxPub = newMemberInbox,
+                alias = "Bob",
+                sendingPub = ByteArray(32) { 0x77 },
+            ),
+            adminAlias = "Alice",
+            commitment = ByteArray(32) { 0x01 },
+            epoch = 5uL,  // claims epoch 5
+        )
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = storedAdmin),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            // Chain BEHIND (epoch 3) the claimed epoch 5.
+            chainState = FakeChainState(
+                SepCommitmentEntry(commitment = ByteArray(32) { 0x01 }, epoch = 3uL),
+            ),
+        )
+
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        assertTrue(
+            "an announcement ahead of the chain must be dropped",
+            groupRepository.snapshots.value.single().memberProfiles.isEmpty(),
+        )
+    }
+
     private fun announcementPayload() = MemberAnnouncementPayload(
         version = 1,
         groupId = groupId,
@@ -424,4 +597,34 @@ private class InMemoryGroupStore : GroupStore {
 private class ConstantIdentity(private val id: IdentityId) : ActiveIdentityProvider {
     override val currentIdentityId: StateFlow<IdentityId?> = MutableStateFlow(id)
     override fun registerRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {}
+}
+
+private class SpyPendingInvites : PendingInvitesRecording {
+    val recorded = mutableListOf<PendingInvite>()
+    override suspend fun record(invite: PendingInvite) {
+        recorded.add(invite)
+    }
+}
+
+private class FakeChainState(private val entry: SepCommitmentEntry) : ChainStateReading {
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry = entry
+}
+
+private class SpyGroupStateRefresher : GroupStateRefreshing {
+    val deferred = mutableListOf<ByteArray>()
+    val handled = mutableListOf<ByteArray>()
+    override suspend fun deferVerification(
+        invitation: app.onym.android.group.GroupInvitationPayload,
+        ownerIdentityId: IdentityId,
+    ) {
+        deferred.add(invitation.groupId)
+    }
+
+    override suspend fun handleRefreshRequest(
+        request: GroupStateRefreshRequest,
+        ownerIdentityId: IdentityId,
+        requesterEd25519: ByteArray?,
+    ) {
+        handled.add(request.groupId)
+    }
 }


### PR DESCRIPTION
Ports two stacked iOS PRs to Android, mapping each piece to its Android analogue (manual DI, kotlinx.serialization, Compose, coroutines) rather than transliterating Swift:

- onymchat/onym-ios#158 — the invite-offer handshake
- onymchat/onym-ios#159 — verify-at-current group state (supersedes #158's interim staleness window; this PR builds the #159 model, not the window)

## Problem
Create-time "add member via QR" shipped a `GroupInvitationPayload` (a membership grant pinned to one on-chain epoch) directly to a non-member's inbox. The invitee was never added to the on-chain roster nor recorded in the inviter's member directory — **inviter saw 1 member, invitee saw 2, messages didn't flow back** — and the epoch-pinned snapshot went stale the moment any other invitee anchored.

## Handshake (#158)
Route create-time invites into the existing on-chain join machinery (intro keys → `JoinRequestSender` → `IntroInboxPump` → `JoinRequestApprover` → `update_commitment` → member announcement):
- Tyranny create mints a per-invitee intro key and sends a durable, epoch-free `GroupInviteOfferPayload` (grants nothing, never expires) instead of a snapshot. OneOnOne/Anarchy keep the membership-grant send.
- Inbound offers route to a `PendingInvitesStore` and **never materialize a group**.
- The invitee explicitly **Accepts** → ships a `JoinRequestPayload` to the intro key (reuses `JoinRequestSender`).
- The admin explicitly **Approves** via the existing `ApproveRequests` UI (unchanged) — the only on-chain `update_commitment`. No auto-anchor, no silent add.

## Verify-at-current (#159)
A Tyranny snapshot materializes **only** when it byte-verifies against the chain at an **exact epoch** (reproducing `Poseidon(Poseidon(root, epoch), salt)` needs the random salt, which is never on chain — the forgery gate). When the chain has advanced past the snapshot:
- the receiver refuses to trust it and sends a `GroupStateRefreshRequest` to the admin, marking the group **verifying** and keeping it **hidden from the chats list**;
- the admin replies with the current snapshot **only to a current member** whose envelope-signer matches their stored Ed25519, sealing to the member's **stored** inbox (a forged request can't redirect the salt to a non-member);
- on timeout / unknown admin inbox the group is marked **"couldn't verify"** with a **Retry** — never silently materialized or dropped.

The `MemberAnnouncement` verifier keeps its converge-forward (`>=`) gate — it's admin-Ed25519-signed and out of scope for #159.

## Files
**New:** `GroupInviteOfferPayload`, `GroupStateRefreshRequest`, `PendingInvitesStore`, `PendingVerificationStore`, `PendingInvitesViewModel`, `PendingInvitesScreen`, `GroupStateVerifier`.
**Edited:** `CreateGroupInteractor` (Tyranny sends offers), `IncomingMessageDispatcher` (offer + refresh fast-paths; exact-epoch verify with defer-on-stale), `ChatsScreen`/`RootScreen` (Invitations toolbar badge + route), `OnymApplication`/`AppDependencies` (DI wiring + per-identity lifecycle).

## Hard invariants verified
- Roster stays on chain (admin anonymous — never disclosed on chain).
- The only on-chain anchor is the admin's explicit Approve; no auto-anchor, no silent add.
- The offer grants nothing and never expires.
- Salt is disclosed only to a verified current member, sealed to their stored inbox.
- `JoinRequestApprover.approve` was already serialized under a `Mutex` — no change needed.

## Tests
Offer + refresh-request codecs and wire-disambiguation; dispatcher queues offers (no materialize) / routes refresh requests / defers stale snapshots (androidTest FFI: exact-epoch materializes, chain-ahead defers); verifier marks unreachable on unknown admin inbox and refuses non-members / signer-mismatch (salt non-disclosure). **554 unit tests green** (`testDebugUnitTest`); main + androidTest compile.

> Note: instrumentation (androidTest) suites compile but were not executed here (no device/emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)