### PR TITLE
feat(chats): differentiate message senders without avatars

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
@@ -2,6 +2,7 @@ package app.onym.android.chats
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -26,18 +27,32 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 /**
  * Chat-thread bubble. Two visual modes driven by [ChatMessage.direction]:
  *
- *  - [MessageDirection.OUTGOING] — `colorScheme.primary` fill,
- *    `colorScheme.onPrimary` text, trailing-aligned. Status glyph
+ *  - [MessageDirection.OUTGOING] — filled with the sender's accent
+ *    ([ChatSenderDisplay.accent], which for own messages hashes to the
+ *    user's own color), `onAccent` text, trailing-aligned. Status glyph
  *    below the trailing edge (clock / check / red bang).
- *  - [MessageDirection.INCOMING] — `colorScheme.surfaceVariant`
- *    fill, `colorScheme.onSurfaceVariant` text, leading-aligned.
- *    No status indicator (the message arriving is proof of
+ *  - [MessageDirection.INCOMING] — tinted with the sender's accent at
+ *    [INCOMING_TINT_ALPHA], `onSurface` text for readability,
+ *    leading-aligned, optionally topped by an accent-colored name
+ *    header. No status indicator (the message arriving is proof of
  *    delivery).
+ *
+ * Sender differentiation (onym-ios PR #162): there are no avatars, so
+ * consecutive incoming messages from one person are grouped under a
+ * single accent-colored name header ([ChatSenderDisplay.showNameHeader],
+ * decided by the screen's run-grouping pass) and the bubble carries
+ * that sender's accent. The accent is a hash of the BLS pubkey, not the
+ * alias, so it doubles as a cheap visual fingerprint an alias-spoofer
+ * can't forge. The bubble stays a dumb renderer — it receives a
+ * resolved [ChatSenderDisplay] and never looks up aliases or hashes
+ * pubkeys itself.
  *
  * Bubble max width is capped at [maxWidthFraction] of the parent
  * row (default 75%) so a long monologue doesn't reach the opposite
@@ -61,20 +76,32 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ChatBubble(
     message: ChatMessage,
+    sender: ChatSenderDisplay = ChatSenderDisplay.Unknown,
     modifier: Modifier = Modifier,
     maxWidthFraction: Float = 0.75f,
     onRetry: (() -> Unit)? = null,
 ) {
     val isOutgoing = message.direction == MessageDirection.OUTGOING
+    // The Chats tab is Material-themed (no OnymTheme provider), so we
+    // resolve the accent against the system theme directly — the no-arg
+    // OnymAccent.color() would always return the dark variant here.
+    val darkTheme = isSystemInDarkTheme()
+    val accentColor: Color = sender.accent.color(darkTheme)
     val fill: Color = if (isOutgoing) {
-        MaterialTheme.colorScheme.primary
+        // Own messages: solid fill in the user's own accent (so "your
+        // color" is consistent with the members list and every group).
+        accentColor
     } else {
-        MaterialTheme.colorScheme.surfaceVariant
+        // Others' messages: low-opacity tint in the sender's accent —
+        // distinguishable per person while keeping body text readable.
+        accentColor.copy(alpha = INCOMING_TINT_ALPHA)
     }
     val textColor: Color = if (isOutgoing) {
-        MaterialTheme.colorScheme.onPrimary
+        // White on the darker light-variant fills, black on the bright
+        // dark-variant fills — mirrors OnymTokens.onAccent.
+        if (darkTheme) Color.Black else Color.White
     } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
+        MaterialTheme.colorScheme.onSurface
     }
     val retryEnabled = canRetry(message) && onRetry != null
 
@@ -93,6 +120,24 @@ fun ChatBubble(
                 verticalArrangement = Arrangement.spacedBy(2.dp),
                 modifier = Modifier.widthIn(max = bubbleMaxWidth),
             ) {
+                // Accent-colored sender name at the start of an incoming
+                // run. Suppressed mid-run, on outgoing rows, and in
+                // 1-on-1 groups — the screen's run-grouping pass decides
+                // via ChatSenderDisplay.showNameHeader.
+                if (sender.showNameHeader) {
+                    Text(
+                        text = sender.name,
+                        color = accentColor,
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .padding(start = 4.dp)
+                            .testTag("chat_thread.sender.${message.id}"),
+                    )
+                }
                 BubbleBody(
                     body = message.body,
                     fill = fill,
@@ -219,3 +264,8 @@ internal enum class ChatStatusTint { Muted, Error }
 
 private val BUBBLE_RADIUS = 16.dp
 private val STATUS_ICON_SIZE = 14.dp
+
+/** Incoming-bubble tint opacity over the background. Low enough that
+ *  the body text stays readable on top, high enough that the sender's
+ *  accent reads at a glance. Mirrors iOS's `incomingTintAlpha` (0.20). */
+private const val INCOMING_TINT_ALPHA = 0.20f

