### PR TITLE
feat(groups): scan-QR invite on create-group flow (#88)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,15 @@ dependencies {
     // renderer).
     implementation(libs.zxing.core)
 
+    // CameraX — preview + image analysis behind the invite-QR scanner
+    // (`QrScannerScreen`). camera-view supplies `PreviewView`; the
+    // analysis frames are decoded with the zxing-core reader above so
+    // we add no ML Kit model to the APK.
+    implementation(libs.androidx.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
+
     implementation(libs.onym.sdk)
 
     // Room — `suspend` DAO + KSP-generated bindings. PersistenceStore

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,23 @@
     -->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!--
+        CAMERA: the invite-QR scanner on the Create Group → "Invite by
+        inbox key" screen (`QrScannerScreen`) reads a contact's
+        `https://onym.app/i?k=…` identity-invite QR via CameraX.
+        Requested at runtime (API 23+) the first time the user taps
+        "Scan QR"; denial degrades to the existing paste-the-key path.
+
+        `uses-feature ... required="false"`: a camera is not essential
+        to the app — devices without one (or where the user declines)
+        still use manual key entry — so we don't want Play Store to
+        filter the listing on camera hardware.
+    -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+
     <application
         android:name=".OnymApplication"
         android:label="@string/app_name"

--- a/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
@@ -293,6 +293,22 @@ class CreateGroupViewModel(
         )
     }
 
+    /**
+     * Drop a scanned QR payload into [CreateGroupState.inviteeInput].
+     * Strips known URL wrappers (see [canonicalizeInviteKey]) so the
+     * user sees the raw 64-char hex and can review before tapping
+     * "Add invitee" — validation stays in [tappedAddInvitee], so a
+     * malformed scan surfaces the same inline error as a bad paste.
+     *
+     * Mirrors `CreateGroupFlow.tappedScannedKey(_:)` from onym-ios.
+     */
+    fun tappedScannedKey(raw: String) {
+        _state.value = _state.value.copy(
+            inviteeInput = canonicalizeInviteKey(raw),
+            inviteeError = null,
+        )
+    }
+
     fun tappedCancelInviteByKey() {
         _state.value = _state.value.copy(route = CreateGroupRoute.Step2)
     }

--- a/app/src/main/kotlin/app/onym/android/group/InviteKeyCanonicalizer.kt
+++ b/app/src/main/kotlin/app/onym/android/group/InviteKeyCanonicalizer.kt
@@ -1,0 +1,75 @@
+package app.onym.android.group
+
+import java.net.URI
+import java.util.Base64
+
+/**
+ * Pull a candidate inbox key out of a raw scanned/pasted string.
+ *
+ * The QR scanner ([app.onym.android.scan.QrScannerScreen]) is
+ * deliberately generic — it hands back whatever text the code
+ * encodes. This function turns that text into the bare 64-char hex
+ * inbox key the Create Group "Invite by inbox key" field expects, so
+ * the user sees a reviewable key before tapping "Add invitee" and the
+ * existing validation in [CreateGroupViewModel.tappedAddInvitee]
+ * surfaces the same inline error on a bad scan as on a bad paste.
+ *
+ * Recognises:
+ *  - bare hex — returned trimmed, case preserved (the recipient's
+ *    "Settings → Identity → Inbox Key" string); the caller's
+ *    [decodeHex] accepts either case.
+ *  - `https://onym.app/i?k=<urlsafe-base64>` — the identity-invite
+ *    QR rendered by [app.onym.android.identity.inviteUrl] /
+ *    `OnymQrCode`; `k` is the 32-byte X25519 inbox key in URL-safe
+ *    Base64 (no padding).
+ *  - `https://onym.app?payload=<hex>` — the legacy onym-ios settings
+ *    QR (kept so a key shared from an older iOS build still scans).
+ *
+ * Falls back to the trimmed input on anything it doesn't recognise so
+ * the caller's length/hex validation produces a meaningful message.
+ *
+ * Mirrors `CreateGroupFlow.canonicalizeInviteKey(_:)` from onym-ios.
+ * Pure (java.net.URI + java.util.Base64, no `android.net.Uri`) so it
+ * unit-tests on the JVM without Robolectric.
+ */
+fun canonicalizeInviteKey(raw: String): String {
+    val trimmed = raw.trim()
+    val query = try {
+        URI(trimmed).rawQuery
+    } catch (_: Throwable) {
+        null
+    } ?: return trimmed
+
+    for (part in query.split('&')) {
+        val eq = part.indexOf('=')
+        if (eq < 0) continue
+        val name = part.substring(0, eq)
+        val value = part.substring(eq + 1)
+        when (name) {
+            // Android identity invite — 32-byte key as URL-safe base64.
+            "k" -> {
+                val bytes = try {
+                    Base64.getUrlDecoder().decode(value)
+                } catch (_: IllegalArgumentException) {
+                    continue
+                }
+                if (bytes.isNotEmpty()) return bytes.toHexLower()
+            }
+            // Legacy onym-ios settings QR — already hex.
+            "payload" -> if (value.isNotEmpty()) return value.lowercase()
+        }
+    }
+    return trimmed
+}
+
+private fun ByteArray.toHexLower(): String {
+    val sb = StringBuilder(size * 2)
+    for (b in this) {
+        val v = b.toInt() and 0xFF
+        sb.append(HEX[v ushr 4])
+        sb.append(HEX[v and 0x0F])
+    }
+    return sb.toString()
+}
+
+private const val HEX = "0123456789abcdef"

--- a/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -27,9 +27,15 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,6 +63,7 @@ import app.onym.android.group.OnymGovIcon
 import app.onym.android.group.OnymGroupAvatar
 import app.onym.android.group.LocalOnymTokens
 import app.onym.android.group.OnymUIGovernance
+import app.onym.android.scan.QrScannerScreen
 
 /**
  * Top-level screen for the Create Group flow. Switches between the
@@ -514,6 +521,8 @@ private fun Step2Screen(viewModel: CreateGroupViewModel) {
 private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val accent = state.accent.color()
+    var showScanner by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxSize()) {
     Column(modifier = Modifier.fillMaxSize()) {
         val groupLabel = state.name.ifEmpty {
             stringResource(R.string.create_group_invite_by_key_default_group_label)
@@ -578,6 +587,41 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
                     )
                 }
             }
+            Spacer(Modifier.height(16.dp))
+            // Scan-QR affordance — reads a contact's identity-invite
+            // QR (https://onym.app/i?k=…) and drops the canonicalised
+            // key into the field above for review.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(accent.copy(alpha = 0.10f))
+                    .border(
+                        width = 1.dp,
+                        color = accent.copy(alpha = 0.30f),
+                        shape = RoundedCornerShape(14.dp),
+                    )
+                    .clickable { showScanner = true }
+                    .padding(vertical = 13.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.QrCodeScanner,
+                        contentDescription = null,
+                        tint = accent,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.create_group_invite_by_key_scan),
+                        color = accent,
+                        style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
+                    )
+                }
+            }
             Spacer(Modifier.height(20.dp))
             Text(
                 text = stringResource(R.string.create_group_invite_by_key_helper),
@@ -596,6 +640,16 @@ private fun InviteByKeyScreen(viewModel: CreateGroupViewModel) {
             OnymQuietButton(
                 title = stringResource(R.string.cancel),
                 onClick = viewModel::tappedCancelInviteByKey,
+            )
+        }
+    }
+        if (showScanner) {
+            QrScannerScreen(
+                onScanned = { value ->
+                    viewModel.tappedScannedKey(value)
+                    showScanner = false
+                },
+                onCancel = { showScanner = false },
             )
         }
     }

--- a/app/src/main/kotlin/app/onym/android/scan/QrCodeAnalyzer.kt
+++ b/app/src/main/kotlin/app/onym/android/scan/QrCodeAnalyzer.kt
@@ -1,0 +1,86 @@
+package app.onym.android.scan
+
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.NotFoundException
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.common.HybridBinarizer
+
+/**
+ * CameraX [ImageAnalysis.Analyzer] that decodes a QR code out of each
+ * camera frame with zxing's [MultiFormatReader] and reports the first
+ * decoded text via [onDecoded].
+ *
+ * Decoding runs on the analyzer's executor (a background thread), so
+ * [onDecoded] is invoked off the main thread — the caller
+ * ([QrScannerScreen]) marshals back and de-dupes. The analyzer itself
+ * is stateless beyond the reused reader and keeps firing until the
+ * caller stops delivering frames; a clean QR typically resolves
+ * within a frame or two.
+ *
+ * We feed the Y (luminance) plane straight into
+ * [PlanarYUVLuminanceSource] using its row stride as the data width —
+ * no Bitmap allocation, no colour conversion. Restricted to
+ * [BarcodeFormat.QR_CODE] so the reader doesn't waste cycles probing
+ * 1-D symbologies we never emit.
+ */
+class QrCodeAnalyzer(
+    private val onDecoded: (String) -> Unit,
+) : ImageAnalysis.Analyzer {
+
+    private val reader = MultiFormatReader().apply {
+        setHints(
+            mapOf(
+                DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
+                DecodeHintType.TRY_HARDER to true,
+            ),
+        )
+    }
+
+    override fun analyze(image: ImageProxy) {
+        try {
+            val text = decode(image)
+            if (text != null && text.isNotEmpty()) onDecoded(text)
+        } finally {
+            // Must always close, or CameraX stalls the analysis pipe.
+            image.close()
+        }
+    }
+
+    private fun decode(image: ImageProxy): String? {
+        val plane = image.planes.firstOrNull() ?: return null
+        val buffer = plane.buffer
+        val data = ByteArray(buffer.remaining())
+        buffer.get(data)
+
+        val source = PlanarYUVLuminanceSource(
+            /* yuvData = */ data,
+            /* dataWidth = */ plane.rowStride,
+            /* dataHeight = */ image.height,
+            /* left = */ 0,
+            /* top = */ 0,
+            /* width = */ image.width,
+            /* height = */ image.height,
+            /* reverseHorizontal = */ false,
+        )
+        val bitmap = BinaryBitmap(HybridBinarizer(source))
+        return try {
+            reader.decodeWithState(bitmap).text
+        } catch (_: NotFoundException) {
+            // No QR in this frame — also try the inverted luminance so
+            // light-on-dark codes (rare, but some sharers theme them)
+            // still resolve.
+            try {
+                reader.decodeWithState(BinaryBitmap(HybridBinarizer(source.invert()))).text
+            } catch (_: NotFoundException) {
+                null
+            }
+        } finally {
+            reader.reset()
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/scan/QrScannerScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/scan/QrScannerScreen.kt
@@ -1,0 +1,262 @@
+package app.onym.android.scan
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.NoPhotography
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import app.onym.android.R
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Full-screen camera surface that scans a QR code and reports the
+ * decoded payload via [onScanned], or backs out via [onCancel].
+ *
+ * Deliberately generic — it doesn't know the payload means an inbox
+ * key. The caller (today, the Create Group "Invite by inbox key"
+ * screen) runs the decoded string through
+ * [app.onym.android.group.canonicalizeInviteKey]. Keeping the parser
+ * out of the scanner lets the same surface scan future payload shapes.
+ *
+ * Android twin of `QRCodeScannerView.swift` from onym-ios: same black
+ * chrome, centred viewfinder, top-right cancel, bottom hint, and a
+ * one-shot delivery so a held-up code fires [onScanned] exactly once.
+ *
+ * Camera permission is requested on first composition. Denial swaps
+ * to an inline message — the caller's paste-the-key path is the
+ * fallback, so we don't hard-block here.
+ */
+@Composable
+fun QrScannerScreen(
+    onScanned: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    var hasPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+                PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    var permissionRequested by remember { mutableStateOf(false) }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> hasPermission = granted }
+
+    LaunchedEffect(Unit) {
+        if (!hasPermission) {
+            permissionRequested = true
+            launcher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+    ) {
+        if (hasPermission) {
+            CameraPreview(onScanned = onScanned)
+            Viewfinder()
+        } else if (permissionRequested) {
+            PermissionDenied()
+        }
+
+        // Bottom hint — only meaningful while the camera is live.
+        if (hasPermission) {
+            Text(
+                text = stringResource(R.string.qr_scanner_hint),
+                color = Color.White,
+                style = TextStyle(
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                ),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .systemBarsPadding()
+                    .padding(horizontal = 24.dp, vertical = 40.dp),
+            )
+        }
+
+        // Top-right cancel.
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .systemBarsPadding()
+                .padding(8.dp)
+                .size(44.dp)
+                .clip(RoundedCornerShape(50))
+                .background(Color.Black.copy(alpha = 0.45f))
+                .clickable(onClick = onCancel),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = stringResource(R.string.cancel),
+                tint = Color.White,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+/** CameraX preview + QR analysis bound to the composition lifecycle. */
+@Composable
+private fun CameraPreview(onScanned: (String) -> Unit) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val previewView = remember {
+        PreviewView(context).apply {
+            scaleType = PreviewView.ScaleType.FILL_CENTER
+        }
+    }
+    // Single-thread analysis executor; shut down on dispose.
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+    // One-shot latch — AVFoundation's iOS twin has the same guard;
+    // STRATEGY_KEEP_ONLY_LATEST still hands us several frames of the
+    // same held-up code, and we must fire onScanned only once.
+    val consumed = remember { AtomicBoolean(false) }
+
+    AndroidView(
+        factory = { previewView },
+        modifier = Modifier.fillMaxSize(),
+    )
+
+    DisposableEffect(Unit) {
+        val providerFuture = ProcessCameraProvider.getInstance(context)
+        providerFuture.addListener({
+            val provider = providerFuture.get()
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(previewView.surfaceProvider)
+            }
+            val analysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+                .also {
+                    it.setAnalyzer(
+                        analysisExecutor,
+                        QrCodeAnalyzer { text ->
+                            if (consumed.compareAndSet(false, true)) {
+                                // Hop to the main thread; onScanned
+                                // tears down this composable.
+                                previewView.post { onScanned(text) }
+                            }
+                        },
+                    )
+                }
+            try {
+                provider.unbindAll()
+                provider.bindToLifecycle(
+                    lifecycleOwner,
+                    CameraSelector.DEFAULT_BACK_CAMERA,
+                    preview,
+                    analysis,
+                )
+            } catch (_: Exception) {
+                // No back camera / camera in use — leave the surface
+                // black; the cancel button and paste fallback remain.
+            }
+        }, ContextCompat.getMainExecutor(context))
+
+        onDispose {
+            try {
+                providerFuture.get().unbindAll()
+            } catch (_: Exception) {
+                // Provider never resolved — nothing bound to release.
+            }
+            analysisExecutor.shutdown()
+        }
+    }
+}
+
+/** Centred square viewfinder, non-interactive — pure chrome. */
+@Composable
+private fun BoxScope.Viewfinder() {
+    Box(
+        modifier = Modifier
+            .align(Alignment.Center)
+            .fillMaxWidth(0.65f)
+            .aspectRatio(1f)
+            .border(
+                width = 2.dp,
+                color = Color.White.copy(alpha = 0.85f),
+                shape = RoundedCornerShape(18.dp),
+            ),
+    )
+}
+
+@Composable
+private fun BoxScope.PermissionDenied() {
+    Column(
+        modifier = Modifier
+            .align(Alignment.Center)
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.NoPhotography,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.85f),
+            modifier = Modifier.size(36.dp),
+        )
+        Spacer(Modifier.height(14.dp))
+        Text(
+            text = stringResource(R.string.qr_scanner_permission_denied),
+            color = Color.White,
+            style = TextStyle(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+            ),
+        )
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -412,6 +412,11 @@
     <string name="create_group_invite_by_key_count">(%1$d/64)</string>
     <string name="create_group_invite_by_key_helper">Получатель создаёт этот ключ на своём устройстве. Найти его можно в Настройках → Личность → Ключ входящих.</string>
     <string name="create_group_invite_by_key_add">Добавить участника</string>
+    <string name="create_group_invite_by_key_scan">Сканировать QR-код</string>
+
+    <!-- QR-сканер (Создание группы → Пригласить по ключу → Сканировать QR) -->
+    <string name="qr_scanner_hint">Наведите камеру на QR-код приглашения Onym.</string>
+    <string name="qr_scanner_permission_denied">Доступ к камере отключён. Включите его в настройках и вернитесь, чтобы отсканировать.</string>
 
     <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
     <string name="create_group_cta_empty">Создать пустую группу</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,6 +420,11 @@
     <string name="create_group_invite_by_key_count">(%1$d/64)</string>
     <string name="create_group_invite_by_key_helper">The recipient generates this key on their own device. They can find it in Settings → Identity → Inbox Key.</string>
     <string name="create_group_invite_by_key_add">Add invitee</string>
+    <string name="create_group_invite_by_key_scan">Scan QR code</string>
+
+    <!-- QR scanner (Create Group → Invite by inbox key → Scan QR) -->
+    <string name="qr_scanner_hint">Point your camera at an Onym invite QR code.</string>
+    <string name="qr_scanner_permission_denied">Camera access is off. Enable it in Settings, then come back to scan.</string>
 
     <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
     <string name="create_group_cta_empty">Create empty group</string>

--- a/app/src/test/kotlin/app/onym/android/group/InviteKeyCanonicalizerTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/InviteKeyCanonicalizerTest.kt
@@ -1,0 +1,69 @@
+package app.onym.android.group
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Base64
+
+/**
+ * Pins [canonicalizeInviteKey] against the link shapes a scan can
+ * yield. The contract is the twin of onym-ios
+ * `CreateGroupFlow.canonicalizeInviteKey(_:)` — keep them in lockstep.
+ */
+class InviteKeyCanonicalizerTest {
+
+    // A fixed 32-byte key + its hex and URL-safe-base64 encodings.
+    private val keyBytes = ByteArray(32) { it.toByte() }
+    private val keyHex = keyBytes.joinToString("") { "%02x".format(it) }
+    private val keyB64Url = Base64.getUrlEncoder().withoutPadding().encodeToString(keyBytes)
+
+    @Test
+    fun bareHex_returnedUnchanged() {
+        assertEquals(keyHex, canonicalizeInviteKey(keyHex))
+    }
+
+    @Test
+    fun bareHex_trimmedButCasePreserved() {
+        // Matches iOS: only `payload=` is lowercased; a bare hex paste
+        // is returned as-is (decodeHex accepts either case).
+        val upper = keyHex.uppercase()
+        assertEquals(upper, canonicalizeInviteKey("  $upper  "))
+    }
+
+    @Test
+    fun identityInviteLink_extractsHexFromK() {
+        val link = "https://onym.app/i?k=$keyB64Url"
+        assertEquals(keyHex, canonicalizeInviteKey(link))
+    }
+
+    @Test
+    fun identityInviteLink_customScheme_extractsHexFromK() {
+        // Same `k` param under a non-https URI still parses.
+        val link = "onym://i?k=$keyB64Url"
+        assertEquals(keyHex, canonicalizeInviteKey(link))
+    }
+
+    @Test
+    fun legacyIosSettingsLink_extractsLoweredPayload() {
+        val link = "https://onym.app?payload=${keyHex.uppercase()}"
+        assertEquals(keyHex, canonicalizeInviteKey(link))
+    }
+
+    @Test
+    fun unrecognisedString_returnedTrimmed() {
+        assertEquals("not-a-key", canonicalizeInviteKey("  not-a-key  "))
+    }
+
+    @Test
+    fun linkWithoutKnownParams_returnedTrimmed() {
+        val link = "https://onym.app/i?foo=bar"
+        assertEquals(link, canonicalizeInviteKey(link))
+    }
+
+    @Test
+    fun garbledBase64InK_fallsThroughToTrimmedInput() {
+        // '!' isn't a base64 char — decode fails, so the raw link is
+        // returned and the caller's hex validation rejects it.
+        val link = "https://onym.app/i?k=!!!notbase64!!!"
+        assertEquals(link, canonicalizeInviteKey(link))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,11 +43,21 @@ onym-sdk = "0.0.2"
 # Crypto
 bouncycastle = "1.78.1"
 
-# ZXing — pure-Java QR encoder (Apache 2.0). The `core` artifact is
-# free of any Android dependency; we render the resulting BitMatrix
-# ourselves on a Compose `Canvas`, so the heavier `zxing-android`
-# extras (camera, intent integrators) stay out of the APK.
+# ZXing — pure-Java QR encoder + decoder (Apache 2.0). The `core`
+# artifact is free of any Android dependency; we render the encode-
+# side BitMatrix ourselves on a Compose `Canvas`, and on the decode
+# side we feed CameraX luminance frames straight into
+# `MultiFormatReader` (see `QrCodeAnalyzer`). The heavier
+# `zxing-android` extras (their stock camera surface + intent
+# integrators) stay out of the APK — CameraX is the camera layer.
 zxing-core = "3.5.3"
+
+# CameraX — camera preview + frame analysis for the invite-QR
+# scanner (`QrScannerScreen`). 1.4.1 is the current stable line and
+# ships 16-KB-aligned native libs for Android 15+. We pull the four
+# standard artifacts: core + camera2 backend, the lifecycle-aware
+# `ProcessCameraProvider`, and `PreviewView` for the surface.
+androidx-camera = "1.4.1"
 
 # Room — Kotlin-coroutines DAO (`suspend` queries) + KSP-generated
 # bindings. 2.6.1 is the newest stable that pairs cleanly with AGP
@@ -123,9 +133,17 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 # BouncyCastle — Curve25519 (Ed25519 + X25519) raw-key APIs not in the JDK
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 
-# ZXing core — QR-bit-matrix generator. Drawn by `OnymQrCode` onto a
-# Compose Canvas; no Android-side ZXing artifact needed.
+# ZXing core — QR-bit-matrix generator (encode) + `MultiFormatReader`
+# (decode). Drawn by `OnymQrCode` onto a Compose Canvas; decoded from
+# CameraX frames by `QrCodeAnalyzer`. No Android-side ZXing artifact
+# needed.
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+
+# CameraX — preview + image analysis for the invite-QR scanner.
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "androidx-camera" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "androidx-camera" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "androidx-camera" }
+androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "androidx-camera" }
 
 # Test
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
## What

Adds a **Scan QR code** affordance to the Create Group → *Invite by inbox key* screen, mirroring onym-ios. The user scans a contact's identity-invite QR (`https://onym.app/i?k=…`); the decoded string is canonicalised to the bare 64-char hex inbox key and dropped into the existing field for review before *Add invitee*. A malformed scan surfaces the same inline error as a malformed paste.

Closes part of #88 (the Scan-QR ask — see Scope below).

## How

| Piece | Detail |
|---|---|
| `group/InviteKeyCanonicalizer.kt` | Pure-JVM twin of iOS `canonicalizeInviteKey(_:)`. Recognises bare hex, `/i?k=<base64url>` (identity invite), and legacy iOS `?payload=<hex>`. Falls through to trimmed input so the caller's hex validation produces a meaningful error. Unit-tested, no Robolectric. |
| `scan/QrCodeAnalyzer.kt` | CameraX `ImageAnalysis.Analyzer` decoding the Y-plane with zxing-core `MultiFormatReader` (QR-only, `TRY_HARDER`, inverted fallback). |
| `scan/QrScannerScreen.kt` | Full-screen CameraX preview, runtime `CAMERA` permission, viewfinder + cancel chrome matching the iOS `QRCodeScannerView`, one-shot dedup latch. |
| `CreateGroupViewModel.tappedScannedKey` | Canonicalises into `inviteeInput`; validation stays in `tappedAddInvitee`. |
| Plumbing | `CAMERA` permission + `uses-feature camera.any required="false"`; CameraX 1.4.1 in the version catalog; en + ru strings. |

### Dependency choice
Camera layer is **CameraX**; decode reuses the **zxing-core** dependency already in the APK (encode-only until now). No ML Kit model and no Google Play Services — keeps the APK **F-Droid-buildable** (both deps are Apache-2.0, source-buildable).

## Scope

Scan path only. The other #88 asks are deliberate follow-ups:
- pasting a full invite link into the key field,
- copying your own inbox key from Identity Settings,
- `onym.app/i` deep linking (the manifest deep-links `/join` for group invites but not `/i` for identity invites).

## Testing

- `InviteKeyCanonicalizerTest` — 8/8 pass (bare hex case-preserved, `/i?k=`, custom-scheme `k=`, legacy `?payload=`, unknown/garbled fallbacks).
- `:app:compileDebugKotlin` and `:app:lintDebug` (incl. hard-gated `MissingTranslation`) pass.
- ⚠️ Live camera decode not exercised on hardware — worth a device smoke test (CameraX Y-plane → zxing is the standard path, but verify against a real `/i?k=` QR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)