### PR TITLE
feat(groups): invite by QR — show from Group Settings, scan to join

### DIFF
--- a/app/src/main/kotlin/app/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/RootScreen.kt
@@ -37,6 +37,7 @@ import app.onym.android.group.CreateGroupViewModel
 import app.onym.android.group.IntroCapability
 import app.onym.android.group.JoinScreen
 import app.onym.android.group.JoinViewModel
+import app.onym.android.group.ScanToJoinScreen
 import app.onym.android.group.ShareInviteViewModel
 import app.onym.android.group.creategroup.CreateGroupScreen
 import app.onym.android.group.creategroup.ShareInviteScreen
@@ -189,6 +190,21 @@ fun RootScreen(
                         // tap deeper behind the thread's info button.
                         navController.navigate("chat_thread/$groupId")
                     },
+                    onScanToJoin = { navController.navigate(ROUTE_SCAN_JOIN) },
+                )
+            }
+            composable(ROUTE_SCAN_JOIN) {
+                ScanToJoinScreen(
+                    onCapability = { capability ->
+                        // Route a scanned invite through the exact join
+                        // destination the tapped-link path uses; drop the
+                        // scanner from the back stack so Back from Join
+                        // returns to Chats, not the live camera.
+                        navController.navigate("join_invite/${capability.encode()}") {
+                            popUpTo(ROUTE_SCAN_JOIN) { inclusive = true }
+                        }
+                    },
+                    onCancel = { navController.popBackStack() },
                 )
             }
             composable("chat_thread/{groupId}") { entry ->
@@ -566,4 +582,5 @@ private const val ROUTE_ANCHORS_ROOT = "anchors_root"
 private const val ROUTE_CREATE_GROUP = "create_group"
 private const val ROUTE_APPROVE_REQUESTS = "approve_requests"
 private const val ROUTE_PENDING_INVITES = "pending_invites"
+private const val ROUTE_SCAN_JOIN = "scan_join"
 private val TAB_ROUTES = setOf(Tab.Chats.route, Tab.Settings.route, Tab.Search.route)

--- a/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Button
@@ -33,6 +34,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -85,6 +87,7 @@ fun ChatsScreen(
     pendingInvitesViewModel: PendingInvitesViewModel? = null,
     onOpenInvitations: (() -> Unit)? = null,
     onOpenChat: (groupId: String) -> Unit = {},
+    onScanToJoin: () -> Unit = {},
 ) {
     val groups by viewModel.groups.collectAsStateWithLifecycle()
     val pending by (approveRequestsViewModel?.pending?.collectAsStateWithLifecycle()
@@ -100,6 +103,18 @@ fun ChatsScreen(
             TopAppBar(
                 title = { Text(stringResource(R.string.chats_title)) },
                 actions = {
+                    // Scan-to-join is always available — a brand-new
+                    // user with no chats still needs a way in, and an
+                    // existing member may want to join another group.
+                    IconButton(
+                        onClick = onScanToJoin,
+                        modifier = Modifier.testTag("chats.scan_to_join_toolbar"),
+                    ) {
+                        Icon(
+                            Icons.Filled.QrCodeScanner,
+                            contentDescription = stringResource(R.string.chats_scan_to_join),
+                        )
+                    }
                     if (approveRequestsViewModel != null && onOpenApproveRequests != null) {
                         Box(modifier = Modifier.padding(end = 4.dp)) {
                             IconButton(
@@ -171,7 +186,11 @@ fun ChatsScreen(
         containerColor = MaterialTheme.colorScheme.surface,
     ) { padding ->
         if (groups.isEmpty()) {
-            EmptyState(padding = padding, onCreateGroup = onCreateGroup)
+            EmptyState(
+                padding = padding,
+                onCreateGroup = onCreateGroup,
+                onScanToJoin = onScanToJoin,
+            )
         } else {
             LazyColumn(
                 modifier = Modifier
@@ -193,6 +212,7 @@ fun ChatsScreen(
 private fun EmptyState(
     padding: PaddingValues,
     onCreateGroup: () -> Unit,
+    onScanToJoin: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -239,6 +259,24 @@ private fun EmptyState(
         ) {
             Text(
                 text = stringResource(R.string.chats_create_group),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        // Secondary affordance: a first-time user who was sent an
+        // invite QR (and has no chats yet) joins from here.
+        TextButton(
+            onClick = onScanToJoin,
+            modifier = Modifier.testTag("chats.scan_to_join_empty_cta"),
+        ) {
+            Icon(
+                Icons.Filled.QrCodeScanner,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.size(8.dp))
+            Text(
+                text = stringResource(R.string.chats_scan_to_join),
                 style = MaterialTheme.typography.titleMedium,
             )
         }

--- a/app/src/main/kotlin/app/onym/android/group/ScanToJoinScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/group/ScanToJoinScreen.kt
@@ -1,0 +1,80 @@
+package app.onym.android.group
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import app.onym.android.R
+import app.onym.android.scan.QrScannerScreen
+import app.onym.android.transport.DeeplinkCapture
+import kotlinx.coroutines.launch
+
+/**
+ * "Scan to join" surface: reuses the generic [QrScannerScreen] camera
+ * UI and runs whatever it decodes through the **same**
+ * [DeeplinkCapture] allowlist + [IntroCapability] decoder the
+ * tapped-link path uses ([app.onym.android.MainActivity] →
+ * `DeeplinkCapture.introCapabilityFromIntent`). So a scanned QR and a
+ * tapped `https://onym.app/join?c=…` link reach the join flow
+ * identically — no second decoder, no second join path.
+ *
+ * A scanned string that isn't an Onym invite (decoder returns null —
+ * wrong host/scheme, or a malformed `c=` payload) shows a snackbar and
+ * re-arms the camera instead of starting a join. Re-arming is done by
+ * re-[key]ing the scanner: its one-shot latch lives in a `remember`
+ * inside [QrScannerScreen], so swapping the key gives a fresh latch and
+ * lets the user line up another code.
+ *
+ * Android twin of the scan-and-route logic in `ChatsView.swift`
+ * (onym-ios PR #168), which parses via
+ * `DeeplinkCapture.introCapability(fromString:)` and drives the same
+ * JoinView the deeplink uses.
+ */
+@Composable
+fun ScanToJoinScreen(
+    onCapability: (IntroCapability) -> Unit,
+    onCancel: () -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val notOnymMessage = stringResource(R.string.scan_join_not_onym)
+    // Bumped on each rejected scan to re-arm the scanner's one-shot
+    // latch (see KDoc).
+    var attempt by remember { mutableIntStateOf(0) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        key(attempt) {
+            QrScannerScreen(
+                onScanned = { raw ->
+                    val capability = DeeplinkCapture.introCapabilityFromUri(raw)
+                    if (capability != null) {
+                        onCapability(capability)
+                    } else {
+                        scope.launch { snackbarHostState.showSnackbar(notOnymMessage) }
+                        attempt++
+                    }
+                },
+                onCancel = onCancel,
+            )
+        }
+        // Sits above the scanner's own chrome; system-bar padding keeps
+        // it clear of the gesture bar.
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .systemBarsPadding(),
+        )
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/group/creategroup/ShareInviteScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/group/creategroup/ShareInviteScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.onym.android.R
 import app.onym.android.group.IntroCapability
 import app.onym.android.group.ShareInviteViewModel
+import app.onym.android.settings.OnymQrCode
 
 /**
  * Post-create surface. The just-created group is identified by hex
@@ -121,6 +122,23 @@ fun ShareInviteScreen(
                 is ShareInviteViewModel.State.Ready -> {
                     val chooserTitle = stringResource(R.string.share_invite_link_chooser)
                     val clipboardLabel = stringResource(R.string.share_invite_clipboard_label)
+                    // Same brand-anchored QR component the identity
+                    // invite-key screen uses. Encodes the *exact* link
+                    // string the Share / Copy buttons hand out, so a
+                    // scanned QR and a tapped link decode identically.
+                    OnymQrCode(
+                        value = s.link,
+                        size = 220.dp,
+                        modifier = Modifier.testTag("share_invite.qr"),
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(R.string.share_invite_qr_caption),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(20.dp))
                     Button(
                         onClick = {
                             val sendIntent = Intent().apply {

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -391,6 +391,7 @@
     <string name="share_invite_copied">Скопировано!</string>
     <string name="share_invite_failed">Не удалось создать приглашение: %1$s</string>
     <string name="share_invite_skip">Сделаю это позже</string>
+    <string name="share_invite_qr_caption">Пусть отсканируют это камерой, чтобы присоединиться.</string>
 
     <!-- ─── Create group — Step 1 ─────────────────────────────── -->
     <string name="create_group_step1_title">Новая группа</string>
@@ -428,6 +429,10 @@
     <!-- QR-сканер (Создание группы → Пригласить по ключу → Сканировать QR) -->
     <string name="qr_scanner_hint">Наведите камеру на QR-код приглашения Onym.</string>
     <string name="qr_scanner_permission_denied">Доступ к камере отключён. Включите его в настройках и вернитесь, чтобы отсканировать.</string>
+
+    <!-- Сканировать для присоединения (Чаты → отсканировать QR приглашения) -->
+    <string name="chats_scan_to_join">Сканировать приглашение</string>
+    <string name="scan_join_not_onym">Это не приглашение Onym.</string>
 
     <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
     <string name="create_group_cta_empty">Создать пустую группу</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,6 +399,7 @@
     <string name="share_invite_copied">Copied!</string>
     <string name="share_invite_failed">Couldn\'t generate an invite: %1$s</string>
     <string name="share_invite_skip">I\'ll do this later</string>
+    <string name="share_invite_qr_caption">Have them scan this with their camera to join.</string>
 
     <!-- ─── Create group — Step 1 ─────────────────────────────── -->
     <string name="create_group_step1_title">New Group</string>
@@ -436,6 +437,10 @@
     <!-- QR scanner (Create Group → Invite by inbox key → Scan QR) -->
     <string name="qr_scanner_hint">Point your camera at an Onym invite QR code.</string>
     <string name="qr_scanner_permission_denied">Camera access is off. Enable it in Settings, then come back to scan.</string>
+
+    <!-- Scan to join (Chats → scan an invite QR) -->
+    <string name="chats_scan_to_join">Scan to join</string>
+    <string name="scan_join_not_onym">Not an Onym invite.</string>
 
     <!-- ─── Create group — Step 2 CTA labels ──────────────────── -->
     <string name="create_group_cta_empty">Create empty group</string>


### PR DESCRIPTION
Reaches parity with iOS PR onymchat/onym-ios#168 — "invite by QR code" for group invites.

## What's in here

### Host side — show the invite as a QR
- `ShareInviteScreen` (reached from Group Settings → members roster via the admin-only "Share invite" action, and reused as the post-create invite screen) now renders the minted invite link as a QR code above the existing Share / Copy buttons, with a caption: *"Have them scan this with their camera to join."*
- Reuses the existing **`OnymQrCode`** component (the same brand-anchored QR the identity invite-key screen uses) — no new generator.
- Encodes the **exact** `s.link` string the Share/Copy buttons already hand out (`https://onym.app/join?c=<…>`), untruncated.

### Joiner side — scan to join, in-app
- New **`ScanToJoinScreen`** wraps the existing generic **`QrScannerScreen`** (camera + permission flow reused as-is) and runs whatever it decodes through the **same** `DeeplinkCapture.introCapabilityFromUri` allowlist + `IntroCapability` decoder the tapped-link path uses. A scanned QR and a tapped link reach the identical `join_invite/{capability}` destination — no second decoder, no second join path.
- A scanned string that isn't an Onym invite (decoder returns `null`) shows a **"Not an Onym invite"** snackbar and re-arms the camera instead of starting a join.
- Two entry points on the Chats screen:
  - an always-visible **QR scanner action in the top bar**, and
  - a secondary **"Scan to join"** button in the **empty state** (a brand-new user joining their first group has no chat yet).
- Strings added in `en` + `ru`.

## Test plan
- [ ] **Host shows QR:** open a Tyranny group → members roster → Share invite → a QR renders above Share/Copy; the QR encodes the same link the Copy button puts on the clipboard.
- [ ] **Post-create:** create a group → the share screen shows the same QR.
- [ ] **Scan valid invite:** on a second device/identity, Chats → QR action (or empty-state "Scan to join") → scan the host's QR → lands on the Join screen for that group (same as tapping the link).
- [ ] **Scan non-Onym QR:** scan an arbitrary QR (e.g. a plain URL) → "Not an Onym invite" snackbar, camera stays live, no join started.
- [ ] **Tapped link still works:** opening `https://onym.app/join?c=…` / `onym://join?c=…` still routes to Join unchanged.

## ⚠️ Cross-platform blocker (flagged, not fixed here)
iOS found that the recent "avatar in the group invitation snapshot" work can break joining on **both** scan and tapped-link paths. **Android has the same issue, confirmed:**

- `GroupInvitationPayload.avatar` (`app/.../group/GroupInvitationPayload.kt`) carries the raw group-avatar **JPEG** (budget `GroupAvatarImage.MAX_BYTES = 16 KB` raw → ~22 KB base64 on the wire), and `CreateGroupInteractor.sendInvitations` includes it in the sealed invitation.
- The sealed envelope is then **base64-encoded again** into the Nostr event `content` (`NostrInboxTransport.buildSendEvent`), roughly doubling size.
- There is **no pre-publish size check**, and `NostrRelayConnection.publishAndAwaitOK` **treats a publish timeout as success**; the create path only checks `acceptedBy >= 1`. So a strict relay that drops the oversized event silently is indistinguishable from success, and the joiner never materializes the group.

This is independent of the QR work — it would break joining regardless. Recommend tracking + fixing separately (e.g. move the avatar out of the invitation snapshot onto the dedicated `GroupAvatarPayload` channel, and/or add a pre-publish size guard + distinguish `OK false` from timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