--- a/app/src/main/kotlin/app/onym/android/chats/ChatSenderDisplay.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatSenderDisplay.kt
@@ -1,0 +1,95 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.group.MemberProfile
+import app.onym.android.group.OnymAccent
+import java.util.UUID
+
+/**
+ * Resolved sender presentation for one bubble — computed by the chat
+ * thread screen (which alone knows the group's member profiles + the
+ * message ordering) and handed to [ChatBubble]. The bubble stays a
+ * dumb renderer: it doesn't look up aliases or hash pubkeys itself.
+ *
+ * [accent] is derived from the sender's BLS pubkey via
+ * [OnymAccent.forSender], so it's a stable per-person color rather
+ * than anything tied to the (spoofable) alias.
+ *
+ * Mirrors `ChatSenderDisplay` from onym-ios PR #162.
+ */
+data class ChatSenderDisplay(
+    /** Alias if the member set one, else a short BLS-fingerprint
+     *  fallback. Only rendered when [showNameHeader] is true. */
+    val name: String,
+    /** Per-sender color. Tints the incoming bubble; fills the
+     *  outgoing bubble; colors the name header. */
+    val accent: OnymAccent,
+    /** Show the name header above this bubble. The screen sets this
+     *  only at the start of a run of consecutive same-sender incoming
+     *  messages, and never in 1-on-1 groups (one other person — naming
+     *  them on every run is noise). */
+    val showNameHeader: Boolean,
+) {
+    companion object {
+        /** Neutral default used by the bubble when no sender info is
+         *  supplied (older call sites / a missing display). Blue, no
+         *  header — matches the pre-sender-differentiation look. */
+        val Unknown = ChatSenderDisplay(
+            name = "",
+            accent = OnymAccent.Blue,
+            showNameHeader = false,
+        )
+    }
+}
+
+/**
+ * Recompute the per-message sender presentation from [messages] (in
+ * display order) + [memberProfiles]. A name header shows only at the
+ * *start* of a run of consecutive same-sender messages, only for
+ * incoming messages (own messages are obvious from alignment + color),
+ * and never in 1-on-1 groups (a single other person doesn't need to be
+ * named on every run). Color is hashed from the BLS pubkey, so it's
+ * stable per-person and independent of the alias.
+ *
+ * Pure function — the production composable calls it inside a
+ * `remember(messages, memberProfiles)` and feeds the result to each
+ * bubble, so a unit test exercises the run-grouping policy without
+ * standing up Compose. Mirrors
+ * `ChatThreadViewController.rebuildSenderDisplays` from onym-ios
+ * PR #162; on iOS the controller owns this, on Android the screen does.
+ */
+internal fun buildSenderDisplays(
+    messages: List<ChatMessage>,
+    memberProfiles: Map<String, MemberProfile>,
+): Map<UUID, ChatSenderDisplay> {
+    val displays = HashMap<UUID, ChatSenderDisplay>(messages.size)
+    var previousSender: String? = null
+    for (message in messages) {
+        val isRunStart = message.senderBlsPubkeyHex != previousSender
+        val showHeader = isRunStart &&
+            message.direction == MessageDirection.INCOMING &&
+            message.groupType != SepGroupType.ONE_ON_ONE
+        displays[message.id] = ChatSenderDisplay(
+            name = senderName(message.senderBlsPubkeyHex, memberProfiles),
+            accent = OnymAccent.forSender(message.senderBlsPubkeyHex),
+            showNameHeader = showHeader,
+        )
+        previousSender = message.senderBlsPubkeyHex
+    }
+    return displays
+}
+
+/**
+ * The sender's display name: their self-asserted alias when set, else
+ * a short BLS-pubkey fingerprint (`BLS ` + the first 8 hex chars).
+ * Mirrors the `ChatMembersScreen` fallback so an unnamed member reads
+ * consistently in both places.
+ */
+internal fun senderName(
+    blsPubkeyHex: String,
+    memberProfiles: Map<String, MemberProfile>,
+): String {
+    val alias = memberProfiles[blsPubkeyHex]?.alias ?: ""
+    if (alias.isNotEmpty()) return alias
+    return "BLS " + blsPubkeyHex.take(8)
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.onym.android.group.MemberProfile
 
 /**
  * Compose chat-thread screen. Tapping a group in the Chats tab
@@ -108,6 +109,12 @@ fun ChatThreadScreen(
         } else {
             ChatThreadBody(
                 messages = messages,
+                // Member profiles flow from the same live `group`
+                // snapshot the title reads, so a joiner landing or an
+                // alias edit repaints the rendered name headers without
+                // a fresh message arriving (requirement #6) — Compose
+                // recomposes the `remember(memberProfiles)` below.
+                memberProfiles = group?.memberProfiles.orEmpty(),
                 padding = padding,
                 onSend = viewModel::send,
                 onRetry = viewModel::retry,
@@ -119,6 +126,7 @@ fun ChatThreadScreen(
 @Composable
 private fun ChatThreadBody(
     messages: List<ChatMessage>,
+    memberProfiles: Map<String, MemberProfile>,
     padding: PaddingValues,
     onSend: (String) -> Unit,
     onRetry: (java.util.UUID) -> Unit,
@@ -131,6 +139,13 @@ private fun ChatThreadBody(
     // the controller boundary.
     val sortedMessages = remember(messages) {
         messages.sortedBy { it.sentAtMillis }
+    }
+    // Resolve per-message sender presentation (name + accent + whether
+    // to show the run-start header) off the sorted order + the group's
+    // member profiles. Recomputes when either changes — including a
+    // live profile update — so headers repaint in place.
+    val senderDisplays = remember(sortedMessages, memberProfiles) {
+        buildSenderDisplays(sortedMessages, memberProfiles)
     }
 
     // Auto-scroll behavior:
@@ -248,6 +263,7 @@ private fun ChatThreadBody(
                 ) { message ->
                     ChatBubble(
                         message = message,
+                        sender = senderDisplays[message.id] ?: ChatSenderDisplay.Unknown,
                         onRetry = { onRetry(message.id) },
                     )
                 }

--- a/app/src/main/kotlin/app/onym/android/group/OnymBrand.kt
+++ b/app/src/main/kotlin/app/onym/android/group/OnymBrand.kt
@@ -145,6 +145,48 @@ enum class OnymAccent(private val light: Color, private val dark: Color) {
     @ReadOnlyComposable
     fun color(): Color =
         if (LocalOnymTokens.current === OnymTokens.Dark) dark else light
+
+    /** Resolve against an explicit dark/light flag. For call sites
+     *  *outside* an [OnymTheme] scope — e.g. the Chats tab, which is
+     *  Material-themed and reads `isSystemInDarkTheme()` directly —
+     *  that still want the accent to track the system theme. (The
+     *  no-arg [color] would always return [dark] there, since
+     *  [LocalOnymTokens] defaults to [OnymTokens.Dark] without an
+     *  [OnymTheme] provider.) */
+    fun color(darkTheme: Boolean): Color = if (darkTheme) dark else light
+
+    companion object {
+        /**
+         * Deterministic accent for a chat sender, keyed off their BLS
+         * pubkey hex.
+         *
+         * Color keys on the *load-bearing* identity (the pubkey), never
+         * the self-asserted [MemberProfile.alias] — so two members who
+         * both claim "Alice" still get different colors, and an impostor
+         * can't steal the original's color by copying their name. The
+         * mapping is a pure function of the hex bytes (FNV-1a, not the
+         * per-process-seeded [hashCode]), so the same person resolves to
+         * the same color on every device, in every group, across
+         * launches.
+         *
+         * Byte-for-byte identical to `OnymAccent.forSender(blsPubkeyHex:)`
+         * in onym-ios PR #162: same FNV-1a constants, same UTF-8 byte
+         * input, same `% entries.size` into the same palette order
+         * (orange, blue, green, purple, pink, yellow). Do not change the
+         * constants or the enum declaration order without coordinating
+         * with iOS — a person must read as the same color on both
+         * platforms.
+         */
+        fun forSender(blsPubkeyHex: String): OnymAccent {
+            var hash = 0xcbf2_9ce4_8422_2325uL // FNV-1a 64-bit offset basis
+            for (byte in blsPubkeyHex.encodeToByteArray()) {
+                hash = hash xor byte.toUByte().toULong()
+                hash *= 0x0000_0100_0000_01b3uL // FNV-1a 64-bit prime
+            }
+            val all = entries
+            return all[(hash % all.size.toULong()).toInt()]
+        }
+    }
 }
 
 // ─── Theme scope ─────────────────────────────────────────────────

