### PR TITLE
feat(groups): group avatars, wire-compatible with iOS

### DIFF
--- a/app/src/androidTest/kotlin/app/onym/android/group/GroupAvatarImageTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/group/GroupAvatarImageTest.kt
@@ -1,0 +1,60 @@
+package app.onym.android.group
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.random.Random
+
+/**
+ * Instrumented tests for [GroupAvatarImage]. Lives in `androidTest/`
+ * because real JPEG encoding + bitmap scaling run on the device runtime
+ * (Robolectric's bitmap shadows don't produce real, size-bounded JPEG
+ * bytes, so the 16 KB budget can't be verified off-device).
+ *
+ * Mirrors `GroupAvatarImageTests.swift` from onym-ios PR #164.
+ */
+@RunWith(AndroidJUnit4::class)
+class GroupAvatarImageTest {
+
+    @Test
+    fun encode_highEntropySource_isSquare256AndUnderBudget() {
+        // Worst case for JPEG: a large, full-resolution noise image —
+        // high entropy resists compression, stressing the quality loop.
+        val noise = Bitmap.createBitmap(1024, 768, Bitmap.Config.ARGB_8888)
+        val rng = Random(42)
+        for (y in 0 until noise.height) {
+            for (x in 0 until noise.width) {
+                noise.setPixel(
+                    x,
+                    y,
+                    Color.rgb(rng.nextInt(256), rng.nextInt(256), rng.nextInt(256)),
+                )
+            }
+        }
+
+        val encoded = GroupAvatarImage.encode(noise)
+
+        assertTrue(
+            "encoded JPEG must be within the 16 KB budget, was ${encoded.size}",
+            encoded.size <= GroupAvatarImage.MAX_BYTES,
+        )
+        val decoded = android.graphics.BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
+        assertEquals(GroupAvatarImage.SIZE, decoded.width)
+        assertEquals(GroupAvatarImage.SIZE, decoded.height)
+    }
+
+    @Test
+    fun encode_nonSquareSource_isCentreCroppedToSquare() {
+        val wide = Bitmap.createBitmap(800, 200, Bitmap.Config.ARGB_8888)
+        wide.eraseColor(Color.BLUE)
+        val encoded = GroupAvatarImage.encode(wide)
+        val decoded = android.graphics.BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
+        assertEquals(GroupAvatarImage.SIZE, decoded.width)
+        assertEquals(GroupAvatarImage.SIZE, decoded.height)
+        assertTrue(encoded.size <= GroupAvatarImage.MAX_BYTES)
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -290,6 +290,7 @@ class OnymApplication : Application() {
                 .addMigrations(
                     GroupDatabaseMigrations.MIGRATION_3_4,
                     GroupDatabaseMigrations.MIGRATION_4_5,
+                    GroupDatabaseMigrations.MIGRATION_5_6,
                 )
                 .fallbackToDestructiveMigration()
                 .build()
@@ -631,7 +632,16 @@ class OnymApplication : Application() {
                 )
             },
             makeChatsViewModel = {
-                app.onym.android.chats.ChatsViewModel(repository = groupRepository)
+                app.onym.android.chats.ChatsViewModel(
+                    repository = groupRepository,
+                    avatarBroadcaster = app.onym.android.group.GroupAvatarBroadcaster(
+                        activeIdentity = identityRepository,
+                        identitiesFlow = identityRepository.identities,
+                        envelopeSealer = identityRepository,
+                        groupRepository = groupRepository,
+                        inboxTransport = inboxTransport,
+                    ),
+                )
             },
             makeChatThreadViewModel = { groupId ->
                 // PR A5: per-thread VM. The SendMessageInteractor is

--- a/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
@@ -1,6 +1,13 @@
 package app.onym.android.chats
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PersonOutline
+import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -24,14 +32,19 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -41,8 +54,12 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.onym.android.chain.SepGroupType
 import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupAvatarImage
 import app.onym.android.group.MemberProfile
 import app.onym.android.identity.IdentitiesViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Roster screen drilled into from a chat row. Renders one row per
@@ -93,6 +110,27 @@ fun ChatMembersScreen(
     }
     val showShareInvite = onShareInviteClick != null && canShareInvite
 
+    // Only the cryptographic admin may change the group photo — same
+    // gate as Share Invite (the receive-side trust check rejects a
+    // non-admin's avatar message anyway, so a non-admin's edit would be
+    // a dead-end). Non-admins get the read-only display below.
+    val canEditAvatar = canShareInvite
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val photoPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        val g = group ?: return@rememberLauncherForActivityResult
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                decodeAndEncodeAvatar(context, uri)
+            } ?: return@launch
+            chatsViewModel.setGroupAvatar(g.id, bytes)
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -130,6 +168,15 @@ fun ChatMembersScreen(
             ChatMembersBody(
                 group = group,
                 activeBlsHex = activeBlsHex,
+                canEditAvatar = canEditAvatar,
+                onPickPhoto = {
+                    photoPicker.launch(
+                        PickVisualMediaRequest(
+                            ActivityResultContracts.PickVisualMedia.ImageOnly,
+                        ),
+                    )
+                },
+                onRemovePhoto = { chatsViewModel.setGroupAvatar(group.id, null) },
                 modifier = Modifier.padding(padding).fillMaxSize(),
             )
         }
@@ -140,6 +187,9 @@ fun ChatMembersScreen(
 private fun ChatMembersBody(
     group: ChatGroup,
     activeBlsHex: String?,
+    canEditAvatar: Boolean,
+    onPickPhoto: () -> Unit,
+    onRemovePhoto: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val rows = remember(group.memberProfiles, activeBlsHex) {
@@ -155,6 +205,12 @@ private fun ChatMembersBody(
     }
 
     Column(modifier = modifier) {
+        GroupAvatarHeader(
+            group = group,
+            canEdit = canEditAvatar,
+            onPickPhoto = onPickPhoto,
+            onRemovePhoto = onRemovePhoto,
+        )
         if (rows.isEmpty()) {
             EmptyState(modifier = Modifier.fillMaxSize())
         } else {
@@ -308,6 +364,92 @@ private fun MissingGroupState(modifier: Modifier = Modifier) {
     }
 }
 
+/**
+ * Group-photo header. Renders the avatar (the stored JPEG, or a
+ * monogram placeholder) above the roster. Admins ([canEdit]) get a
+ * "Change photo" affordance — tapping the avatar or the button opens
+ * the system photo picker — plus "Remove" when a photo is set.
+ * Non-admins see the same image, read-only.
+ */
+@Composable
+private fun GroupAvatarHeader(
+    group: ChatGroup,
+    canEdit: Boolean,
+    onPickPhoto: () -> Unit,
+    onRemovePhoto: () -> Unit,
+) {
+    val avatarBitmap = remember(group.avatar) {
+        group.avatar?.let { bytes ->
+            runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }.getOrNull()
+        }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp, bottom = 8.dp)
+            .testTag("members.avatar_header"),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val circle = Modifier
+            .size(96.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .then(if (canEdit) Modifier.clickable(onClick = onPickPhoto) else Modifier)
+            .testTag("members.avatar_image")
+        Box(modifier = circle, contentAlignment = Alignment.Center) {
+            if (avatarBitmap != null) {
+                Image(
+                    bitmap = avatarBitmap.asImageBitmap(),
+                    contentDescription = "Group photo",
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                val letter = group.name.firstOrNull()?.uppercase().orEmpty()
+                if (letter.isNotEmpty()) {
+                    Text(
+                        text = letter,
+                        fontSize = 36.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    Icon(
+                        Icons.Filled.PersonOutline,
+                        contentDescription = null,
+                        modifier = Modifier.size(44.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+        if (canEdit) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextButton(
+                    onClick = onPickPhoto,
+                    modifier = Modifier.testTag("members.avatar_change"),
+                ) {
+                    Icon(
+                        Icons.Filled.PhotoCamera,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.size(6.dp))
+                    Text(if (group.avatar == null) "Add photo" else "Change photo")
+                }
+                if (group.avatar != null) {
+                    TextButton(
+                        onClick = onRemovePhoto,
+                        modifier = Modifier.testTag("members.avatar_remove"),
+                    ) {
+                        Text("Remove", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+        }
+    }
+}
+
 internal data class MemberRow(
     val blsHex: String,
     val blsPrefix: String,
@@ -317,4 +459,35 @@ internal data class MemberRow(
 
 private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
     for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+}
+
+/**
+ * Decode the picked image [uri] into a downsampled [Bitmap] and run it
+ * through [GroupAvatarImage.encode] to get budget-bounded JPEG bytes.
+ * Returns `null` on any decode failure. Call off the main thread.
+ */
+private fun decodeAndEncodeAvatar(
+    context: android.content.Context,
+    uri: android.net.Uri,
+): ByteArray? {
+    val resolver = context.contentResolver
+    // Pass 1: bounds only, so a huge source doesn't OOM on decode.
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+        ?: return null
+    val minEdge = minOf(bounds.outWidth, bounds.outHeight)
+    if (minEdge <= 0) return null
+
+    // Downsample so the smaller edge is at least 2× the target — enough
+    // detail for the centre-crop + 256² scale without decoding full res.
+    var sample = 1
+    while (minEdge / (sample * 2) >= GroupAvatarImage.SIZE * 2) {
+        sample *= 2
+    }
+    val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+    val bitmap = resolver.openInputStream(uri)?.use {
+        BitmapFactory.decodeStream(it, null, decodeOpts)
+    } ?: return null
+
+    return runCatching { GroupAvatarImage.encode(bitmap) }.getOrNull()
 }

--- a/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
@@ -472,9 +472,12 @@ private fun decodeAndEncodeAvatar(
 ): ByteArray? {
     val resolver = context.contentResolver
     // Pass 1: bounds only, so a huge source doesn't OOM on decode.
+    // `decodeStream` returns null in this mode by design (it just fills
+    // outWidth/outHeight), so the null guard MUST be on `openInputStream`
+    // — not on the decode result, or we'd bail out on every image.
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
-        ?: return null
+    val boundsStream = resolver.openInputStream(uri) ?: return null
+    boundsStream.use { BitmapFactory.decodeStream(it, null, bounds) }
     val minEdge = minOf(bounds.outWidth, bounds.outHeight)
     if (minEdge <= 0) return null
 

--- a/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
@@ -1,6 +1,8 @@
 package app.onym.android.chats
 
+import android.graphics.BitmapFactory
 import android.text.format.DateUtils
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -40,6 +42,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -257,11 +261,9 @@ private fun ChatsRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        // Reuse the broken-ring brand mark as the per-chat avatar —
-        // same identity the user saw on the Create Group hero. Once
-        // group avatars / uploads ship, this becomes the
-        // image-or-mark fallback.
-        OnymGroupAvatar(size = 44.dp, accent = OnymAccent.Blue.color())
+        // Group photo when set, else the broken-ring brand mark — same
+        // identity the user saw on the Create Group hero.
+        ChatsRowAvatar(group = group, size = 44.dp)
 
         Column(modifier = Modifier.weight(1f)) {
             Text(
@@ -286,6 +288,31 @@ private fun ChatsRow(
                 modifier = Modifier.size(18.dp),
             )
         }
+    }
+}
+
+/**
+ * Per-chat avatar: the group's photo ([ChatGroup.avatar], the raw JPEG)
+ * decoded + clipped to a circle when set, otherwise the broken-ring
+ * brand mark. `remember(group.avatar)` re-decodes only when the bytes
+ * change, so an admin's photo update re-renders the row immediately.
+ */
+@Composable
+private fun ChatsRowAvatar(group: ChatGroup, size: androidx.compose.ui.unit.Dp) {
+    val bitmap = remember(group.avatar) {
+        group.avatar?.let { bytes ->
+            runCatching { BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }.getOrNull()
+        }
+    }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.size(size).clip(CircleShape),
+        )
+    } else {
+        OnymGroupAvatar(size = size, accent = OnymAccent.Blue.color())
     }
 }
 

--- a/app/src/main/kotlin/app/onym/android/chats/ChatsViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatsViewModel.kt
@@ -3,10 +3,12 @@ package app.onym.android.chats
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupAvatarBroadcaster
 import app.onym.android.group.GroupRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 /**
  * Read-only ViewModel for the Chats tab. Drains
@@ -24,9 +26,15 @@ import kotlinx.coroutines.flow.stateIn
  * Mirrors `ChatsFlow` from onym-ios PR #30 (the iOS twin uses an
  * `Observable @MainActor` driver pumping `AsyncStream`; same role,
  * Android-idiomatic types).
+ *
+ * The single mutating intent — the admin's group-photo change — is
+ * delegated to [GroupAvatarBroadcaster] (apply locally + fan out). The
+ * row UI itself stays read-only; [groups] re-emits once the change
+ * persists.
  */
 class ChatsViewModel(
     private val repository: GroupRepository,
+    private val avatarBroadcaster: GroupAvatarBroadcaster? = null,
 ) : ViewModel() {
 
     val groups: StateFlow<List<ChatGroup>> = repository.snapshots.stateIn(
@@ -34,4 +42,18 @@ class ChatsViewModel(
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = repository.snapshots.value,
     )
+
+    /**
+     * Admin-only: set ([avatar] non-null) or clear ([avatar] == null)
+     * the group photo and broadcast the change. No-op when the
+     * broadcaster wasn't wired (e.g. lightweight test/preview VMs). The
+     * broadcaster itself enforces the admin gate; non-admin callers are
+     * dropped there.
+     */
+    fun setGroupAvatar(groupId: String, avatar: ByteArray?) {
+        val broadcaster = avatarBroadcaster ?: return
+        viewModelScope.launch {
+            broadcaster.setAvatar(groupId, avatar)
+        }
+    }
 }

--- a/app/src/main/kotlin/app/onym/android/group/ChatGroup.kt
+++ b/app/src/main/kotlin/app/onym/android/group/ChatGroup.kt
@@ -113,6 +113,24 @@ data class ChatGroup(
      */
     @SerialName("owner_identity_id")
     val ownerIdentityId: String,
+    /**
+     * Raw JPEG bytes of the group's avatar (square, centre-cropped,
+     * 256×256, encoded under a 16 KB budget by
+     * [GroupAvatarImage.encode]). `null` for groups without a photo —
+     * the UI falls back to the monogram placeholder.
+     *
+     * Set on the creator/admin side via [GroupAvatarBroadcaster], and
+     * on the receiver side either from a [GroupInvitationPayload.avatar]
+     * at materialize time (create-time members, esp. Tyranny) or from a
+     * dedicated [GroupAvatarPayload] (later changes). Stored on the wire
+     * as base64 — same `Data` encoding iOS uses — so an avatar set on
+     * either platform renders on the other.
+     *
+     * Mirrors `ChatGroup.avatar` from onym-ios PR #164.
+     */
+    @SerialName("avatar")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val avatar: ByteArray? = null,
 ) {
     /** Strongly-typed accessor — same value as [ownerIdentityId] but
      *  wrapped so callers don't carry stringly-typed identity ids
@@ -141,7 +159,8 @@ data class ChatGroup(
             adminPubkeyHex == other.adminPubkeyHex &&
             adminEd25519PubkeyHex == other.adminEd25519PubkeyHex &&
             isPublishedOnChain == other.isPublishedOnChain &&
-            ownerIdentityId == other.ownerIdentityId
+            ownerIdentityId == other.ownerIdentityId &&
+            (avatar?.contentEquals(other.avatar) ?: (other.avatar == null))
     }
 
     override fun hashCode(): Int {
@@ -160,6 +179,7 @@ data class ChatGroup(
         h = 31 * h + (adminEd25519PubkeyHex?.hashCode() ?: 0)
         h = 31 * h + isPublishedOnChain.hashCode()
         h = 31 * h + ownerIdentityId.hashCode()
+        h = 31 * h + (avatar?.contentHashCode() ?: 0)
         return h
     }
 

--- a/app/src/main/kotlin/app/onym/android/group/GroupAvatarBroadcaster.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupAvatarBroadcaster.kt
@@ -1,0 +1,118 @@
+package app.onym.android.group
+
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.IdentityRepository
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.transport.InboxTransport
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.Json
+
+/**
+ * Admin-side sender for group-avatar changes. Applies the new photo
+ * locally (persist first — the broadcast is best-effort) and fans a
+ * [GroupAvatarPayload] out to every member's inbox **except the admin's
+ * own key**, sealed with the same X25519 + AES-GCM + Ed25519-signature
+ * envelope as [MemberAnnouncementPayload] (one envelope per recipient).
+ *
+ * Best-effort by design: a per-member transport failure is swallowed
+ * and the loop moves on. A member who misses an update picks up the
+ * current avatar from the next full snapshot
+ * ([GroupInvitationPayload.avatar]). Setting [avatar] to `null` clears
+ * the photo (the payload omits the `avatar` key → receivers read it as
+ * removal).
+ *
+ * Only the cryptographic admin may change the photo — gated here on the
+ * active identity's BLS key matching [ChatGroup.adminPubkeyHex], the
+ * same key the receive-side trust gate verifies against (via the
+ * envelope's Ed25519 signer). Non-admin governance models (Anarchy /
+ * OneOnOne, where there is no admin) return [Outcome.NotAdmin].
+ *
+ * Mirrors `GroupAvatarBroadcaster.swift` from onym-ios PR #166.
+ */
+class GroupAvatarBroadcaster(
+    private val activeIdentity: ActiveIdentityProvider,
+    private val identitiesFlow: StateFlow<List<IdentitySummary>>,
+    private val envelopeSealer: InvitationEnvelopeSealer,
+    private val groupRepository: GroupRepository,
+    private val inboxTransport: InboxTransport,
+) {
+    sealed class Outcome {
+        /** Applied locally + fanned out (best-effort). */
+        object Sent : Outcome()
+
+        /** No group with this id under the active identity. */
+        object UnknownGroup : Outcome()
+
+        /** Active identity isn't this group's admin. */
+        object NotAdmin : Outcome()
+
+        /** No identity selected, or its summary couldn't be resolved. */
+        object NoIdentity : Outcome()
+    }
+
+    /**
+     * Set (or, with `avatar == null`, clear) the group's photo and
+     * broadcast the change. Idempotent on the persistence side —
+     * re-running with the same bytes rewrites the same row.
+     */
+    suspend fun setAvatar(groupId: String, avatar: ByteArray?): Outcome {
+        val group = groupRepository.snapshots.value
+            .firstOrNull { it.id.equals(groupId, ignoreCase = true) }
+            ?: return Outcome.UnknownGroup
+
+        val activeId = activeIdentity.currentIdentityId.value ?: return Outcome.NoIdentity
+        val activeBls = identitiesFlow.value
+            .firstOrNull { it.id == activeId }
+            ?.blsPublicKey
+            ?: return Outcome.NoIdentity
+        val activeBlsHex = activeBls.toHexLowercase()
+
+        // Admin gate: only the group's admin may change the photo.
+        val adminHex = group.adminPubkeyHex?.lowercase() ?: return Outcome.NotAdmin
+        if (activeBlsHex != adminHex) return Outcome.NotAdmin
+
+        // Apply + persist first; broadcast is best-effort.
+        groupRepository.insert(group.copy(avatar = avatar))
+
+        val payload = GroupAvatarPayload(
+            version = 1,
+            groupId = group.groupIdBytes,
+            senderBlsHex = activeBlsHex,
+            sentAtMillis = System.currentTimeMillis(),
+            avatar = avatar,
+        )
+        val payloadBytes = try {
+            jsonFormat.encodeToString(GroupAvatarPayload.serializer(), payload)
+                .toByteArray(Charsets.UTF_8)
+        } catch (_: Throwable) {
+            // Local apply already succeeded; skip the fan-out.
+            return Outcome.Sent
+        }
+
+        for ((memberKey, profile) in group.memberProfiles) {
+            if (memberKey.equals(activeBlsHex, ignoreCase = true)) continue // skip self
+            val sealed = try {
+                envelopeSealer.sealInvitation(payloadBytes, profile.inboxPublicKey)
+            } catch (_: Throwable) {
+                continue
+            }
+            val tag = TransportInboxId(IdentityRepository.inboxTag(profile.inboxPublicKey))
+            // Discard the receipt — fan-out is best-effort; the next
+            // snapshot backfills anyone who missed this update.
+            runCatching { inboxTransport.send(sealed, tag) }
+        }
+        return Outcome.Sent
+    }
+
+    private companion object {
+        /** `encodeDefaults = false` so a null avatar (removal) omits the
+         *  `avatar` key entirely, matching the iOS removal wire shape. */
+        private val jsonFormat = Json { encodeDefaults = false; ignoreUnknownKeys = true }
+
+        private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+            for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
@@ -1,0 +1,73 @@
+package app.onym.android.group
+
+import android.graphics.Bitmap
+import java.io.ByteArrayOutputStream
+import kotlin.math.min
+
+/**
+ * Image pipeline for group avatars. Produces a small, square JPEG that
+ * fits inside a sealed NOSTR envelope: **square, centre-cropped, 256×256
+ * px, JPEG, encoded under a 16 KB raw budget** (base64 on the wire is
+ * ~22 KB). The budget keeps sealed envelopes within relay event-size
+ * limits — deliberately undersized.
+ *
+ * The raw JPEG bytes are what gets stored on [ChatGroup.avatar] and sent
+ * on the wire (base64) in [GroupInvitationPayload.avatar] /
+ * [GroupAvatarPayload.avatar]. Cross-platform: iOS produces the same
+ * shape, so an avatar set on either platform renders on the other.
+ *
+ * Mirrors `GroupAvatarImage.swift` from onym-ios PR #164.
+ */
+object GroupAvatarImage {
+    /** Output edge length in pixels. */
+    const val SIZE = 256
+
+    /** Raw (pre-base64) byte budget. */
+    const val MAX_BYTES = 16 * 1024
+
+    /** Starting JPEG quality (~0.8). The loop steps down until the
+     *  encoded size fits [MAX_BYTES]. */
+    private const val START_QUALITY = 80
+    private const val MIN_QUALITY = 10
+    private const val QUALITY_STEP = 10
+
+    /**
+     * Centre-crop [source] to a square, scale to [SIZE]×[SIZE], then
+     * JPEG-encode under [MAX_BYTES] by stepping quality down from
+     * [START_QUALITY]. Returns the smallest encoding that fits the
+     * budget, or — if even [MIN_QUALITY] overshoots (vanishingly
+     * unlikely for a 256² image) — the [MIN_QUALITY] encoding.
+     */
+    fun encode(source: Bitmap): ByteArray {
+        val square = centreCropSquare(source)
+        val scaled = if (square.width == SIZE && square.height == SIZE) {
+            square
+        } else {
+            Bitmap.createScaledBitmap(square, SIZE, SIZE, /* filter = */ true)
+        }
+
+        var quality = START_QUALITY
+        var encoded = compress(scaled, quality)
+        while (encoded.size > MAX_BYTES && quality > MIN_QUALITY) {
+            quality -= QUALITY_STEP
+            encoded = compress(scaled, quality)
+        }
+        return encoded
+    }
+
+    private fun compress(bitmap: Bitmap, quality: Int): ByteArray =
+        ByteArrayOutputStream().use { out ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, out)
+            out.toByteArray()
+        }
+
+    /** Crop the largest centred square out of [source]. Returns the
+     *  source untouched when it's already square. */
+    private fun centreCropSquare(source: Bitmap): Bitmap {
+        val edge = min(source.width, source.height)
+        if (source.width == edge && source.height == edge) return source
+        val x = (source.width - edge) / 2
+        val y = (source.height - edge) / 2
+        return Bitmap.createBitmap(source, x, y, edge, edge)
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/group/GroupAvatarPayload.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupAvatarPayload.kt
@@ -1,0 +1,95 @@
+package app.onym.android.group
+
+import app.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Dedicated admin-signed control message announcing the group's
+ * **current** avatar state. The admin seals it (X25519 + AES-GCM via
+ * `IdentityRepository.sealInvitation`, signed by their Ed25519 stellar
+ * key) and ships one envelope per member inbox — the same fan-out path
+ * as [MemberAnnouncementPayload]. Carries later avatar changes;
+ * create-time members get their first photo from
+ * [GroupInvitationPayload.avatar] instead.
+ *
+ * ## Wire shape
+ *
+ * The keys are deliberately prefixed `avatar_*` so the payload can't be
+ * structurally mistaken for a [app.onym.android.chats.ChatMessagePayload]
+ * (which shares `version` / `group_id` / `sender` / `timestamp`
+ * spellings). The receive-side dispatcher trial-decodes this type
+ * **before** the chat-message branch; the unique keys keep the two from
+ * colliding in either direction.
+ *
+ * ```json
+ * {
+ *   "avatar_version": 1,
+ *   "avatar_group_id": "<base64 of 32-byte group id>",
+ *   "avatar_sender_bls_hex": "<lowercase BLS pubkey hex, 96 chars>",
+ *   "avatar_sent_at_millis": 1700000000000,
+ *   "avatar": "<base64 JPEG, OR omit the key to signal removal>"
+ * }
+ * ```
+ *
+ * ## Removal semantics
+ *
+ * This message always expresses the *current* avatar state, so an
+ * absent / nil [avatar] means the photo was **cleared** — not
+ * "unspecified". Senders omit the key on removal; receivers clear the
+ * stored avatar when it's absent.
+ *
+ * ## Trust
+ *
+ * [senderBlsHex] is informational only (for display / debugging) — do
+ * **not** authenticate with it. Provenance is the OUTER `SealedEnvelope`
+ * Ed25519 signature, cross-checked by the dispatcher against the
+ * group's stored `adminEd25519PubkeyHex` (same rule as
+ * [MemberAnnouncementPayload]). There is no on-chain commitment check —
+ * the avatar isn't part of the cryptographic group state.
+ *
+ * Mirrors `GroupAvatarPayload.swift` from onym-ios PR #166.
+ */
+@Serializable
+data class GroupAvatarPayload(
+    @SerialName("avatar_version")
+    val version: Int,
+    @SerialName("avatar_group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    /** Lowercase BLS pubkey hex (96 chars) of the admin who set the
+     *  avatar. Informational only — never used to authenticate. */
+    @SerialName("avatar_sender_bls_hex")
+    val senderBlsHex: String,
+    /** Milliseconds since the Unix epoch at send time. */
+    @SerialName("avatar_sent_at_millis")
+    val sentAtMillis: Long,
+    /** Raw JPEG bytes, base64 on the wire. **Absent / nil = photo
+     *  removed** (this message expresses the current state). */
+    @SerialName("avatar")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val avatar: ByteArray? = null,
+) {
+    init {
+        require(groupId.size == 32) {
+            "groupId: expected 32 bytes, got ${groupId.size}"
+        }
+    }
+
+    override fun equals(other: Any?): Boolean = this === other ||
+        (other is GroupAvatarPayload &&
+            version == other.version &&
+            groupId.contentEquals(other.groupId) &&
+            senderBlsHex == other.senderBlsHex &&
+            sentAtMillis == other.sentAtMillis &&
+            (avatar?.contentEquals(other.avatar) ?: (other.avatar == null)))
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + senderBlsHex.hashCode()
+        h = 31 * h + sentAtMillis.hashCode()
+        h = 31 * h + (avatar?.contentHashCode() ?: 0)
+        return h
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/group/GroupDatabase.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupDatabase.kt
@@ -21,7 +21,9 @@ import androidx.room.RoomDatabase
     // column on top of v4's `encryptedMemberProfilesJson`. Both
     // migrations are non-destructive — existing rows decode to null
     // at the store boundary.
-    version = 5,
+    // v6 (group avatar): adds nullable `encryptedAvatar` column —
+    // iOS #164–#166 parity. Existing rows decode to a null avatar.
+    version = 6,
     exportSchema = false,
 )
 abstract class GroupDatabase : RoomDatabase() {
@@ -54,6 +56,16 @@ object GroupDatabaseMigrations {
     val MIGRATION_4_5 = object : androidx.room.migration.Migration(4, 5) {
         override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
             db.execSQL("ALTER TABLE groups ADD COLUMN encryptedAdminEd25519PubkeyHex BLOB")
+        }
+    }
+
+    /**
+     * v5 → v6: introduce `encryptedAvatar` (nullable BLOB) for the
+     * group photo. Existing rows decode to a null avatar (no photo).
+     */
+    val MIGRATION_5_6 = object : androidx.room.migration.Migration(5, 6) {
+        override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE groups ADD COLUMN encryptedAvatar BLOB")
         }
     }
 }

--- a/app/src/main/kotlin/app/onym/android/group/GroupInvitationPayload.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupInvitationPayload.kt
@@ -84,6 +84,25 @@ data class GroupInvitationPayload(
      */
     @SerialName("member_profiles")
     val memberProfiles: Map<String, MemberProfile>? = null,
+    /**
+     * Raw JPEG bytes of the group avatar at send time, base64 on the
+     * wire (matches Swift `Data` Codable, which base64-encodes in
+     * JSON). Optional with "if present" semantics: a pre-avatar sender
+     * omits the key entirely and the receiver falls back to no photo —
+     * the default keeps such envelopes decoding. Senders include it
+     * only when the group actually has an avatar, and omit the key when
+     * nil so photo-less invites stay small.
+     *
+     * This is the only path that delivers the photo to **create-time**
+     * members (esp. Tyranny, where the full snapshot is sent at
+     * join-approval, not at create). Later changes ride the dedicated
+     * [GroupAvatarPayload].
+     *
+     * Mirrors `GroupInvitationPayload.avatar` from onym-ios PR #165.
+     */
+    @SerialName("avatar")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val avatar: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -101,7 +120,8 @@ data class GroupInvitationPayload(
             adminPubkeyHex == other.adminPubkeyHex &&
             (inviteeBlsSecretKey?.contentEquals(other.inviteeBlsSecretKey)
                 ?: (other.inviteeBlsSecretKey == null)) &&
-            memberProfiles == other.memberProfiles
+            memberProfiles == other.memberProfiles &&
+            (avatar?.contentEquals(other.avatar) ?: (other.avatar == null))
     }
 
     override fun hashCode(): Int {
@@ -118,6 +138,7 @@ data class GroupInvitationPayload(
         h = 31 * h + (adminPubkeyHex?.hashCode() ?: 0)
         h = 31 * h + (inviteeBlsSecretKey?.contentHashCode() ?: 0)
         h = 31 * h + (memberProfiles?.hashCode() ?: 0)
+        h = 31 * h + (avatar?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/app/onym/android/group/JoinRequestApprover.kt
+++ b/app/src/main/kotlin/app/onym/android/group/JoinRequestApprover.kt
@@ -251,6 +251,11 @@ open class JoinRequestApprover(
             // joiner's own profile gets backfilled by the receiver's
             // materializer (PR 83) from their active identity.
             memberProfiles = anchored.memberProfiles.takeIf { it.isNotEmpty() },
+            // Carry the group photo so a create-time member sees it the
+            // moment the snapshot lands — the only delivery path for
+            // members who join via the full snapshot rather than a later
+            // GroupAvatarPayload. `null` when the group has no photo.
+            avatar = anchored.avatar,
         )
         val payloadBytes = try {
             jsonFormat.encodeToString(GroupInvitationPayload.serializer(), invitePayload)

--- a/app/src/main/kotlin/app/onym/android/group/PersistedGroup.kt
+++ b/app/src/main/kotlin/app/onym/android/group/PersistedGroup.kt
@@ -71,6 +71,13 @@ data class PersistedGroup(
      * without an admin (Anarchy / OneOnOne).
      */
     val encryptedAdminEd25519PubkeyHex: ByteArray? = null,
+    /**
+     * Optional AES-GCM-encrypted raw JPEG of the group avatar (PR for
+     * iOS #164–#166 parity). `null` on rows migrated from the pre-avatar
+     * schema or for groups without a photo. Encrypted at rest like the
+     * other sensitive columns — a local avatar can leak who the group is.
+     */
+    val encryptedAvatar: ByteArray? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -89,7 +96,8 @@ data class PersistedGroup(
             (encryptedCommitment?.contentEquals(other.encryptedCommitment) ?: (other.encryptedCommitment == null)) &&
             (encryptedAdminPubkeyHex?.contentEquals(other.encryptedAdminPubkeyHex) ?: (other.encryptedAdminPubkeyHex == null)) &&
             (encryptedMemberProfilesJson?.contentEquals(other.encryptedMemberProfilesJson) ?: (other.encryptedMemberProfilesJson == null)) &&
-            (encryptedAdminEd25519PubkeyHex?.contentEquals(other.encryptedAdminEd25519PubkeyHex) ?: (other.encryptedAdminEd25519PubkeyHex == null))
+            (encryptedAdminEd25519PubkeyHex?.contentEquals(other.encryptedAdminEd25519PubkeyHex) ?: (other.encryptedAdminEd25519PubkeyHex == null)) &&
+            (encryptedAvatar?.contentEquals(other.encryptedAvatar) ?: (other.encryptedAvatar == null))
     }
 
     override fun hashCode(): Int {
@@ -108,6 +116,7 @@ data class PersistedGroup(
         h = 31 * h + (encryptedAdminPubkeyHex?.contentHashCode() ?: 0)
         h = 31 * h + (encryptedMemberProfilesJson?.contentHashCode() ?: 0)
         h = 31 * h + (encryptedAdminEd25519PubkeyHex?.contentHashCode() ?: 0)
+        h = 31 * h + (encryptedAvatar?.contentHashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/app/onym/android/group/RoomGroupStore.kt
+++ b/app/src/main/kotlin/app/onym/android/group/RoomGroupStore.kt
@@ -105,6 +105,7 @@ class RoomGroupStore(
             encryptedAdminPubkeyHex = group.adminPubkeyHex?.let(encryption::encrypt),
             encryptedMemberProfilesJson = memberProfilesEncrypted,
             encryptedAdminEd25519PubkeyHex = group.adminEd25519PubkeyHex?.let(encryption::encrypt),
+            encryptedAvatar = group.avatar?.let(encryption::encrypt),
         )
     }
 
@@ -130,6 +131,7 @@ class RoomGroupStore(
         val commitment = row.encryptedCommitment?.let { tryDecrypt(it) }
         val adminPubkeyHex = row.encryptedAdminPubkeyHex?.let { tryDecryptString(it) }
         val adminEd25519PubkeyHex = row.encryptedAdminEd25519PubkeyHex?.let { tryDecryptString(it) }
+        val avatar = row.encryptedAvatar?.let { tryDecrypt(it) }
         val memberProfiles: Map<String, MemberProfile> = row.encryptedMemberProfilesJson
             ?.let { tryDecrypt(it) }
             ?.let { bytes ->
@@ -163,6 +165,7 @@ class RoomGroupStore(
             adminEd25519PubkeyHex = adminEd25519PubkeyHex,
             isPublishedOnChain = row.isPublishedOnChain,
             ownerIdentityId = row.ownerIdentityId,
+            avatar = avatar,
         )
     }
 

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -10,6 +10,7 @@ import app.onym.android.chats.MessageDirection
 import app.onym.android.chats.MessageRepository
 import app.onym.android.chats.MessageStatus
 import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupAvatarPayload
 import app.onym.android.group.GroupCommitmentBuilder
 import app.onym.android.group.GroupInvitationPayload
 import app.onym.android.group.GroupInviteOfferPayload
@@ -161,6 +162,17 @@ class IncomingMessageDispatcher(
             return
         }
 
+        // Fast path: GroupAvatarPayload — admin-signed group-photo
+        // change. Decoded BEFORE the chat-message branch; its unique
+        // `avatar_*` keys keep it from colliding with a chat message in
+        // either direction. Applies (or clears) the local group's photo
+        // after the admin-Ed25519 trust gate.
+        val avatarUpdate = tryDecodeGroupAvatar(envelope.plaintext)
+        if (avatarUpdate != null) {
+            applyAvatar(avatarUpdate, envelope.senderEd25519PublicKey)
+            return
+        }
+
         // Fast path: ChatMessagePayload — body of the chat thread.
         // Verifies the envelope's Ed25519 signer matches the claimed
         // sender's [MemberProfile.sendingPubkey] (insider-spoof
@@ -265,6 +277,9 @@ class IncomingMessageDispatcher(
             // by the time it lands the group is on chain.
             isPublishedOnChain = true,
             ownerIdentityId = ownerIdentityId.value,
+            // "If present" semantics: a pre-avatar sender omits the key
+            // and the group materializes photo-less.
+            avatar = invitation.avatar,
         )
         groupRepository.insert(group)
     }
@@ -407,6 +422,64 @@ class IncomingMessageDispatcher(
     private fun tryDecodeAnnouncement(bytes: ByteArray): MemberAnnouncementPayload? = try {
         permissiveJson.decodeFromString(
             MemberAnnouncementPayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    /**
+     * Apply an inbound [GroupAvatarPayload] to the matching local
+     * group's [ChatGroup.avatar]. No-op when:
+     *
+     *   - The group isn't on this device (drop unknown group ids).
+     *   - The trust gate fails: a group with a stored admin Ed25519 key
+     *     requires the envelope's verified signer to equal it
+     *     (lowercased hex). Skipped (best-effort) only for admin-less
+     *     governance models / legacy rows with no stored admin — same
+     *     rule as [applyAnnouncement]. There is NO on-chain commitment
+     *     check; the avatar isn't part of the cryptographic group state.
+     *   - The stored avatar already equals the incoming bytes
+     *     (idempotent re-delivery).
+     *
+     * Otherwise sets the avatar — or clears it when the payload omits
+     * the photo (absent = removal) — and persists. `avatar_sender_bls_hex`
+     * is informational; never used to authenticate.
+     */
+    private suspend fun applyAvatar(
+        payload: GroupAvatarPayload,
+        senderEd25519PublicKey: ByteArray?,
+    ) {
+        val groups = groupRepository.snapshots.value
+        val group = groups.firstOrNull {
+            it.groupIdBytes.contentEquals(payload.groupId)
+        } ?: return
+
+        // Trust gate (same as member announcements): the change must be
+        // signed by the group's known admin.
+        val storedAdmin = group.adminEd25519PubkeyHex
+        if (storedAdmin != null) {
+            val sender = senderEd25519PublicKey ?: return
+            if (sender.toHexLowercase() != storedAdmin.lowercase()) return
+        }
+
+        // Idempotency: no-op when the stored avatar already matches
+        // (both absent, or byte-equal).
+        val current = group.avatar
+        val incoming = payload.avatar
+        val unchanged = if (current == null || incoming == null) {
+            current == null && incoming == null
+        } else {
+            current.contentEquals(incoming)
+        }
+        if (unchanged) return
+
+        groupRepository.insert(group.copy(avatar = incoming))
+    }
+
+    private fun tryDecodeGroupAvatar(bytes: ByteArray): GroupAvatarPayload? = try {
+        permissiveJson.decodeFromString(
+            GroupAvatarPayload.serializer(),
             bytes.toString(Charsets.UTF_8),
         )
     } catch (_: Throwable) {

--- a/app/src/test/kotlin/app/onym/android/group/GroupAvatarBroadcasterTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/GroupAvatarBroadcasterTest.kt
@@ -1,0 +1,216 @@
+package app.onym.android.group
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.transport.InboundInbox
+import app.onym.android.transport.InboxTransport
+import app.onym.android.transport.PublishReceipt
+import app.onym.android.transport.TransportEndpoint
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Sender-side behavior for [GroupAvatarBroadcaster]: applies the change
+ * locally, fans out one sealed envelope per member inbox **except the
+ * admin's own key**, gates non-admins, and omits the avatar key on
+ * removal.
+ *
+ * Mirrors `GroupAvatarBroadcasterTests.swift` from onym-ios PR #166.
+ */
+class GroupAvatarBroadcasterTest {
+
+    private val ownerIdentity = IdentityId("owner")
+    private val groupIdBytes = ByteArray(32) { 0xAA.toByte() }
+    private val groupIdHex = groupIdBytes.toHex()
+
+    private val adminBls = ByteArray(48) { 0x11 }
+    private val adminBlsHex = adminBls.toHex()
+    private val adminInbox = ByteArray(32) { 0x12 }
+    private val m1Inbox = ByteArray(32) { 0x23 }
+    private val m2Inbox = ByteArray(32) { 0x34 }
+    private val newAvatar = ByteArray(40) { 0x5A }
+
+    private lateinit var store: BroadcasterGroupStore
+    private lateinit var groupRepository: GroupRepository
+    private lateinit var sealer: RecordingSealer
+    private lateinit var transport: RecordingTransport
+    private lateinit var identities: MutableStateFlow<List<IdentitySummary>>
+
+    @Before
+    fun setUp() = runTest {
+        store = BroadcasterGroupStore()
+        groupRepository = GroupRepository(
+            store = store,
+            identity = BroadcasterIdentity(ownerIdentity),
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        groupRepository.insert(group())
+        groupRepository.reload()
+        sealer = RecordingSealer()
+        transport = RecordingTransport()
+        identities = MutableStateFlow(listOf(adminSummary(adminBls)))
+    }
+
+    private fun broadcaster() = GroupAvatarBroadcaster(
+        activeIdentity = BroadcasterIdentity(ownerIdentity),
+        identitiesFlow = identities,
+        envelopeSealer = sealer,
+        groupRepository = groupRepository,
+        inboxTransport = transport,
+    )
+
+    @Test
+    fun setAvatar_appliesLocallyAndFansOutToEveryoneButAdmin() = runTest {
+        val outcome = broadcaster().setAvatar(groupIdHex, newAvatar)
+
+        assertEquals(GroupAvatarBroadcaster.Outcome.Sent, outcome)
+        // Applied locally.
+        assertArrayEquals(newAvatar, groupRepository.snapshots.value.single().avatar)
+        // Fanned out to the two non-admin members only.
+        assertEquals(setOf(m1Inbox.toHex(), m2Inbox.toHex()), sealer.recipients())
+        assertEquals(2, transport.sends.size)
+    }
+
+    @Test
+    fun setAvatar_nonAdminIsRejectedAndNoSends() = runTest {
+        // Active identity isn't the admin.
+        identities.value = listOf(adminSummary(ByteArray(48) { 0x99.toByte() }))
+
+        val outcome = broadcaster().setAvatar(groupIdHex, newAvatar)
+
+        assertEquals(GroupAvatarBroadcaster.Outcome.NotAdmin, outcome)
+        assertNull(groupRepository.snapshots.value.single().avatar)
+        assertTrue(sealer.sealed.isEmpty())
+        assertTrue(transport.sends.isEmpty())
+    }
+
+    @Test
+    fun setAvatar_unknownGroup() = runTest {
+        val outcome = broadcaster().setAvatar("ff".repeat(32), newAvatar)
+        assertEquals(GroupAvatarBroadcaster.Outcome.UnknownGroup, outcome)
+    }
+
+    @Test
+    fun removeAvatar_clearsLocallyAndOmitsAvatarKey() = runTest {
+        // Seed an existing photo first.
+        groupRepository.insert(group().copy(avatar = ByteArray(8) { 0x7 }))
+        groupRepository.reload()
+
+        val outcome = broadcaster().setAvatar(groupIdHex, null)
+
+        assertEquals(GroupAvatarBroadcaster.Outcome.Sent, outcome)
+        assertNull(groupRepository.snapshots.value.single().avatar)
+        // Removal payload omits the avatar key entirely.
+        assertTrue(sealer.sealed.isNotEmpty())
+        sealer.sealed.forEach { (payload, _) ->
+            val json = payload.toString(Charsets.UTF_8)
+            assertTrue("removal must omit avatar key", !json.contains("\"avatar\":"))
+        }
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private fun group(): ChatGroup = ChatGroup(
+        id = groupIdHex,
+        name = "Family",
+        groupSecret = ByteArray(32),
+        createdAtMillis = 0L,
+        members = emptyList(),
+        memberProfiles = mapOf(
+            adminBlsHex to profile(adminInbox),
+            ByteArray(48) { 0x22 }.toHex() to profile(m1Inbox),
+            ByteArray(48) { 0x33 }.toHex() to profile(m2Inbox),
+        ),
+        epoch = 0uL,
+        salt = ByteArray(32),
+        commitment = null,
+        tier = SepTier.SMALL,
+        groupType = SepGroupType.TYRANNY,
+        adminPubkeyHex = adminBlsHex,
+        adminEd25519PubkeyHex = null,
+        isPublishedOnChain = true,
+        ownerIdentityId = ownerIdentity.value,
+        avatar = null,
+    )
+
+    private fun profile(inbox: ByteArray) = MemberProfile(
+        alias = "x",
+        inboxPublicKey = inbox,
+        sendingPubkey = ByteArray(32) { 0x01 },
+    )
+
+    private fun adminSummary(bls: ByteArray) = IdentitySummary(
+        id = ownerIdentity,
+        name = "Admin",
+        blsPublicKey = bls,
+        inboxPublicKey = adminInbox,
+        sendingPublicKey = ByteArray(32) { 0x02 },
+    )
+
+    private fun ByteArray.toHex() = joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+}
+
+private class RecordingSealer : InvitationEnvelopeSealer {
+    val sealed = mutableListOf<Pair<ByteArray, ByteArray>>()
+    override suspend fun sealInvitation(
+        payload: ByteArray,
+        recipientInboxPublicKey: ByteArray,
+    ): ByteArray {
+        sealed.add(payload to recipientInboxPublicKey)
+        return payload
+    }
+    fun recipients(): Set<String> =
+        sealed.map { it.second.joinToString("") { b -> "%02x".format(b.toInt() and 0xFF) } }.toSet()
+}
+
+private class RecordingTransport : InboxTransport {
+    val sends = mutableListOf<TransportInboxId>()
+    override suspend fun connect(endpoints: List<TransportEndpoint>) {}
+    override suspend fun disconnect() {}
+    override suspend fun send(payload: ByteArray, inbox: TransportInboxId): PublishReceipt {
+        sends.add(inbox)
+        return PublishReceipt(messageId = "msg", acceptedBy = 1)
+    }
+    override fun subscribe(inbox: TransportInboxId): Flow<InboundInbox> = emptyFlow()
+    override suspend fun unsubscribe(inbox: TransportInboxId) {}
+}
+
+private class BroadcasterGroupStore : GroupStore {
+    private val rows = mutableMapOf<String, ChatGroup>()
+    override suspend fun list(): List<ChatGroup> = rows.values.toList()
+    override suspend fun listForOwner(ownerIdentityId: String): List<ChatGroup> =
+        rows.values.filter { it.ownerIdentityId == ownerIdentityId }
+    override suspend fun deleteForOwner(ownerIdentityId: String): Int {
+        val before = rows.size
+        rows.entries.removeAll { it.value.ownerIdentityId == ownerIdentityId }
+        return before - rows.size
+    }
+    override suspend fun insertOrUpdate(group: ChatGroup): Boolean {
+        val isNew = !rows.containsKey(group.id)
+        rows[group.id] = group
+        return isNew
+    }
+    override suspend fun markPublished(id: String, commitment: ByteArray?) {}
+    override suspend fun delete(id: String) { rows.remove(id) }
+}
+
+private class BroadcasterIdentity(private val id: IdentityId) : ActiveIdentityProvider {
+    override val currentIdentityId: StateFlow<IdentityId?> = MutableStateFlow(id)
+    override fun registerRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {}
+}

--- a/app/src/test/kotlin/app/onym/android/group/GroupAvatarPayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/GroupAvatarPayloadTest.kt
@@ -1,0 +1,133 @@
+package app.onym.android.group
+
+import app.onym.android.chats.ChatMessagePayload
+import app.onym.android.chats.ChatMessageVariant
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+import java.util.UUID
+
+/**
+ * Wire-format pin for [GroupAvatarPayload]. Cross-checks the distinct
+ * `avatar_*` snake_case keys + base64 byte encoding so the iOS receiver
+ * decodes Android-emitted avatar messages bit-for-bit, and confirms the
+ * payload can't be structurally confused with a chat message in either
+ * direction.
+ *
+ * Mirrors `GroupAvatarPayloadTests.swift` from onym-ios PR #166.
+ */
+class GroupAvatarPayloadTest {
+
+    /** Mirrors the dispatcher's permissive decode. */
+    private val json = Json { encodeDefaults = false; ignoreUnknownKeys = true }
+
+    private val groupId = ByteArray(32) { 0xAA.toByte() }
+    private val senderBlsHex = "ab".repeat(48) // 96 chars
+
+    @Test
+    fun roundTrip_withAvatar_preservesAllFields() {
+        val avatar = ByteArray(128) { (it * 3).toByte() }
+        val original = GroupAvatarPayload(
+            version = 1,
+            groupId = groupId,
+            senderBlsHex = senderBlsHex,
+            sentAtMillis = 1_700_000_000_000L,
+            avatar = avatar,
+        )
+        val text = json.encodeToString(GroupAvatarPayload.serializer(), original)
+
+        // Distinct avatar_* keys + base64 avatar.
+        assertTrue("avatar_version key", text.contains("\"avatar_version\":"))
+        assertTrue("avatar_group_id key", text.contains("\"avatar_group_id\":"))
+        assertTrue("avatar_sender_bls_hex key", text.contains("\"avatar_sender_bls_hex\":"))
+        assertTrue("avatar_sent_at_millis key", text.contains("\"avatar_sent_at_millis\":"))
+
+        val decoded = json.decodeFromString(GroupAvatarPayload.serializer(), text)
+        assertEquals(original, decoded)
+        assertArrayEquals(avatar, decoded.avatar)
+    }
+
+    @Test
+    fun encode_omitsAvatarKeyWhenRemoved() {
+        // Absent avatar = removal: the key must drop off the wire so a
+        // receiver reads it as "cleared", not "unspecified".
+        val removal = GroupAvatarPayload(
+            version = 1,
+            groupId = groupId,
+            senderBlsHex = senderBlsHex,
+            sentAtMillis = 42L,
+            avatar = null,
+        )
+        val text = json.encodeToString(GroupAvatarPayload.serializer(), removal)
+        assertTrue("avatar key omitted on removal", !text.contains("\"avatar\":"))
+    }
+
+    @Test
+    fun decode_absentAvatar_isRemoval() {
+        val text = """
+            {
+              "avatar_version": 1,
+              "avatar_group_id": "${b64(groupId)}",
+              "avatar_sender_bls_hex": "$senderBlsHex",
+              "avatar_sent_at_millis": 42
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(GroupAvatarPayload.serializer(), text)
+        assertNull("absent avatar decodes to null = removal", decoded.avatar)
+    }
+
+    @Test
+    fun avatarPayload_doesNotDecodeAsChatMessage() {
+        val avatarText = json.encodeToString(
+            GroupAvatarPayload.serializer(),
+            GroupAvatarPayload(
+                version = 1,
+                groupId = groupId,
+                senderBlsHex = senderBlsHex,
+                sentAtMillis = 1L,
+                avatar = ByteArray(16) { 0x01 },
+            ),
+        )
+        // ChatMessagePayload requires message_id / sender_bls_pubkey_hex /
+        // variant — none present here, so decode must fail.
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(ChatMessagePayload.serializer(), avatarText)
+        }
+    }
+
+    @Test
+    fun chatMessage_doesNotDecodeAsAvatarPayload() {
+        val chatText = json.encodeToString(
+            ChatMessagePayload.serializer(),
+            ChatMessagePayload(
+                version = 1,
+                messageId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                groupId = groupId,
+                senderBlsPubkeyHex = senderBlsHex,
+                sentAtMillis = 1L,
+                variant = ChatMessageVariant.Tyranny(body = "hi"),
+            ),
+        )
+        // GroupAvatarPayload requires the avatar_* keys — absent here.
+        assertThrows(Exception::class.java) {
+            json.decodeFromString(GroupAvatarPayload.serializer(), chatText)
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun rejectsGroupIdOfWrongLength() {
+        GroupAvatarPayload(
+            version = 1,
+            groupId = ByteArray(31),
+            senderBlsHex = senderBlsHex,
+            sentAtMillis = 1L,
+        )
+    }
+
+    private fun b64(bytes: ByteArray) = Base64.getEncoder().encodeToString(bytes)
+}

--- a/app/src/test/kotlin/app/onym/android/group/GroupInvitationPayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/GroupInvitationPayloadTest.kt
@@ -137,6 +137,76 @@ class GroupInvitationPayloadTest {
         assertArrayEquals(sk1, decoded.inviteeBlsSecretKey)
     }
 
+    // ─── avatar field (iOS #165 parity) ───────────────────────────
+
+    @Test
+    fun roundtrip_withAvatar_preservesBytes() {
+        val avatar = ByteArray(64) { (it * 7).toByte() }
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0x11 },
+            groupSecret = ByteArray(32) { 0x22 },
+            name = "Friends",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32) { 0x33 },
+            commitment = ByteArray(32) { 0x44 },
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            avatar = avatar,
+        )
+        val encoded = json.encodeToString(GroupInvitationPayload.serializer(), original)
+        // Wire key is "avatar", base64-encoded (matches Swift Data).
+        val obj = json.parseToJsonElement(encoded).jsonObject
+        assertArrayEquals(avatar, Base64.getDecoder().decode(obj["avatar"]!!.jsonPrimitive.content))
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+        assertArrayEquals(avatar, decoded.avatar)
+    }
+
+    @Test
+    fun decode_legacyEnvelopeWithoutAvatar_decodesWithNullField() {
+        // A pre-avatar sender omits the key entirely — must not fail
+        // decode, and avatar falls back to null (no photo).
+        val legacyJson = """
+            {
+              "version": 1,
+              "group_id": "${b64(ByteArray(32) { 0x10 })}",
+              "group_secret": "${b64(ByteArray(32) { 0x20 })}",
+              "name": "legacy",
+              "members": [],
+              "epoch": 0,
+              "salt": "${b64(ByteArray(32) { 0x30 })}",
+              "tier_raw": 0,
+              "group_type_raw": "tyranny"
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(GroupInvitationPayload.serializer(), legacyJson)
+        assertNull(decoded.avatar)
+    }
+
+    @Test
+    fun encode_omitsAvatarKeyWhenNil() {
+        // With encodeDefaults = false the null avatar drops off the wire
+        // entirely (the type supports the iOS "omit when nil" shape so
+        // photo-less invites stay small).
+        val lean = Json { encodeDefaults = false }
+        val original = GroupInvitationPayload(
+            version = 1,
+            groupId = ByteArray(32),
+            groupSecret = ByteArray(32),
+            name = "G",
+            members = emptyList(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            tierRaw = 0,
+            groupTypeRaw = "tyranny",
+            avatar = null,
+        )
+        val encoded = lean.encodeToString(GroupInvitationPayload.serializer(), original)
+        assertTrue("avatar key must be omitted when nil", !encoded.contains("\"avatar\""))
+    }
+
     @Test
     fun decode_legacyEnvelopeWithoutInviteeBlsSecretKey_decodesWithNullField() {
         // Envelopes from a pre-PR-2 sender don't include the new field.

--- a/app/src/test/kotlin/app/onym/android/group/RoomGroupStoreTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/RoomGroupStoreTest.kt
@@ -242,6 +242,32 @@ class RoomGroupStoreTest {
         assertEquals(emptyMap<String, MemberProfile>(), store.list().single().memberProfiles)
     }
 
+    // ─── avatar ───────────────────────────────────────────────────
+
+    @Test
+    fun avatar_roundTripsThroughEncryptedColumn() = runTest {
+        val avatar = ByteArray(64) { (it * 5).toByte() }
+        val group = makeGroup(id = "fc".repeat(32), name = "G").copy(avatar = avatar)
+        store.insertOrUpdate(group)
+
+        val raw = db.groupDao().findById(group.id)!!
+        assertNotEquals(
+            "encryptedAvatar must not contain the plaintext JPEG bytes",
+            avatar.toList(),
+            raw.encryptedAvatar?.toList(),
+        )
+        assertArrayEquals(avatar, store.list().single().avatar)
+    }
+
+    @Test
+    fun avatar_nullPersistsAsNullColumn() = runTest {
+        val group = makeGroup(id = "fd".repeat(32), name = "G")
+        store.insertOrUpdate(group)
+        val raw = db.groupDao().findById(group.id)!!
+        assertNull(raw.encryptedAvatar)
+        assertNull(store.list().single().avatar)
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private fun makeGroup(

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherAvatarTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherAvatarTest.kt
@@ -1,0 +1,217 @@
+package app.onym.android.inbox
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.chain.SepTier
+import app.onym.android.group.ChatGroup
+import app.onym.android.group.GroupAvatarPayload
+import app.onym.android.group.GroupRepository
+import app.onym.android.group.GroupStore
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.DecryptedEnvelope
+import app.onym.android.identity.IdentityId
+import app.onym.android.identity.InvitationEnvelopeDecrypter
+import app.onym.android.persistence.InMemoryInvitationStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Receive-side behavior for [GroupAvatarPayload] in
+ * [IncomingMessageDispatcher]: applied on an admin-signer match,
+ * rejected on a mismatch, and cleared when the avatar is absent.
+ *
+ * Mirrors the avatar cases of `IncomingMessageDispatcherTests.swift`
+ * from onym-ios PR #166.
+ */
+class IncomingMessageDispatcherAvatarTest {
+
+    private val groupId = ByteArray(32) { 0xAA.toByte() }
+    private val adminEd25519 = ByteArray(32) { 0x10 }
+    private val adminEd25519Hex = adminEd25519.toHex()
+    private val ownerIdentity = IdentityId("owner")
+    private val newAvatar = ByteArray(48) { 0x5A }
+
+    private lateinit var groupStore: AvatarInMemoryGroupStore
+    private lateinit var groupRepository: GroupRepository
+    private lateinit var invitationsRepository: IncomingInvitationsRepository
+
+    @Before
+    fun setUp() = runTest {
+        groupStore = AvatarInMemoryGroupStore()
+        groupRepository = GroupRepository(
+            store = groupStore,
+            identity = AvatarConstantIdentity(ownerIdentity),
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+        invitationsRepository = IncomingInvitationsRepository(
+            store = InMemoryInvitationStore(),
+            identity = AvatarConstantIdentity(ownerIdentity),
+            scope = CoroutineScope(UnconfinedTestDispatcher()),
+        )
+    }
+
+    @Test
+    fun avatar_appliedWhenSenderMatchesStoredAdmin() = runTest {
+        seed(group(adminEd25519Hex = adminEd25519Hex, avatar = null))
+        dispatch(payload(avatar = newAvatar), senderPub = adminEd25519)
+
+        assertArrayEquals(newAvatar, groupRepository.snapshots.value.single().avatar)
+        assertNoQueue()
+    }
+
+    @Test
+    fun avatar_rejectedWhenSenderDoesNotMatchStoredAdmin() = runTest {
+        seed(group(adminEd25519Hex = adminEd25519Hex, avatar = null))
+        // Forged sender — different Ed25519 pubkey.
+        dispatch(payload(avatar = newAvatar), senderPub = ByteArray(32) { 0x99.toByte() })
+
+        assertNull(
+            "forged avatar message must not mutate the group",
+            groupRepository.snapshots.value.single().avatar,
+        )
+    }
+
+    @Test
+    fun avatar_clearedWhenPayloadAbsent() = runTest {
+        // Group already has a photo; an absent-avatar message clears it.
+        seed(group(adminEd25519Hex = adminEd25519Hex, avatar = ByteArray(16) { 0x77 }))
+        dispatch(payload(avatar = null), senderPub = adminEd25519)
+
+        assertNull(
+            "absent avatar = removal",
+            groupRepository.snapshots.value.single().avatar,
+        )
+    }
+
+    @Test
+    fun avatar_droppedForUnknownGroup() = runTest {
+        seed(group(adminEd25519Hex = adminEd25519Hex, avatar = null))
+        val foreign = GroupAvatarPayload(
+            version = 1,
+            groupId = ByteArray(32) { 0xFF.toByte() }, // not on device
+            senderBlsHex = "cd".repeat(48),
+            sentAtMillis = 1L,
+            avatar = newAvatar,
+        )
+        dispatch(foreign, senderPub = adminEd25519)
+
+        assertNull(groupRepository.snapshots.value.single().avatar)
+        assertNoQueue()
+    }
+
+    @Test
+    fun avatar_appliedBestEffortWhenNoStoredAdmin() = runTest {
+        // Admin-less / legacy group (no stored admin Ed25519) → trust
+        // gate skipped, same as member announcements.
+        seed(group(adminEd25519Hex = null, avatar = null))
+        dispatch(payload(avatar = newAvatar), senderPub = null)
+
+        assertArrayEquals(newAvatar, groupRepository.snapshots.value.single().avatar)
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────
+
+    private suspend fun seed(group: ChatGroup) {
+        groupRepository.insert(group)
+        groupRepository.reload()
+    }
+
+    private suspend fun dispatch(payload: GroupAvatarPayload, senderPub: ByteArray?) {
+        val plaintext = Json.encodeToString(GroupAvatarPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = AvatarStubDecrypter(plaintext, senderPub),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+        )
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+    }
+
+    private suspend fun assertNoQueue() {
+        invitationsRepository.bootstrap()
+        assertTrue(invitationsRepository.invitations.value.isEmpty())
+    }
+
+    private fun payload(avatar: ByteArray?) = GroupAvatarPayload(
+        version = 1,
+        groupId = groupId,
+        senderBlsHex = "ab".repeat(48),
+        sentAtMillis = 1_700_000_000_000L,
+        avatar = avatar,
+    )
+
+    private fun group(adminEd25519Hex: String?, avatar: ByteArray?): ChatGroup =
+        ChatGroup(
+            id = groupId.toHex(),
+            name = "Family",
+            groupSecret = ByteArray(32),
+            createdAtMillis = 0L,
+            members = emptyList(),
+            memberProfiles = emptyMap(),
+            epoch = 0uL,
+            salt = ByteArray(32),
+            commitment = null,
+            tier = SepTier.SMALL,
+            groupType = SepGroupType.TYRANNY,
+            adminPubkeyHex = null,
+            adminEd25519PubkeyHex = adminEd25519Hex,
+            isPublishedOnChain = true,
+            ownerIdentityId = ownerIdentity.value,
+            avatar = avatar,
+        )
+
+    private fun ByteArray.toHex() = joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+}
+
+private class AvatarStubDecrypter(
+    private val plaintext: ByteArray,
+    private val senderPub: ByteArray?,
+) : InvitationEnvelopeDecrypter {
+    override suspend fun decryptInvitation(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): ByteArray = plaintext
+    override suspend fun decryptInvitationWithSender(
+        envelopeBytes: ByteArray,
+        asIdentity: IdentityId,
+    ): DecryptedEnvelope = DecryptedEnvelope(plaintext, senderPub)
+}
+
+private class AvatarInMemoryGroupStore : GroupStore {
+    private val rows = mutableMapOf<String, ChatGroup>()
+    override suspend fun list(): List<ChatGroup> = rows.values.toList()
+    override suspend fun listForOwner(ownerIdentityId: String): List<ChatGroup> =
+        rows.values.filter { it.ownerIdentityId == ownerIdentityId }
+    override suspend fun deleteForOwner(ownerIdentityId: String): Int {
+        val before = rows.size
+        rows.entries.removeAll { it.value.ownerIdentityId == ownerIdentityId }
+        return before - rows.size
+    }
+    override suspend fun insertOrUpdate(group: ChatGroup): Boolean {
+        val isNew = !rows.containsKey(group.id)
+        rows[group.id] = group
+        return isNew
+    }
+    override suspend fun markPublished(id: String, commitment: ByteArray?) {
+        val existing = rows[id] ?: return
+        rows[id] = existing.copy(
+            isPublishedOnChain = true,
+            commitment = commitment ?: existing.commitment,
+        )
+    }
+    override suspend fun delete(id: String) { rows.remove(id) }
+}
+
+private class AvatarConstantIdentity(private val id: IdentityId) : ActiveIdentityProvider {
+    override val currentIdentityId: StateFlow<IdentityId?> = MutableStateFlow(id)
+    override fun registerRemovalListener(listener: (suspend (IdentityId) -> Unit)?) {}
+}


### PR DESCRIPTION
Brings Android to parity with the iOS group-avatar stack (`onymchat/onym-ios` #164–#166). An avatar set or changed on either platform renders on the other, including removal; non-admin avatar messages are rejected; photo-less groups are unaffected.

## Wire format / interop
- **`GroupInvitationPayload`** — optional base64 `avatar` field (matches Swift `Data`). "If present" decode: pre-avatar senders omit the key and still decode. Included on send (`JoinRequestApprover`) and applied at materialize time. This is the only path that delivers the photo to **create-time** members (esp. Tyranny, where the full snapshot is sent at join-approval).
- **`GroupAvatarPayload`** (new) — dedicated admin-signed control message with the distinct `avatar_*` keys so it can't be structurally confused with a chat message. Absent `avatar` = removal; `avatar_sender_bls_hex` is informational only (never authenticated with).

## Send / receive
- **`GroupAvatarBroadcaster`** (new) — admin-only. Applies + persists locally first (best-effort broadcast), then seals one envelope per member inbox **except the admin's own key**, on the same X25519 + AES-GCM + Ed25519 path as member announcements.
- **`IncomingMessageDispatcher`** — new decode branch **before** the chat-message branch. Trust gate identical to member announcements (verified Ed25519 signer must equal the stored admin; skipped for admin-less/legacy groups), idempotency no-op, clear-on-absent. **No on-chain commitment check** — the avatar isn't part of the cryptographic group state.

## Persistence
`ChatGroup.avatar` + `PersistedGroup.encryptedAvatar` (AES-GCM at rest), `GroupDatabase` v5→v6 (`MIGRATION_5_6`, non-destructive), wired in `OnymApplication`.

## Image pipeline
`GroupAvatarImage.encode` — centre-crop to square → 256×256 → JPEG quality loop from ~0.8 down until ≤ 16 KB raw (≈22 KB base64), keeping sealed envelopes within relay event-size limits.

## UI
`ChatMembersScreen` shows the group photo (decoded JPEG, or a monogram placeholder). Admins get tap-to-pick + Add/Change/Remove via the system photo picker; non-admins see it read-only.

## Tests
- Invitation payload: round-trips with/without `avatar`; legacy (no key) → null; key omitted when nil.
- `GroupAvatarPayload`: round-trip; absent `avatar` = removal; does **not** decode as a chat message and vice-versa.
- Dispatcher: applied on admin-signer match; rejected on mismatch; cleared on absent; dropped for unknown group; best-effort when no stored admin.
- Broadcaster: fan-out to all-but-admin; non-admin gate; removal omits the key.
- `RoomGroupStore`: encrypted-avatar round-trip + null column.
- Image pipeline (androidTest — real JPEG encoding): 256×256 & ≤ 16 KB on high-entropy and non-square input.

`./gradlew :app:testDebugUnitTest` passes; main + androidTest source sets compile clean. The instrumented image-pipeline test requires a device/emulator to run.

## Note
Production invitation serialization (`encodeDefaults=true`) emits `"avatar":null` when there's no photo — consistent with how `commitment`/`member_profiles` already behave, and iOS `decodeIfPresent` reads it as nil. The type fully supports omission (covered by `encode_omitsAvatarKeyWhenNil`); the actual JPEG bytes are only present when an avatar is set, so photo-less invites stay small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)