### PR TITLE
feat(groups): set group photo in the Create Group flow

### DIFF
--- a/app/src/androidTest/kotlin/app/onym/android/group/GroupAvatarImageTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/group/GroupAvatarImageTest.kt
@@ -1,12 +1,17 @@
 package app.onym.android.group
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.Color
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 import kotlin.random.Random
 
 /**
@@ -45,6 +50,30 @@ class GroupAvatarImageTest {
         val decoded = android.graphics.BitmapFactory.decodeByteArray(encoded, 0, encoded.size)
         assertEquals(GroupAvatarImage.SIZE, decoded.width)
         assertEquals(GroupAvatarImage.SIZE, decoded.height)
+    }
+
+    @Test
+    fun decodeFromUri_realImage_returnsBudgetBoundedSquareBytes() {
+        // Regression: the bounds-only first pass returns null by design,
+        // so the helper must NOT key its null check off the decode
+        // result — otherwise every picked photo silently drops and the
+        // avatar never applies (group settings + create flow).
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val source = Bitmap.createBitmap(640, 480, Bitmap.Config.ARGB_8888)
+        source.eraseColor(Color.MAGENTA)
+        val file = File.createTempFile("avatar-test", ".jpg", ctx.cacheDir)
+        file.outputStream().use { source.compress(Bitmap.CompressFormat.JPEG, 90, it) }
+
+        try {
+            val bytes = GroupAvatarImage.decodeFromUri(ctx, Uri.fromFile(file))
+            assertNotNull("decodeFromUri must not drop a valid image", bytes)
+            assertTrue(bytes!!.size <= GroupAvatarImage.MAX_BYTES)
+            val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            assertEquals(GroupAvatarImage.SIZE, decoded.width)
+            assertEquals(GroupAvatarImage.SIZE, decoded.height)
+        } finally {
+            file.delete()
+        }
     }
 
     @Test

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -621,11 +621,12 @@ class OnymApplication : Application() {
                     introducer = inviteIntroducer,
                 )
                 CreateGroupViewModel(
-                    createGroup = { name, invitees, groupType, onProgress ->
+                    createGroup = { name, invitees, groupType, avatar, onProgress ->
                         interactor.create(
                             name = name,
                             invitees = invitees,
                             groupType = groupType,
+                            avatar = avatar,
                             onProgress = onProgress,
                         )
                     },

--- a/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMembersScreen.kt
@@ -125,7 +125,7 @@ fun ChatMembersScreen(
         if (uri == null) return@rememberLauncherForActivityResult
         scope.launch {
             val bytes = withContext(Dispatchers.IO) {
-                decodeAndEncodeAvatar(context, uri)
+                GroupAvatarImage.decodeFromUri(context, uri)
             } ?: return@launch
             chatsViewModel.setGroupAvatar(g.id, bytes)
         }
@@ -459,38 +459,4 @@ internal data class MemberRow(
 
 private fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
     for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
-}
-
-/**
- * Decode the picked image [uri] into a downsampled [Bitmap] and run it
- * through [GroupAvatarImage.encode] to get budget-bounded JPEG bytes.
- * Returns `null` on any decode failure. Call off the main thread.
- */
-private fun decodeAndEncodeAvatar(
-    context: android.content.Context,
-    uri: android.net.Uri,
-): ByteArray? {
-    val resolver = context.contentResolver
-    // Pass 1: bounds only, so a huge source doesn't OOM on decode.
-    // `decodeStream` returns null in this mode by design (it just fills
-    // outWidth/outHeight), so the null guard MUST be on `openInputStream`
-    // — not on the decode result, or we'd bail out on every image.
-    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    val boundsStream = resolver.openInputStream(uri) ?: return null
-    boundsStream.use { BitmapFactory.decodeStream(it, null, bounds) }
-    val minEdge = minOf(bounds.outWidth, bounds.outHeight)
-    if (minEdge <= 0) return null
-
-    // Downsample so the smaller edge is at least 2× the target — enough
-    // detail for the centre-crop + 256² scale without decoding full res.
-    var sample = 1
-    while (minEdge / (sample * 2) >= GroupAvatarImage.SIZE * 2) {
-        sample *= 2
-    }
-    val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
-    val bitmap = resolver.openInputStream(uri)?.use {
-        BitmapFactory.decodeStream(it, null, decodeOpts)
-    } ?: return null
-
-    return runCatching { GroupAvatarImage.encode(bitmap) }.getOrNull()
 }

