### PR TITLE
feat(groups): Tyranny-only picker + rename it to "Founder"

### DIFF
--- a/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
@@ -292,7 +292,7 @@ private fun ChatsRow(
 @Composable
 private fun subtitleFor(group: ChatGroup): String {
     val label = when (group.groupType) {
-        SepGroupType.TYRANNY -> "Tyranny"
+        SepGroupType.TYRANNY -> "Founder"
         SepGroupType.ANARCHY -> "Anarchy"
         SepGroupType.ONE_ON_ONE -> "1-on-1"
         SepGroupType.DEMOCRACY -> "Democracy"

--- a/app/src/main/kotlin/app/onym/android/group/ApproveRequestsViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/group/ApproveRequestsViewModel.kt
@@ -146,7 +146,7 @@ class ApproveRequestsViewModel(
             is JoinRequestApprover.ApproveOutcome.NoActiveRelayer ->
                 "No chain relayer configured. Set one in Settings → Network → Relayer."
             is JoinRequestApprover.ApproveOutcome.NoContractBinding ->
-                "No Tyranny contract selected for this network. Pick one in Settings → Network → Anchors."
+                "No Founder contract selected for this network. Pick one in Settings → Network → Anchors."
             is JoinRequestApprover.ApproveOutcome.NotAdminOfThisGroup ->
                 "The active identity isn’t this group’s admin. Switch to the identity that created the group, then try again."
             is JoinRequestApprover.ApproveOutcome.ProofFailed ->

--- a/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
@@ -91,10 +91,12 @@ data class CreateGroupState(
      *  screen content. */
     val createdGroup: ChatGroup? = null,
 ) {
-    /** True when the selected governance type is wired to the chain
-     *  layer. All three flavours (Tyranny / 1-on-1 / Anarchy) are
-     *  wired today. The name no longer gates advance — submit falls
-     *  back to [generatedName] when the field is empty. */
+    /** True when the selected governance type is offered by the picker
+     *  ([OnymUIGovernance.isAvailable]). Only Tyranny is offered today,
+     *  and it's the default, so this is effectively always true — the
+     *  guard stays so a future not-yet-offered default would block
+     *  advance. The name no longer gates advance — submit falls back to
+     *  [generatedName] when the field is empty. */
     val canAdvanceToStep2: Boolean
         get() = governance.isAvailable
 
@@ -452,8 +454,9 @@ class CreateGroupViewModel(
 
 /**
  * UI-side mirror of the design's three governance cards. Maps to
- * [SepGroupType] for the actual chain call. All three flavours are
- * wired post-Anarchy — `isAvailable` returns true for every entry.
+ * [SepGroupType] for the actual chain call. Only Tyranny is offered
+ * today; OneOnOne and Anarchy render with a "Soon" badge and can't be
+ * selected (see [isAvailable]), matching the iOS create-group picker.
  *
  * Display strings (card label, sub-line, tooltip, Step-2 hint) live
  * in the `res/values*` localized `strings.xml` files and are resolved
@@ -468,11 +471,15 @@ enum class OnymUIGovernance {
     Anarchy,
     ;
 
-    /** All three governance flavours are wired to the chain layer:
-     *  Tyranny (`@RunWith` PR #36), OneOnOne (#36/47/48 stack),
-     *  Anarchy (#50/51/this-PR stack). Future flavours
-     *  (Democracy, Oligarchy) flip on as they wire. */
-    val isAvailable: Boolean get() = true
+    /** Whether the picker offers this flavour. Only Tyranny is
+     *  selectable for now; OneOnOne and Anarchy show a "Soon" badge and
+     *  are non-interactive — matching the iOS create-group picker. Flip
+     *  each on as its create-group UX is finished. */
+    val isAvailable: Boolean
+        get() = when (this) {
+            Tyranny -> true
+            OneOnOne, Anarchy -> false
+        }
 
     val sepGroupType: SepGroupType
         get() = when (this) {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -347,10 +347,10 @@
     <string name="governance_democracy">Демократия</string>
     <string name="governance_oligarchy">Олигархия</string>
     <string name="governance_oneonone">Один на один</string>
-    <string name="governance_tyranny">Тирания</string>
+    <string name="governance_tyranny">Основатель</string>
 
     <!-- ─── Governance card copy (CreateGroup Step 1 / Step 2) ─── -->
-    <string name="governance_tyranny_card_label">Тирания</string>
+    <string name="governance_tyranny_card_label">Основатель</string>
     <string name="governance_tyranny_sub">Один админ</string>
     <string name="governance_tyranny_oneline">Вы управляете участниками и настройками.</string>
     <string name="governance_tyranny_step2hint">Вы будете единственным админом.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,13 +352,13 @@
     <string name="governance_democracy">Democracy</string>
     <string name="governance_oligarchy">Oligarchy</string>
     <string name="governance_oneonone">One-on-one</string>
-    <string name="governance_tyranny">Tyranny</string>
+    <string name="governance_tyranny">Founder</string>
 
     <!-- ─── Governance card copy (CreateGroup Step 1 / Step 2) ─────
          Short pill labels for the picker cards plus the per-flavour
          sub-line, tooltip blurb, and Step-2 banner hint that used
          to live as hardcoded strings inside `OnymUIGovernance`. -->
-    <string name="governance_tyranny_card_label">Tyranny</string>
+    <string name="governance_tyranny_card_label">Founder</string>
     <string name="governance_tyranny_sub">Single admin</string>
     <string name="governance_tyranny_oneline">You control membership and settings.</string>
     <string name="governance_tyranny_step2hint">You\'ll be the only admin.</string>

--- a/app/src/test/kotlin/app/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/CreateGroupViewModelTest.kt
@@ -57,20 +57,26 @@ class CreateGroupViewModelTest {
     }
 
     @Test
-    fun allGovernanceTypes_areSelectable() = runTest {
-        // All three flavours (Tyranny / OneOnOne / Anarchy) are wired
-        // post-Anarchy stack — the picker accepts every entry. This
-        // test used to assert Anarchy was a no-op (when only Tyranny
-        // was wired) and then OneOnOne (after the OneOnOne stack);
-        // both invariants are gone now. Kept as a guard against
-        // someone re-introducing an "unavailable" flavour without
-        // also updating the picker UI.
+    fun onlyTyranny_isSelectable_oneOnOneAndAnarchyShowSoon() = runTest {
+        // The picker offers Tyranny only; OneOnOne and Anarchy render a
+        // "Soon" badge and are non-interactive — mirrors the iOS
+        // create-group picker. `setGovernance` enforces the same gate
+        // (a tap on a disabled card is a no-op), so governance stays on
+        // the default. The chain layer still supports all three (see the
+        // CreateGroup*E2ETest suites) — this is purely which flavours
+        // the picker exposes today.
         val vm = makeViewModel()
-        for (g in OnymUIGovernance.entries) {
-            vm.setGovernance(g)
-            assertEquals(g, vm.state.value.governance)
-            assertTrue(vm.state.value.canAdvanceToStep2)
-        }
+
+        vm.setGovernance(OnymUIGovernance.Tyranny)
+        assertEquals(OnymUIGovernance.Tyranny, vm.state.value.governance)
+        assertTrue(vm.state.value.canAdvanceToStep2)
+
+        assertTrue("OneOnOne not offered yet", !OnymUIGovernance.OneOnOne.isAvailable)
+        assertTrue("Anarchy not offered yet", !OnymUIGovernance.Anarchy.isAvailable)
+        vm.setGovernance(OnymUIGovernance.OneOnOne)
+        assertEquals(OnymUIGovernance.Tyranny, vm.state.value.governance)
+        vm.setGovernance(OnymUIGovernance.Anarchy)
+        assertEquals(OnymUIGovernance.Tyranny, vm.state.value.governance)
     }
 
     @Test
@@ -259,45 +265,17 @@ class CreateGroupViewModelTest {
     }
 
     // ─── OneOnOne governance ──────────────────────────────────────
-
-    @Test
-    fun oneOnOne_isSelectable_andAdvancesToStep2() = runTest {
-        val vm = makeViewModel()
-        vm.setGovernance(OnymUIGovernance.OneOnOne)
-        assertEquals(OnymUIGovernance.OneOnOne, vm.state.value.governance)
-        assertTrue(vm.state.value.canAdvanceToStep2)
-    }
-
-    @Test
-    fun oneOnOne_canSubmitOnly_whenInviteeCountIsExactlyOne() = runTest {
-        val vm = makeViewModel()
-        vm.setGovernance(OnymUIGovernance.OneOnOne)
-        // Zero invitees → cannot submit.
-        assertTrue("zero invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
-        // One invitee → enabled.
-        vm.setInviteeInput("aa".repeat(32))
-        vm.tappedAddInvitee()
-        assertTrue("one invitee enables 1-on-1 submit", vm.state.value.canSubmit)
-        // Two invitees → blocked again.
-        vm.tappedInviteByKey()
-        vm.setInviteeInput("bb".repeat(32))
-        vm.tappedAddInvitee()
-        assertTrue("two invitees blocks 1-on-1 submit", !vm.state.value.canSubmit)
-    }
-
-    @Test
-    fun oneOnOne_ctaLabel_explainsTheGate() = runTest {
-        val vm = makeViewModel()
-        vm.setGovernance(OnymUIGovernance.OneOnOne)
-        assertEquals(CreateCtaLabel.OneOnOneAddOther, vm.state.value.createCtaLabel)
-        vm.setInviteeInput("aa".repeat(32))
-        vm.tappedAddInvitee()
-        assertEquals(CreateCtaLabel.OneOnOneStart, vm.state.value.createCtaLabel)
-        vm.tappedInviteByKey()
-        vm.setInviteeInput("bb".repeat(32))
-        vm.tappedAddInvitee()
-        assertEquals(CreateCtaLabel.OneOnOneTooMany, vm.state.value.createCtaLabel)
-    }
+    //
+    // OneOnOne is gated out of the picker for now (see
+    // `onlyTyranny_isSelectable_oneOnOneAndAnarchyShowSoon`), so its
+    // selected-state behaviour — the exactly-one-invitee submit gate
+    // ([CreateGroupState.canSubmit]) and the OneOnOneAddOther/Start/
+    // TooMany CTA labels ([CreateGroupState.createCtaLabel]) — is
+    // unreachable through the VM's public API while `setGovernance`
+    // refuses unavailable flavours. The logic stays in CreateGroupState
+    // for when the OneOnOne create-group UX is re-enabled; the three
+    // selected-state tests that exercised it were removed alongside the
+    // gate (recoverable from git history when OneOnOne flips back on).
 
     @Test
     fun tyranny_canSubmit_evenWithZeroInvitees() = runTest {
@@ -393,19 +371,9 @@ class CreateGroupViewModelTest {
     @Test
     fun tappedDismissError_clearsErrorAndReturnsToStep2() = runTest {
         val vm = makeViewModel()
-        // Note: this test used to rely on Anarchy being unavailable to
-        // force an error via submit(). Now all flavours are wired, so
-        // we just exercise the error-dismiss path on a clean state.
-        vm.setGovernance(OnymUIGovernance.Anarchy)
-        // Force the unavailable state by reflection-equivalent: there
-        // isn't a direct setter. Instead just observe that submit
-        // with available=Tyranny doesn't set error, then trigger the
-        // error path by manually constructing on the model.
-        // Simpler approach: confirm tappedDismissError clears error
-        // when one is present (the screen sets state via setError-
-        // equivalent indirectly through submit). Skip the synthetic
-        // setup and just call tappedDismissError on a clean state
-        // — it should still flip route to Step2 (covered separately).
+        // There's no direct error setter, so we exercise the dismiss
+        // path on a clean state: tappedDismissError clears any error and
+        // unconditionally lands on Step2.
         vm.tappedDismissError()
         assertEquals(CreateGroupRoute.Step2, vm.state.value.route)
         assertNull(vm.state.value.error)


### PR DESCRIPTION
Two related Create Group changes.

## 1. Gate 1-on-1 and Anarchy out of the picker

Only **Tyranny** is offered in the governance picker; **1-on-1** and **Anarchy** render the existing "Soon" badge and are non-interactive — matching the iOS create-group picker.

The picker UI already had a full disabled state (dimmed icon, top-right "Soon" badge, `clickable(enabled = available)`); it just never fired because `OnymUIGovernance.isAvailable` hardcoded `true` for every entry. Now it's per-type (`Tyranny → true`, `OneOnOne/Anarchy → false`). `setGovernance` already guards on `isAvailable`, so a tap on a disabled card is a no-op at the ViewModel level too.

This only changes which flavours the picker exposes — the chain layer still fully supports all three (`CreateGroupOneOnOneE2ETest` / `CreateGroupAnarchyE2ETest` drive the interactor directly and are unaffected). The OneOnOne submit-gate / CTA-label logic stays in `CreateGroupState` for re-enablement.

## 2. Rename user-facing "Tyranny" → "Founder"

UI-surface-only rename of the governance flavour's display name. **No code renamed** — the `OnymUIGovernance.Tyranny` / `SepGroupType.TYRANNY` enums, the `tyranny` chain wire values, the `governance_tyranny*` resource *keys*, and all class/identifier names are untouched.

Changed displayed strings:
- `governance_tyranny` / `governance_tyranny_card_label`: "Tyranny" → "Founder" (en); "Тирания" → "Основатель" (ru — localized to match the other governance terms in that locale).
- `ChatsScreen` group-type subtitle literal: "Tyranny" → "Founder".
- `ApproveRequestsViewModel` user-facing approve error: "No Tyranny contract…" → "No Founder contract…" (consistent with the Anchors picker, which renders `governance_tyranny`).

Left intentionally: the `_sub`/`_oneline`/`_step2hint` strings don't contain the word "Tyranny" (descriptive copy). `CreateGroupError.NoContractBinding` builds its message from `GovernanceType.wireValue` (the lowercase `tyranny` protocol slug), not a literal — untouched so the wire identifier stays valid.

## Tests

- Replaced `allGovernanceTypes_areSelectable` with `onlyTyranny_isSelectable_oneOnOneAndAnarchyShowSoon`; removed the three now-unreachable OneOnOne selected-state tests. `CreateGroupViewModelTest`: 24 passing.
- `StringsCompletenessTest` passes (resource keys unchanged).
- `./gradlew :app:compileDebugKotlin :app:processDebugResources` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)