--- a/app/src/test/kotlin/app/onym/android/chats/ChatSenderDisplayTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatSenderDisplayTest.kt
@@ -1,0 +1,149 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.group.MemberProfile
+import app.onym.android.group.OnymAccent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Pure-policy tests for chat sender-differentiation run-grouping +
+ * alias resolution. Exercises [buildSenderDisplays] / [senderName]
+ * without standing up Compose — the production screen wires the same
+ * functions through a `remember(messages, memberProfiles)` and feeds
+ * each bubble the resolved [ChatSenderDisplay].
+ *
+ * Mirrors the run-grouping coverage in `ChatThreadViewControllerTests`
+ * from onym-ios PR #162; on iOS the controller owns this logic, on
+ * Android the screen does, but the policy is identical.
+ */
+class ChatSenderDisplayTest {
+
+    private val alice = "aa".repeat(48)
+    private val bob = "bb".repeat(48)
+
+    @Test
+    fun runGrouping_headerOnlyAtStartOfSameSenderRun() {
+        // Alice, Alice, Bob — header on row 0 (run start) and row 2
+        // (sender change), suppressed on row 1 (mid-run).
+        val msgs = listOf(
+            incoming(alice, "hi", at = 1),
+            incoming(alice, "again", at = 2),
+            incoming(bob, "yo", at = 3),
+        )
+        val displays = buildSenderDisplays(msgs, emptyMap())
+        assertTrue("run start shows header", displays.getValue(msgs[0].id).showNameHeader)
+        assertFalse("mid-run hides header", displays.getValue(msgs[1].id).showNameHeader)
+        assertTrue("sender change shows header", displays.getValue(msgs[2].id).showNameHeader)
+    }
+
+    @Test
+    fun outgoingMessages_neverShowHeader() {
+        val msg = outgoing("cc".repeat(48), "mine", at = 1)
+        val displays = buildSenderDisplays(listOf(msg), emptyMap())
+        assertFalse(
+            "own messages are obvious from alignment + color — no header",
+            displays.getValue(msg.id).showNameHeader,
+        )
+    }
+
+    @Test
+    fun oneOnOneGroup_suppressesHeader() {
+        val msg = incoming("dd".repeat(48), "hey", at = 1, groupType = SepGroupType.ONE_ON_ONE)
+        val displays = buildSenderDisplays(listOf(msg), emptyMap())
+        assertFalse(
+            "1-on-1 chats name no one — there's only one other person",
+            displays.getValue(msg.id).showNameHeader,
+        )
+    }
+
+    @Test
+    fun header_usesAliasFromMemberProfiles() {
+        val msg = incoming(alice, "hi", at = 1)
+        val displays = buildSenderDisplays(listOf(msg), mapOf(alice to profile("Alice")))
+        assertEquals("Alice", displays.getValue(msg.id).name)
+    }
+
+    @Test
+    fun header_fallsBackToFingerprint_whenAliasMissing() {
+        // No alias for this sender → short BLS fingerprint fallback.
+        val msg = incoming(alice, "hi", at = 1)
+        val displays = buildSenderDisplays(listOf(msg), emptyMap())
+        assertEquals("BLS " + alice.take(8), displays.getValue(msg.id).name)
+    }
+
+    @Test
+    fun profileUpdate_refreshesResolvedHeaderName() {
+        // A joiner's alias arriving after their message is on screen
+        // must repaint the header. The screen re-runs buildSenderDisplays
+        // via remember(memberProfiles); here we assert the pure result
+        // reflects the new profile.
+        val msg = incoming(alice, "hi", at = 1)
+        val before = buildSenderDisplays(listOf(msg), emptyMap())
+        assertEquals("BLS " + alice.take(8), before.getValue(msg.id).name)
+
+        val after = buildSenderDisplays(listOf(msg), mapOf(alice to profile("Alice")))
+        assertEquals(
+            "a later profile update must refresh the resolved header name",
+            "Alice",
+            after.getValue(msg.id).name,
+        )
+    }
+
+    @Test
+    fun accent_isHashedFromPubkey_independentOfAlias() {
+        // The accent keys on the pubkey, never the (spoofable) alias:
+        // the same sender resolves to the same accent whether named or
+        // not, and it equals the standalone hash.
+        val msg = incoming(alice, "hi", at = 1)
+        val unnamed = buildSenderDisplays(listOf(msg), emptyMap()).getValue(msg.id).accent
+        val named = buildSenderDisplays(listOf(msg), mapOf(alice to profile("Alice")))
+            .getValue(msg.id).accent
+        assertEquals(unnamed, named)
+        assertEquals(OnymAccent.forSender(alice), named)
+    }
+
+    // ─── Builders ────────────────────────────────────────────────
+
+    private fun profile(alias: String) = MemberProfile(
+        alias = alias,
+        inboxPublicKey = ByteArray(32) { 1 },
+        sendingPubkey = ByteArray(32) { 2 },
+    )
+
+    private fun incoming(
+        sender: String,
+        body: String,
+        at: Long,
+        groupType: SepGroupType = SepGroupType.TYRANNY,
+    ) = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = "aa".repeat(32),
+        ownerIdentityId = "owner",
+        senderBlsPubkeyHex = sender,
+        body = body,
+        sentAtMillis = 1_700_000_000_000 + at,
+        direction = MessageDirection.INCOMING,
+        status = MessageStatus.RECEIVED,
+        groupType = groupType,
+    )
+
+    private fun outgoing(
+        sender: String,
+        body: String,
+        at: Long,
+    ) = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = "aa".repeat(32),
+        ownerIdentityId = "owner",
+        senderBlsPubkeyHex = sender,
+        body = body,
+        sentAtMillis = 1_700_000_000_000 + at,
+        direction = MessageDirection.OUTGOING,
+        status = MessageStatus.SENT,
+        groupType = SepGroupType.TYRANNY,
+    )
+}