--- a/app/src/main/kotlin/app/onym/android/group/CreateGroupInteractor.kt
+++ b/app/src/main/kotlin/app/onym/android/group/CreateGroupInteractor.kt
@@ -103,6 +103,11 @@ open class CreateGroupInteractor(
         name: String,
         invitees: List<ByteArray>,
         groupType: SepGroupType = SepGroupType.TYRANNY,
+        /** Raw JPEG bytes of the group photo (already budget-bounded by
+         *  [GroupAvatarImage.encode]), or `null` for no photo. Stamped
+         *  onto the created [ChatGroup] so it ships in the membership
+         *  snapshot to every invitee. */
+        avatar: ByteArray? = null,
         onProgress: (CreateGroupProgress) -> Unit = {},
     ): ChatGroup {
         // 1. Validate
@@ -310,6 +315,7 @@ open class CreateGroupInteractor(
             adminEd25519PubkeyHex = adminEd25519PubkeyHex,
             isPublishedOnChain = false,
             ownerIdentityId = ownerId.value,
+            avatar = avatar,
         )
         groups.insert(group)
         groups.markPublished(group.id, proof.commitment)
@@ -343,6 +349,7 @@ open class CreateGroupInteractor(
                     adminPubkeyHex = adminPubkeyHex,
                     inviteeBlsSecretKey = secondaryBlsSecret,
                     memberProfiles = group.memberProfiles.takeIf { it.isNotEmpty() },
+                    avatar = avatar,
                 )
             }
         }
