### PR TITLE
fix(chats): keep latest messages visible above keyboard (#154)

### DIFF
--- a/app/src/main/kotlin/app/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/RootScreen.kt
@@ -1,5 +1,6 @@
 package app.onym.android
 
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forum
@@ -151,7 +152,23 @@ fun RootScreen(
         NavHost(
             navController = navController,
             startDestination = Tab.Chats.route,
-            modifier = androidx.compose.ui.Modifier.padding(padding),
+            // `consumeWindowInsets(padding)` is load-bearing, not
+            // decorative: several destinations host their own
+            // `Scaffold` (ChatThreadScreen, SettingsScreen, …). The
+            // outer Scaffold here applies the system-bar insets and
+            // hands them back as `padding`, but does NOT consume them
+            // from the inset tree. Without the consume, a nested
+            // Scaffold reads the full `systemBars` again and re-pads
+            // the bottom navigation-bar inset a second time. On a
+            // scrolling list that doubled inset just looks like extra
+            // bottom padding; on the chat thread's bottom-pinned
+            // input panel it's the visible gap + keyboard-overlap in
+            // #154. Consuming here makes the inner Scaffolds see the
+            // already-applied insets as spent, so `imePadding()`
+            // downstream lands the panel flush on the keyboard.
+            modifier = androidx.compose.ui.Modifier
+                .padding(padding)
+                .consumeWindowInsets(padding),
         ) {
             composable(Tab.Chats.route) {
                 val vm: ChatsViewModel = viewModel(

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -190,14 +190,16 @@ private fun ChatThreadBody(
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
-            // The Scaffold's `padding` already carries the bottom
-            // navigation-bar inset. The IME inset is measured from
-            // the screen bottom and overlaps that same nav-bar band,
-            // so applying `imePadding()` on top would count the
-            // nav-bar height twice — the visible gap between the
-            // keyboard and the input panel in #154. Consuming the
-            // scaffold insets first makes `imePadding()` contribute
-            // only the keyboard height beyond what's already padded.
+            // Consume whatever bottom inset this screen's own Scaffold
+            // already applied before `imePadding()` reads the IME
+            // inset. The IME inset is measured from the screen bottom
+            // and overlaps the navigation-bar band, so without the
+            // consume `imePadding()` would re-add an inset that's
+            // already in `padding` and leave a gap above the keyboard.
+            // (The cross-Scaffold nav-bar double-count from #154 is
+            // handled upstream by `consumeWindowInsets` on RootScreen's
+            // NavHost; this keeps the panel flush even if the screen is
+            // ever hosted without that outer consume — e.g. in a test.)
             .consumeWindowInsets(padding)
             .imePadding()  // slides the input panel above the soft keyboard
             .testTag("chat_thread.body"),

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -3,9 +3,12 @@ package app.onym.android.chats
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -13,6 +16,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -112,6 +116,7 @@ fun ChatThreadScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ChatThreadBody(
     messages: List<ChatMessage>,
@@ -159,10 +164,41 @@ private fun ChatThreadBody(
         }
     }
 
+    // Keyboard-open re-anchor. `imePadding()` below shrinks this
+    // column when the soft keyboard rises; a LazyColumn keeps its
+    // top pinned, so the bottom messages would slide out of view
+    // behind the input panel. Re-scroll to the latest message when
+    // the IME appears — but only if the user was already near the
+    // bottom, mirroring the append heuristic so reading older
+    // messages while typing isn't hijacked. Reading `nearBottom`
+    // here captures the pre-resize position because the IME inset
+    // animates in over subsequent frames, after this effect's
+    // launch observes the visibility flip.
+    val imeVisible = WindowInsets.isImeVisible
+    LaunchedEffect(imeVisible) {
+        if (shouldAnchorBottomOnImeShow(
+                imeVisible = imeVisible,
+                nearBottom = nearBottom,
+                hasMessages = sortedMessages.isNotEmpty(),
+            )
+        ) {
+            listState.animateScrollToItem(sortedMessages.lastIndex)
+        }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(padding)
+            // The Scaffold's `padding` already carries the bottom
+            // navigation-bar inset. The IME inset is measured from
+            // the screen bottom and overlaps that same nav-bar band,
+            // so applying `imePadding()` on top would count the
+            // nav-bar height twice — the visible gap between the
+            // keyboard and the input panel in #154. Consuming the
+            // scaffold insets first makes `imePadding()` contribute
+            // only the keyboard height beyond what's already padded.
+            .consumeWindowInsets(padding)
             .imePadding()  // slides the input panel above the soft keyboard
             .testTag("chat_thread.body"),
     ) {
@@ -237,6 +273,22 @@ internal fun isNearBottom(
  *  the auto-scroll heuristic. 2 = the user is reading the last or
  *  second-to-last message. */
 internal const val NEAR_BOTTOM_INDEX_THRESHOLD = 2
+
+/**
+ * Decides whether the keyboard-open handler should re-anchor the
+ * message list to the latest message. True only when the IME just
+ * became visible, the list is non-empty, and the user was already
+ * near the bottom — so focusing the input while reading older
+ * history doesn't yank the list down. Pure function so the policy
+ * is unit-tested without standing up a `LazyListState` or driving a
+ * real soft keyboard. The composable feeds it `WindowInsets.isImeVisible`
+ * and the same `isNearBottom`-backed `derivedStateOf`.
+ */
+internal fun shouldAnchorBottomOnImeShow(
+    imeVisible: Boolean,
+    nearBottom: Boolean,
+    hasMessages: Boolean,
+): Boolean = imeVisible && nearBottom && hasMessages
 
 @Composable
 private fun EmptyThread(modifier: Modifier = Modifier) {

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -34,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -116,7 +116,6 @@ fun ChatThreadScreen(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ChatThreadBody(
     messages: List<ChatMessage>,
@@ -164,25 +163,43 @@ private fun ChatThreadBody(
         }
     }
 
-    // Keyboard-open re-anchor. `imePadding()` below shrinks this
-    // column when the soft keyboard rises; a LazyColumn keeps its
-    // top pinned, so the bottom messages would slide out of view
-    // behind the input panel. Re-scroll to the latest message when
-    // the IME appears — but only if the user was already near the
-    // bottom, mirroring the append heuristic so reading older
-    // messages while typing isn't hijacked. Reading `nearBottom`
-    // here captures the pre-resize position because the IME inset
-    // animates in over subsequent frames, after this effect's
-    // launch observes the visibility flip.
-    val imeVisible = WindowInsets.isImeVisible
-    LaunchedEffect(imeVisible) {
-        if (shouldAnchorBottomOnImeShow(
-                imeVisible = imeVisible,
-                nearBottom = nearBottom,
+    // Keyboard-rise re-anchor. `imePadding()` below shrinks this
+    // column frame-by-frame as the soft keyboard animates in, and a
+    // LazyColumn keeps its top pinned — so the bottom messages slide
+    // out of view behind the input panel. A single scroll when the
+    // keyboard *starts* showing gets re-hidden by the rest of the
+    // shrink, so we re-pin on every rising frame of the IME inset
+    // instead, gluing the latest message just above the panel for
+    // the whole animation.
+    val imeBottom = WindowInsets.ime.getBottom(LocalDensity.current)
+
+    // The pin decision must reflect where the user was *before* the
+    // keyboard began shrinking the viewport. Capture `nearBottom`
+    // while the IME is down; it freezes at that value the moment the
+    // keyboard starts rising. Reading it live at the rising edge
+    // would race the relayout and misfire on instant (non-animated)
+    // keyboards.
+    var anchoredBeforeIme by remember { mutableStateOf(true) }
+    LaunchedEffect(nearBottom, imeBottom) {
+        if (imeBottom == 0) anchoredBeforeIme = nearBottom
+    }
+
+    // Only rising frames re-pin. Falling frames (keyboard dismissing)
+    // are left alone, so a user who scrolled up to read history while
+    // typing isn't yanked back to the bottom when they close the
+    // keyboard. Instant scroll (not animated) so the bottom tracks
+    // the rising panel smoothly rather than lagging behind it.
+    var prevImeBottom by remember { mutableStateOf(0) }
+    LaunchedEffect(imeBottom) {
+        val rising = imeBottom > prevImeBottom
+        prevImeBottom = imeBottom
+        if (shouldGlueToBottomOnImeRise(
+                rising = rising,
+                anchoredBeforeIme = anchoredBeforeIme,
                 hasMessages = sortedMessages.isNotEmpty(),
             )
         ) {
-            listState.animateScrollToItem(sortedMessages.lastIndex)
+            listState.scrollToItem(sortedMessages.lastIndex)
         }
     }
 
@@ -277,20 +294,22 @@ internal fun isNearBottom(
 internal const val NEAR_BOTTOM_INDEX_THRESHOLD = 2
 
 /**
- * Decides whether the keyboard-open handler should re-anchor the
- * message list to the latest message. True only when the IME just
- * became visible, the list is non-empty, and the user was already
- * near the bottom — so focusing the input while reading older
- * history doesn't yank the list down. Pure function so the policy
- * is unit-tested without standing up a `LazyListState` or driving a
- * real soft keyboard. The composable feeds it `WindowInsets.isImeVisible`
- * and the same `isNearBottom`-backed `derivedStateOf`.
+ * Decides whether a frame of the IME-rise animation should re-pin the
+ * message list to the latest message. True only on a *rising* frame
+ * (the keyboard is growing, not dismissing), when the list is
+ * non-empty, and when the user was at the bottom before the keyboard
+ * started — so reading older history while typing isn't yanked down,
+ * and dismissing the keyboard never drags a scrolled-up user back.
+ * Pure function so the policy is unit-tested without standing up a
+ * `LazyListState` or driving a real soft keyboard; the composable
+ * feeds it the rising-edge test on `WindowInsets.ime` and the
+ * captured pre-keyboard `isNearBottom` state.
  */
-internal fun shouldAnchorBottomOnImeShow(
-    imeVisible: Boolean,
-    nearBottom: Boolean,
+internal fun shouldGlueToBottomOnImeRise(
+    rising: Boolean,
+    anchoredBeforeIme: Boolean,
     hasMessages: Boolean,
-): Boolean = imeVisible && nearBottom && hasMessages
+): Boolean = rising && anchoredBeforeIme && hasMessages
 
 @Composable
 private fun EmptyThread(modifier: Modifier = Modifier) {

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
@@ -78,54 +78,55 @@ class ChatThreadAutoScrollTest {
         assertTrue(isNearBottom(totalItems = 50, lastVisibleIndex = 45, nearBottomThreshold = 5))
     }
 
-    // ─── keyboard-open re-anchor (#154) ──────────────────────────
+    // ─── keyboard-rise re-anchor (#154) ──────────────────────────
 
     @Test
-    fun shouldAnchorBottomOnImeShow_visibleAndNearBottom_anchors() {
-        // User is at the bottom and the keyboard just rose — keep
-        // the latest message visible above the input panel.
+    fun shouldGlueToBottomOnImeRise_risingAndAnchored_glues() {
+        // Keyboard growing and the user was at the bottom before it
+        // opened — re-pin the latest message above the input panel.
         assertTrue(
-            shouldAnchorBottomOnImeShow(
-                imeVisible = true,
-                nearBottom = true,
+            shouldGlueToBottomOnImeRise(
+                rising = true,
+                anchoredBeforeIme = true,
                 hasMessages = true,
             ),
         )
     }
 
     @Test
-    fun shouldAnchorBottomOnImeShow_imeHidden_doesNotAnchor() {
-        // The keyboard closing must never drive a scroll.
+    fun shouldGlueToBottomOnImeRise_falling_doesNotGlue() {
+        // Dismissing the keyboard must never drag a scrolled-up user
+        // back down — only rising frames re-pin.
         assertFalse(
-            shouldAnchorBottomOnImeShow(
-                imeVisible = false,
-                nearBottom = true,
+            shouldGlueToBottomOnImeRise(
+                rising = false,
+                anchoredBeforeIme = true,
                 hasMessages = true,
             ),
         )
     }
 
     @Test
-    fun shouldAnchorBottomOnImeShow_scrolledUp_doesNotAnchor() {
-        // Focusing the input while reading older history must not
-        // yank the list down to the latest message.
+    fun shouldGlueToBottomOnImeRise_scrolledUpBeforeKeyboard_doesNotGlue() {
+        // The user was reading older history when they focused the
+        // input — keep their position instead of yanking to bottom.
         assertFalse(
-            shouldAnchorBottomOnImeShow(
-                imeVisible = true,
-                nearBottom = false,
+            shouldGlueToBottomOnImeRise(
+                rising = true,
+                anchoredBeforeIme = false,
                 hasMessages = true,
             ),
         )
     }
 
     @Test
-    fun shouldAnchorBottomOnImeShow_emptyThread_doesNotAnchor() {
-        // No messages → nothing to anchor to; scrolling would be a
-        // no-op at best and an index error at worst.
+    fun shouldGlueToBottomOnImeRise_emptyThread_doesNotGlue() {
+        // No messages → nothing to pin to; scrolling would be a no-op
+        // at best and an index error at worst.
         assertFalse(
-            shouldAnchorBottomOnImeShow(
-                imeVisible = true,
-                nearBottom = true,
+            shouldGlueToBottomOnImeRise(
+                rising = true,
+                anchoredBeforeIme = true,
                 hasMessages = false,
             ),
         )

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadAutoScrollTest.kt
@@ -77,4 +77,57 @@ class ChatThreadAutoScrollTest {
         assertFalse(isNearBottom(totalItems = 50, lastVisibleIndex = 44, nearBottomThreshold = 5))
         assertTrue(isNearBottom(totalItems = 50, lastVisibleIndex = 45, nearBottomThreshold = 5))
     }
+
+    // ─── keyboard-open re-anchor (#154) ──────────────────────────
+
+    @Test
+    fun shouldAnchorBottomOnImeShow_visibleAndNearBottom_anchors() {
+        // User is at the bottom and the keyboard just rose — keep
+        // the latest message visible above the input panel.
+        assertTrue(
+            shouldAnchorBottomOnImeShow(
+                imeVisible = true,
+                nearBottom = true,
+                hasMessages = true,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldAnchorBottomOnImeShow_imeHidden_doesNotAnchor() {
+        // The keyboard closing must never drive a scroll.
+        assertFalse(
+            shouldAnchorBottomOnImeShow(
+                imeVisible = false,
+                nearBottom = true,
+                hasMessages = true,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldAnchorBottomOnImeShow_scrolledUp_doesNotAnchor() {
+        // Focusing the input while reading older history must not
+        // yank the list down to the latest message.
+        assertFalse(
+            shouldAnchorBottomOnImeShow(
+                imeVisible = true,
+                nearBottom = false,
+                hasMessages = true,
+            ),
+        )
+    }
+
+    @Test
+    fun shouldAnchorBottomOnImeShow_emptyThread_doesNotAnchor() {
+        // No messages → nothing to anchor to; scrolling would be a
+        // no-op at best and an index error at worst.
+        assertFalse(
+            shouldAnchorBottomOnImeShow(
+                imeVisible = true,
+                nearBottom = true,
+                hasMessages = false,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Fixes #154.

When focusing the chat input, the last 2–3 messages stayed hidden behind the keyboard and an unnecessary gap opened between the keyboard and the input panel. Two root causes:

## 1. The gap (double-counted nav-bar inset)

`Scaffold` already feeds the body a `padding` that includes the bottom **navigation-bar** inset, and the body then added `.imePadding()`. The IME inset is measured from the screen bottom and overlaps that same nav-bar band, so the nav-bar height was counted twice — a gap ≈ nav-bar height.

**Fix:** `.consumeWindowInsets(padding)` between `.padding(padding)` and `.imePadding()`, so `imePadding()` contributes only the keyboard height beyond the already-applied inset.

## 2. Hidden messages (LazyColumn pins its top on resize)

`.imePadding()` shrinks the body `Column` when the keyboard rises. A `LazyColumn` keeps its **top** anchored on resize, so the bottom messages slide out of view behind the input panel. The existing auto-scroll only fired on message-count changes, never on keyboard open.

**Fix:** a `LaunchedEffect(WindowInsets.isImeVisible)` re-scrolls to the latest message when the IME appears, gated by the new pure helper `shouldAnchorBottomOnImeShow(imeVisible, nearBottom, hasMessages)`. The `nearBottom` gate reuses the existing append heuristic so focusing the input while reading older history doesn't yank the list down.

## Tests

Added 4 cases to `ChatThreadAutoScrollTest` for the helper (anchors when visible + near-bottom; no-op when IME hidden, scrolled-up, or empty thread). `:app:testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)