### PR TITLE
fix(chats): make disabled Send button visually distinct from input field

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
@@ -105,8 +105,16 @@ fun ChatInputPanel(
             colors = IconButtonDefaults.filledIconButtonColors(
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
-                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                // Disabled state must visually contrast with the
+                // adjacent text field (also `surfaceVariant`) so the
+                // button reads as "greyed out", not as an extension of
+                // the field. Match M3's standard low-alpha disabled
+                // palette — a tinted overlay against the screen surface
+                // rather than a solid fill that blends with the field.
+                disabledContainerColor = MaterialTheme.colorScheme.onSurface
+                    .copy(alpha = 0.12f),
+                disabledContentColor = MaterialTheme.colorScheme.onSurface
+                    .copy(alpha = 0.38f),
             ),
             modifier = Modifier.testTag("chat_thread.send_button"),
         ) {


### PR DESCRIPTION
The disabled Send button used `surfaceVariant` for both container and
content — the same color as the adjacent `OutlinedTextField` background.
On cold open with an empty field, the button blended into the field and
didn't read as "greyed out". Switch to M3's standard low-alpha onSurface
palette so the disabled state contrasts against the surface as a tinted
overlay, the way QA expects (issue #151, test 3).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