@@ -440,6 +447,7 @@ open class CreateGroupInteractor(
         adminPubkeyHex: String?,
         inviteeBlsSecretKey: ByteArray?,
         memberProfiles: Map<String, MemberProfile>?,
+        avatar: ByteArray?,
     ) {
         for ((index, inboxKey) in invitees.withIndex()) {
             val invitePayload = GroupInvitationPayload(
@@ -460,6 +468,7 @@ open class CreateGroupInteractor(
                 // materializes (PR 83). takeIf-not-empty matches iOS;
                 // pre-PR-82 senders shipped null.
                 memberProfiles = memberProfiles,
+                avatar = avatar,
             )
             val payloadBytes = try {
                 jsonFormat.encodeToString(

--- a/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/group/CreateGroupViewModel.kt
@@ -73,6 +73,12 @@ data class CreateGroupState(
      *  wants to type their own". */
     val nameFieldHasBeenFocused: Boolean = false,
     val accent: OnymAccent = OnymAccent.Blue,
+    /** Raw JPEG bytes of the group photo the user picked, already run
+     *  through [GroupAvatarImage.encode] (256×256, ≤16 KB). `null` =
+     *  no photo (the Success screen + invitations fall back to the
+     *  brand placeholder). Passed straight into [GroupCreator] at
+     *  submit so the created group carries it from the first snapshot. */
+    val avatar: ByteArray? = null,
     /** Always [OnymUIGovernance.Tyranny] in PR-C — the picker
      *  disables the others. */
     val governance: OnymUIGovernance = OnymUIGovernance.Tyranny,
@@ -171,6 +177,7 @@ typealias GroupCreator = suspend (
     name: String,
     invitees: List<ByteArray>,
     groupType: SepGroupType,
+    avatar: ByteArray?,
     onProgress: (CreateGroupProgress) -> Unit,
 ) -> ChatGroup
 
@@ -220,6 +227,16 @@ class CreateGroupViewModel(
 
     fun setAccent(accent: OnymAccent) {
         _state.value = _state.value.copy(accent = accent)
+    }
+
+    /**
+     * Set ([avatar] non-null) or clear ([avatar] == null) the group
+     * photo picked on Step 1. The screen has already decoded the
+     * picked image and run it through [GroupAvatarImage.encode], so
+     * [avatar] is the budget-bounded JPEG ready for the wire.
+     */
+    fun setAvatar(avatar: ByteArray?) {
+        _state.value = _state.value.copy(avatar = avatar)
     }
 
     fun setGovernance(governance: OnymUIGovernance) {
@@ -353,6 +370,7 @@ class CreateGroupViewModel(
                 current.effectiveName,
                 current.invitees.map { it.inboxPublicKey },
                 current.governance.sepGroupType,
+                current.avatar,
             ) { p -> _state.value = _state.value.copy(progress = p) }
             _state.value = _state.value.copy(
                 createdGroup = group,

--- a/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
@@ -1,6 +1,9 @@
 package app.onym.android.group
 
+import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import java.io.ByteArrayOutputStream
 import kotlin.math.min
 
@@ -53,6 +56,36 @@ object GroupAvatarImage {
             encoded = compress(scaled, quality)
         }
         return encoded
+    }
+
+    /**
+     * Decode the photo-picker [uri] into a downsampled [Bitmap] and run
+     * it through [encode], yielding budget-bounded JPEG bytes ready for
+     * [ChatGroup.avatar] / the wire. Returns `null` on any decode
+     * failure. Two-pass (bounds first) so a huge source doesn't OOM.
+     * Call off the main thread — it does blocking IO + decode.
+     */
+    fun decodeFromUri(context: Context, uri: Uri): ByteArray? {
+        val resolver = context.contentResolver
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+            ?: return null
+        val minEdge = min(bounds.outWidth, bounds.outHeight)
+        if (minEdge <= 0) return null
+
+        // Downsample so the smaller edge is at least 2× the target —
+        // enough detail for the centre-crop + 256² scale without
+        // decoding full resolution.
+        var sample = 1
+        while (minEdge / (sample * 2) >= SIZE * 2) {
+            sample *= 2
+        }
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        val bitmap = resolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, opts)
+        } ?: return null
+
+        return runCatching { encode(bitmap) }.getOrNull()
     }
 
     private fun compress(bitmap: Bitmap, quality: Int): ByteArray =

--- a/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
+++ b/app/src/main/kotlin/app/onym/android/group/GroupAvatarImage.kt
@@ -67,9 +67,13 @@ object GroupAvatarImage {
      */
     fun decodeFromUri(context: Context, uri: Uri): ByteArray? {
         val resolver = context.contentResolver
+        // Pass 1: bounds only. `decodeStream` returns null in this mode
+        // by design (it just fills outWidth/outHeight), so the null
+        // guard MUST be on `openInputStream` — not on the decode result,
+        // or we'd bail out on every image.
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
-            ?: return null
+        val boundsStream = resolver.openInputStream(uri) ?: return null
+        boundsStream.use { BitmapFactory.decodeStream(it, null, bounds) }
         val minEdge = min(bounds.outWidth, bounds.outHeight)
         if (minEdge <= 0) return null
 

--- a/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/group/creategroup/CreateGroupScreen.kt
@@ -1,9 +1,14 @@
 package app.onym.android.group.creategroup
 
+import android.graphics.BitmapFactory
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -35,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,6 +48,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -58,12 +67,16 @@ import app.onym.android.group.CreateCtaLabel
 import app.onym.android.group.CreateGroupProgress
 import app.onym.android.group.CreateGroupRoute
 import app.onym.android.group.CreateGroupViewModel
+import app.onym.android.group.GroupAvatarImage
 import app.onym.android.group.OnymAccent
 import app.onym.android.group.OnymGovIcon
 import app.onym.android.group.OnymGroupAvatar
 import app.onym.android.group.LocalOnymTokens
 import app.onym.android.group.OnymUIGovernance
 import app.onym.android.scan.QrScannerScreen
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Top-level screen for the Create Group flow. Switches between the
@@ -108,6 +121,19 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val accent = state.accent.color()
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val photoPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        scope.launch {
+            val bytes = withContext(Dispatchers.IO) {
+                GroupAvatarImage.decodeFromUri(context, uri)
+            }
+            if (bytes != null) viewModel.setAvatar(bytes)
+        }
+    }
     Column(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxWidth()) {
             OnymNavTitle(
@@ -137,7 +163,18 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(Modifier.height(10.dp))
-            OnymGroupAvatar(size = 92.dp, accent = accent)
+            CreateGroupAvatarPicker(
+                avatar = state.avatar,
+                accent = accent,
+                onPick = {
+                    photoPicker.launch(
+                        PickVisualMediaRequest(
+                            ActivityResultContracts.PickVisualMedia.ImageOnly,
+                        ),
+                    )
+                },
+                onRemove = { viewModel.setAvatar(null) },
+            )
             Spacer(Modifier.height(18.dp))
 
             // Name field — pre-filled with the generated placeholder
@@ -250,6 +287,68 @@ private fun Step1Screen(viewModel: CreateGroupViewModel) {
                 enabled = state.canAdvanceToStep2,
                 onClick = viewModel::tappedNext,
             )
+        }
+    }
+}
+
+/**
+ * Editable group-photo slot for Step 1. Tapping opens the system photo
+ * picker; once a photo is chosen it renders in the circle (replacing
+ * the brand mark) with "Change photo" / "Remove" actions below.
+ * [avatar] is the budget-bounded JPEG already produced by
+ * [GroupAvatarImage]; [onPick] launches the picker, [onRemove] clears it.
+ */
+@Composable
+private fun CreateGroupAvatarPicker(
+    avatar: ByteArray?,
+    accent: Color,
+    onPick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val bitmap = remember(avatar) {
+        avatar?.let { runCatching { BitmapFactory.decodeByteArray(it, 0, it.size) }.getOrNull() }
+    }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(92.dp)
+                .clip(CircleShape)
+                .clickable(onClick = onPick),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (bitmap != null) {
+                Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = stringResource(R.string.create_group_photo_change),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            } else {
+                OnymGroupAvatar(size = 92.dp, accent = accent)
+            }
+        }
+        Spacer(Modifier.height(6.dp))
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(
+                    if (avatar == null) R.string.create_group_photo_add
+                    else R.string.create_group_photo_change,
+                ),
+                color = accent,
+                style = TextStyle(fontSize = 12.5.sp, fontWeight = FontWeight.Medium),
+                modifier = Modifier.clickable(onClick = onPick),
+            )
+            if (avatar != null) {
+                Text(
+                    text = stringResource(R.string.create_group_photo_remove),
+                    color = LocalOnymTokens.current.text3,
+                    style = TextStyle(fontSize = 12.5.sp, fontWeight = FontWeight.Medium),
+                    modifier = Modifier.clickable(onClick = onRemove),
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -397,6 +397,9 @@
     <string name="create_group_step1_subtitle">Шаг 1 из 2</string>
     <string name="create_group_name_placeholder">Название группы</string>
     <string name="create_group_name_helper">Видно участникам. Можно изменить в любое время.</string>
+    <string name="create_group_photo_add">Добавить фото</string>
+    <string name="create_group_photo_change">Изменить фото</string>
+    <string name="create_group_photo_remove">Удалить</string>
     <string name="create_group_accent_color">Акцентный цвет</string>
     <string name="create_group_how_its_run">Как устроена</string>
     <string name="create_group_soon_badge">Скоро</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,6 +405,9 @@
     <string name="create_group_step1_subtitle">Step 1 of 2</string>
     <string name="create_group_name_placeholder">Group name</string>
     <string name="create_group_name_helper">Visible to members. You can change this anytime.</string>
+    <string name="create_group_photo_add">Add photo</string>
+    <string name="create_group_photo_change">Change photo</string>
+    <string name="create_group_photo_remove">Remove</string>
     <string name="create_group_accent_color">Accent color</string>
     <string name="create_group_how_its_run">How it\'s run</string>
     <string name="create_group_soon_badge">Soon</string>

--- a/app/src/test/kotlin/app/onym/android/group/CreateGroupViewModelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/group/CreateGroupViewModelTest.kt
@@ -337,6 +337,37 @@ class CreateGroupViewModelTest {
     }
 
     @Test
+    fun submit_forwardsPickedAvatarToCreator() = runTest {
+        var receivedAvatar: ByteArray? = null
+        var creatorCalled = false
+        val avatar = ByteArray(32) { 0x7A }
+        val vm = CreateGroupViewModel(
+            createGroup = { _, _, _, a, _ ->
+                creatorCalled = true
+                receivedAvatar = a
+                makeFakeGroup(id = "cd".repeat(32))
+            },
+        )
+
+        vm.setAvatar(avatar)
+        assertArrayEquals(avatar, vm.state.value.avatar)
+
+        vm.submit()
+
+        assertTrue("creator must run", creatorCalled)
+        assertArrayEquals("picked avatar must reach the creator", avatar, receivedAvatar)
+    }
+
+    @Test
+    fun setAvatar_nullClearsThePickedPhoto() = runTest {
+        val vm = makeViewModel()
+        vm.setAvatar(ByteArray(8) { 0x1 })
+        assertNotNull(vm.state.value.avatar)
+        vm.setAvatar(null)
+        assertNull(vm.state.value.avatar)
+    }
+
+    @Test
     fun tappedShareInvite_isNoOpWhenNoGroupCreated() = runTest {
         val vm = makeViewModel()
         var closedCount = 0
@@ -386,7 +417,7 @@ class CreateGroupViewModelTest {
      *  lambda just throws if reached — the screen flow is still fully
      *  exercised via intent dispatch. */
     private fun makeViewModel(): CreateGroupViewModel = CreateGroupViewModel(
-        createGroup = { _, _, _, _ ->
+        createGroup = { _, _, _, _, _ ->
             error("createGroup must not be invoked from VM tests")
         },
     )
@@ -397,7 +428,7 @@ class CreateGroupViewModelTest {
      *  the real interactor. */
     private fun makeViewModelReturning(group: ChatGroup): CreateGroupViewModel =
         CreateGroupViewModel(
-            createGroup = { _, _, _, _ -> group },
+            createGroup = { _, _, _, _, _ -> group },
         )
 
     private fun makeFakeGroup(id: String): ChatGroup = ChatGroup(


### PR DESCRIPTION
**Stacked on #165** (`feat/group-avatars`). Review/merge that first; this PR's diff is against it.

## Problem
The Create Group flow's avatar slot (`OnymGroupAvatar`) was a static brand mark — its own comment reads *"The user never uploads an image in this prototype."* So there was no way to set a group photo at creation, from the gallery or anywhere else.

## Fix
Wire the system photo picker into **Step 1**:
- Tap the avatar (or the **Add/Change photo** action) → `ActivityResultContracts.PickVisualMedia` → decode + run through `GroupAvatarImage` (centre-crop, 256×256, ≤16 KB) → preview in the circle, with a **Remove** action. New strings (en + ru).
- `CreateGroupViewModel`: `avatar` in state + `setAvatar(...)`, passed through `GroupCreator` at submit.
- `CreateGroupInteractor.create` gains an `avatar` param, stamped onto the created `ChatGroup` and shipped in the non-Tyranny create-time snapshot. (Tyranny delivers the photo at join-approval — already handled by `JoinRequestApprover` in #165.)
- `GroupAvatarImage.decodeFromUri` centralizes picker-URI → JPEG bytes (two-pass downsample + encode); `ChatMembersScreen` now reuses it instead of its private copy.

## Result
The creator can set a group photo while creating the group; it persists on the group and ships to invitees (in the snapshot for non-Tyranny, at approval for Tyranny), so it shows on iOS too.

## Scope note
"From AI" generation is **not** included — there's no image-generation backend in the Android repo, and the user confirmed gallery-only for this PR.

## Tests
- `CreateGroupViewModelTest`: submit forwards the picked avatar to the creator; `setAvatar(null)` clears it.
- Full `:app:testDebugUnitTest` green; main + androidTest compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)