### PR TITLE
fix(theme): support light/dark mode app-wide

### DIFF
--- a/app/src/main/kotlin/app/onym/android/MainActivity.kt
+++ b/app/src/main/kotlin/app/onym/android/MainActivity.kt
@@ -5,7 +5,10 @@ import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -104,7 +107,19 @@ class MainActivity : FragmentActivity() {
                 onDispose { removeOnNewIntentListener(listener) }
             }
 
-            MaterialTheme {
+            // Follow the OS light/dark setting app-wide. A bare
+            // `MaterialTheme {}` pins `lightColorScheme()`, which left
+            // the shell (Chats / Settings) always-light while the
+            // Create Group route — wrapped in `OnymTheme`, which reads
+            // `isSystemInDarkTheme()` — flipped to dark on its own,
+            // making it look like a stray dark scene in a light app.
+            // Providing the scheme here is what RootScreen already
+            // assumes ("Chats / Settings adapt via Material's
+            // colorScheme").
+            MaterialTheme(
+                colorScheme = if (isSystemInDarkTheme()) darkColorScheme()
+                else lightColorScheme(),
+            ) {
                 RootScreen(
                     dependencies = dependencies,
                     pendingCapability = pending,

--- a/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -212,7 +212,7 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                         if (state.accent == a) {
                             Text(
                                 text = "✓",
-                                color = Color.White,
+                                color = LocalOnymTokens.current.onAccent,
                                 style = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Bold),
                             )
                         }
@@ -855,7 +855,7 @@ private fun StepRow(label: String, sub: String, status: StepStatus, accent: Colo
             when (status) {
                 StepStatus.Done -> Text(
                     text = "✓",
-                    color = Color.Black,
+                    color = LocalOnymTokens.current.onAccent,
                     style = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Bold),
                 )
                 StepStatus.Active -> Text(

--- a/app/src/main/kotlin/app/onym/android/scan/QrScannerScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/scan/QrScannerScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.NoPhotography
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -64,9 +65,18 @@ import java.util.concurrent.atomic.AtomicBoolean
  * [app.onym.android.group.canonicalizeInviteKey]. Keeping the parser
  * out of the scanner lets the same surface scan future payload shapes.
  *
- * Android twin of `QRCodeScannerView.swift` from onym-ios: same black
- * chrome, centred viewfinder, top-right cancel, bottom hint, and a
- * one-shot delivery so a held-up code fires [onScanned] exactly once.
+ * Android twin of `QRCodeScannerView.swift` from onym-ios: centred
+ * viewfinder, top-right cancel, bottom hint, and a one-shot delivery
+ * so a held-up code fires [onScanned] exactly once.
+ *
+ * Theming: while the camera is live, the overlay chrome (hint,
+ * viewfinder border, cancel scrim) stays light-on-dark — it sits on
+ * the camera feed, so a fixed dark treatment reads regardless of the
+ * app theme, matching the iOS twin. The *non-camera* surfaces (the
+ * blank/denied background, the permission-denied message, and the
+ * cancel button once the feed is gone) follow the app's light/dark
+ * scheme via [MaterialTheme.colorScheme], which the enclosing
+ * `OnymTheme` provides.
  *
  * Camera permission is requested on first composition. Denial swaps
  * to an inline message — the caller's paste-the-key path is the
@@ -101,7 +111,13 @@ fun QrScannerScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black),
+            // Black behind the live feed (camera letterboxing reads as
+            // black); the themed surface only shows in the no-camera
+            // states (permission flow / denied / bind failure).
+            .background(
+                if (hasPermission) Color.Black
+                else MaterialTheme.colorScheme.background,
+            ),
     ) {
         if (hasPermission) {
             CameraPreview(onScanned = onScanned)
@@ -127,7 +143,9 @@ fun QrScannerScreen(
             )
         }
 
-        // Top-right cancel.
+        // Top-right cancel — shown in every state. Over the live feed
+        // it keeps the dark scrim + white glyph; on the themed
+        // no-camera surface it switches to the scheme's surface chip.
         Box(
             modifier = Modifier
                 .align(Alignment.TopEnd)
@@ -135,14 +153,18 @@ fun QrScannerScreen(
                 .padding(8.dp)
                 .size(44.dp)
                 .clip(RoundedCornerShape(50))
-                .background(Color.Black.copy(alpha = 0.45f))
+                .background(
+                    if (hasPermission) Color.Black.copy(alpha = 0.45f)
+                    else MaterialTheme.colorScheme.surfaceVariant,
+                )
                 .clickable(onClick = onCancel),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = Icons.Filled.Close,
                 contentDescription = stringResource(R.string.cancel),
-                tint = Color.White,
+                tint = if (hasPermission) Color.White
+                else MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(24.dp),
             )
         }
@@ -245,13 +267,13 @@ private fun BoxScope.PermissionDenied() {
         Icon(
             imageVector = Icons.Filled.NoPhotography,
             contentDescription = null,
-            tint = Color.White.copy(alpha = 0.85f),
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
             modifier = Modifier.size(36.dp),
         )
         Spacer(Modifier.height(14.dp))
         Text(
             text = stringResource(R.string.qr_scanner_permission_denied),
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onBackground,
             style = TextStyle(
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Medium,

--- a/app/src/main/kotlin/app/onym/android/settings/ContractDetailScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/ContractDetailScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -97,11 +96,7 @@ fun ContractDetailScreen(
                         modifier = Modifier
                             .size(56.dp)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFFFEF0E0), Color(0xFFFFE0C0)),
-                                )
-                            ),
+                            .background(Color(0xFFD14B00).copy(alpha = 0.14f)),
                         contentAlignment = Alignment.Center,
                     ) {
                         OnymMark(size = 32.dp, color = Color(0xFFD14B00))

--- a/app/src/main/kotlin/app/onym/android/settings/IdentitiesScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/IdentitiesScreen.kt
@@ -319,7 +319,10 @@ private fun IdentityListRow(
                 modifier = Modifier
                     .size(40.dp)
                     .clip(CircleShape)
-                    .background(if (row.isActive) Color(0xFFE0EEFE) else Color(0xFFEAEAEE)),
+                    .background(
+                        (if (row.isActive) SettingsTile.Blue else SettingsTile.Gray)
+                            .copy(alpha = 0.14f)
+                    ),
                 contentAlignment = Alignment.Center,
             ) {
                 OnymMark(

--- a/app/src/main/kotlin/app/onym/android/settings/IdentityDetailScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/IdentityDetailScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
@@ -157,11 +156,8 @@ fun IdentityDetailScreen(
                                 .size(96.dp)
                                 .clip(CircleShape)
                                 .background(
-                                    if (row.isActive) {
-                                        Brush.linearGradient(listOf(Color(0xFFEEF5FF), Color(0xFFD5E8FE)))
-                                    } else {
-                                        Brush.linearGradient(listOf(Color(0xFFEFEFF2), Color(0xFFEFEFF2)))
-                                    }
+                                    (if (row.isActive) SettingsTile.Blue else SettingsTile.Gray)
+                                        .copy(alpha = 0.14f)
                                 ),
                             contentAlignment = Alignment.Center,
                         ) {

--- a/app/src/main/kotlin/app/onym/android/settings/PrivacyEncryptionScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/PrivacyEncryptionScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -95,11 +94,7 @@ fun PrivacyEncryptionScreen(
                         modifier = Modifier
                             .size(56.dp)
                             .clip(RoundedCornerShape(14.dp))
-                            .background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFFDFFAEA), Color(0xFFB6F0CD)),
-                                )
-                            ),
+                            .background(SettingsTile.Green.copy(alpha = 0.14f)),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(

--- a/app/src/main/kotlin/app/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/SettingsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -303,11 +302,7 @@ private fun ActiveIdentityHero(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(CircleShape)
-                    .background(
-                        Brush.linearGradient(
-                            listOf(Color(0xFFEEF5FF), Color(0xFFE0EEFE)),
-                        )
-                    ),
+                    .background(SettingsTile.Blue.copy(alpha = 0.14f)),
                 contentAlignment = Alignment.Center,
             ) {
                 OnymMark(size = 36.dp, color = SettingsTile.Blue)

--- a/app/src/main/kotlin/app/onym/android/settings/UseExistingContractScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/UseExistingContractScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -110,11 +109,7 @@ fun UseExistingContractScreen(
                         modifier = Modifier
                             .size(52.dp)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(
-                                Brush.linearGradient(
-                                    listOf(Color(0xFFE5E5FE), Color(0xFFC7C7F4)),
-                                )
-                            ),
+                            .background(SettingsTile.Indigo.copy(alpha = 0.14f)),
                         contentAlignment = Alignment.Center,
                     ) {
                         Icon(


### PR DESCRIPTION
## Problem

The **New Group scene rendered dark while the rest of the app looked light.** Root cause: `MainActivity` wrapped everything in a bare `MaterialTheme { }`, which pins `lightColorScheme()` regardless of the OS setting. The Create Group route (via `OnymTheme`) was the *only* place reading `isSystemInDarkTheme()`, so in dark mode it flipped to dark on its own while the Material-themed shell (Chats / Settings) stayed light — making New Group look like a stray dark scene.

## Fix

**`MainActivity`** — provide the root `colorScheme` from `isSystemInDarkTheme()` (`darkColorScheme()` / `lightColorScheme()`). This is what `RootScreen` already assumed in a comment ("Chats / Settings adapt via Material's colorScheme"). The whole app now follows the OS light/dark setting, and Create Group is consistent with the shell.

## Settings dark-mode audit

With the shell now flipping, I audited the Settings/Chats screens for hardcoded light-only colors. Most were already safe in both modes and were **kept as-is**:
- Intentional dark "console/hero" panels (`0xFF1B1F24 → 0D1117` + white text)
- QR-code backgrounds (must stay white to remain scannable)
- Self-contained colored status chips (verified/testnet/public badges)
- White-on-accent glyphs (icons/labels on colored tiles)

The one genuinely light-only pattern was the **pastel avatar disc behind `OnymMark`** (`0xFFE0EEFE` / `0xFFEEF5FF` gradients, etc.) across SettingsScreen, IdentitiesScreen, IdentityDetailScreen, ContractDetailScreen, UseExistingContractScreen, PrivacyEncryptionScreen. Converted each to a low-alpha tint of its glyph color — the same idiom `OnymGovIcon` already uses (`color.copy(alpha = 0.14f)`) — so it reads as a pale tint in light mode and a subtle tint on dark. `ChatBubble` already adapts via `isSystemInDarkTheme()`; no change needed.

## Also included (Create Group flow)

- `scan/QrScannerScreen.kt` — themed the scanner's non-camera surfaces (background, permission-denied, cancel chip) via `MaterialTheme.colorScheme`; the live-camera overlay chrome stays light-on-dark (matches iOS twin).
- `group/creategroup/CreateGroupScreen.kt` — two stray hardcoded checkmarks now use `LocalOnymTokens.current.onAccent`.

## Testing

- `./gradlew :app:compileDebugKotlin` passes.
- Manual: verify the whole app (Chats, Settings, Create Group) follows the system light/dark toggle, QR codes still scan, and Settings avatar badges read in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)