--- a/app/src/test/kotlin/app/onym/android/group/OnymAccentSenderColorTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/OnymAccentSenderColorTest.kt
@@ -1,0 +1,78 @@
+package app.onym.android.group
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the per-sender accent derivation that drives chat
+ * sender-differentiation. The contract that matters:
+ *
+ *  - **Deterministic**: the same BLS pubkey always resolves to the
+ *    same accent (so a person's color is stable across devices,
+ *    groups, and launches — it's a visual fingerprint).
+ *  - **Keyed on the pubkey alone**: the function never sees the alias,
+ *    so an alias-spoofer can't steal the original's color.
+ *  - **Spread across the palette**: not a constant.
+ *  - **Cross-platform parity**: byte-identical to
+ *    `OnymAccent.forSender(blsPubkeyHex:)` in onym-ios PR #162 — same
+ *    FNV-1a constants over the same UTF-8 bytes into the same palette
+ *    order. The reference-vector test below pins the algorithm so a
+ *    constant typo can't silently desync the two platforms' colors.
+ *
+ * Mirrors `OnymAccentSenderColorTests.swift` from onym-ios PR #162.
+ */
+class OnymAccentSenderColorTest {
+
+    @Test
+    fun forSender_isDeterministic() {
+        val hex = "ab".repeat(48) // 96-char BLS pubkey hex
+        assertEquals(
+            "same pubkey must always map to the same accent",
+            OnymAccent.forSender(hex),
+            OnymAccent.forSender(hex),
+        )
+    }
+
+    @Test
+    fun forSender_distinctPubkeysCanDiffer() {
+        // Generate a spread of pubkeys and confirm the mapping isn't a
+        // constant — at least two distinct accents appear. (A perfect
+        // even split isn't promised; non-degeneracy is.)
+        val accents = (0 until 200)
+            .map { i -> OnymAccent.forSender("%096x".format(i)) }
+            .toSet()
+        assertTrue(
+            "the hash must distribute senders across the palette",
+            accents.size > 1,
+        )
+    }
+
+    @Test
+    fun forSender_alwaysReturnsPaletteMember() {
+        val accent = OnymAccent.forSender("ff".repeat(48))
+        assertTrue(OnymAccent.entries.contains(accent))
+    }
+
+    @Test
+    fun forSender_matchesReferenceFnv1a() {
+        // Independent re-implementation of the documented algorithm —
+        // guards production `forSender` against a constant/ordering
+        // drift that would desync colors from iOS.
+        fun reference(hex: String): OnymAccent {
+            var hash = 0xcbf2_9ce4_8422_2325uL
+            for (b in hex.encodeToByteArray()) {
+                hash = hash xor b.toUByte().toULong()
+                hash *= 0x0000_0100_0000_01b3uL
+            }
+            return OnymAccent.entries[(hash % OnymAccent.entries.size.toULong()).toInt()]
+        }
+        for (hex in listOf("", "a", "ab".repeat(48), "ff".repeat(48), "deadbeef")) {
+            assertEquals(
+                "forSender must equal the reference FNV-1a mapping for '$hex'",
+                reference(hex),
+                OnymAccent.forSender(hex),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Why

Group chats showed **no per-message sender identity** beyond left/right alignment and a fixed color. With no avatars, consecutive incoming messages from different people were indistinguishable.

Ports onym-ios#162 to Android, matching its behavior.

## What

Sender differentiation built on the **load-bearing identity (BLS pubkey)** rather than the self-asserted, spoofable `MemberProfile.alias`:

- **`OnymAccent.forSender(blsPubkeyHex)`** — deterministic accent hashed (FNV-1a) from the BLS pubkey hex. **Byte-identical to iOS**: same constants (offset `0xcbf29ce484222325`, prime `0x100000001b3`), same UTF-8 byte input, same `% 6` into the same palette order (orange, blue, green, purple, pink, yellow). A person reads as the same color on both platforms; the color doubles as a cheap visual fingerprint an alias-impostor can't forge.
- **Incoming runs** get an accent-colored **name header** at the start of each consecutive same-sender run; mid-run messages stay bare. The bubble carries the sender's accent at 20% tint, body text on the normal `onSurface` token for readability. Name = alias, falling back to `BLS xxxxxxxx` (first 8 hex chars) when unset.
- **Outgoing bubbles** fill with the user's **own** hashed accent (own messages already carry `myBlsHex`), so "your color" is consistent with the members list and across groups.
- **1-on-1 groups** (`SepGroupType.ONE_ON_ONE`) suppress the header.
- **Live refresh**: headers repaint as profiles change (joiner admitted, alias edited) without a new message — the screen builds displays off the live `group` snapshot, so Compose recomposes in place (Android's equivalent of iOS's `reconfigureItems`).

## Design

Run-grouping + alias resolution live in the screen layer as a pure `buildSenderDisplays(messages, memberProfiles)`; the `ChatBubble` stays a dumb renderer that receives a resolved `ChatSenderDisplay`. (iOS puts this in the view controller; Android puts it in the screen.)

Note: the Chats tab isn't wrapped in `OnymTheme`, so I added `OnymAccent.color(darkTheme)` to resolve the accent against `isSystemInDarkTheme()` (the no-arg `color()` defaults to the dark variant outside an `OnymTheme` provider).

## Files

- `group/OnymBrand.kt` — `OnymAccent.forSender` + `color(darkTheme)`
- `chats/ChatSenderDisplay.kt` (new) — `ChatSenderDisplay` + pure `buildSenderDisplays` / `senderName`
- `chats/ChatBubble.kt` — accepts `ChatSenderDisplay`, renders name header + per-sender coloring
- `chats/ChatThreadScreen.kt` — builds displays from messages + `group.memberProfiles`, pipes to each bubble

## Tests

- `OnymAccentSenderColorTest` — determinism, palette spread, palette membership, and a reference-FNV-1a vector test pinning cross-platform parity.
- `ChatSenderDisplayTest` — run start / mid-run / sender change, outgoing suppression, 1-on-1 suppression, alias resolution, fingerprint fallback, live profile refresh, and pubkey-keyed (alias-independent) accent.

Full `:app:testDebugUnitTest` suite green; `compileDebugKotlin` + `compileDebugAndroidTestKotlin` clean; secret-read lint clean.

## Note

The BLS fingerprint fallback uses 8 hex chars (`BLS aaaaaaaa`) to match iOS #162 exactly. The existing `ChatMembersScreen` uses a 12-char prefix + ellipsis — a pre-existing minor inconsistency left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)