### PR TITLE
fix(inbox): stop the launch-time get_commitment storm that breaks live joins

### DIFF
--- a/app/src/androidTest/kotlin/app/onym/android/inbox/IncomingMessageDispatcherConvergeForwardFfiTest.kt
+++ b/app/src/androidTest/kotlin/app/onym/android/inbox/IncomingMessageDispatcherConvergeForwardFfiTest.kt
@@ -104,6 +104,112 @@ class IncomingMessageDispatcherConvergeForwardFfiTest {
         )
     }
 
+    @Test
+    fun invitation_tyranny_redelivery_skipsChainReadWhenAlreadyVerified() = runBlocking {
+        // The launch-time storm fix: a re-delivered invitation for an
+        // already-materialized (commitment, epoch) must NOT hit the relayer
+        // again. First delivery verifies (1 chain read) and materializes;
+        // the identical replay short-circuits on the local match, leaving
+        // the chain-read count at 1.
+        val env = environment()
+        val realCommitment = realCommitment(epoch = 0uL)
+        val plaintext = encode(invitation(commitment = realCommitment, epoch = 0uL))
+        val counting = CountingChainState(SepCommitmentEntry(commitment = realCommitment, epoch = 0uL))
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = FakeInvitationEnvelopeDecrypter(
+                FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext),
+            ),
+            groupRepository = env.groups,
+            invitationsRepository = env.invitations,
+            chainState = counting,
+            groupStateRefresher = SpyRefresher(),
+        )
+
+        dispatcher.dispatch("mat-1", owner, byteArrayOf(), Instant.EPOCH)
+        dispatcher.dispatch("mat-1-replay", owner, byteArrayOf(), Instant.EPOCH)
+
+        assertEquals(
+            "idempotent — still exactly one group",
+            1,
+            env.groups.snapshots.value.count { it.groupIdBytes.contentEquals(groupId) },
+        )
+        assertEquals(
+            "replay of an already-verified snapshot must not re-read the chain",
+            1,
+            counting.callCount,
+        )
+    }
+
+    @Test
+    fun invitation_tyranny_chainReadThrows_defersInsteadOfReject() = runBlocking {
+        // A throttled / unreachable relayer is not evidence of forgery. The
+        // invitation must be deferred (retried via the admin-refresh path),
+        // never silently dropped — that drop was the root cause of "joiner
+        // only sees the chat after a restart".
+        val env = environment()
+        val realCommitment = realCommitment(epoch = 0uL)
+        val plaintext = encode(invitation(commitment = realCommitment, epoch = 0uL))
+        val refresher = SpyRefresher()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = FakeInvitationEnvelopeDecrypter(
+                FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext),
+            ),
+            groupRepository = env.groups,
+            invitationsRepository = env.invitations,
+            chainState = ThrowingChainState(),  // simulate throttle / offline
+            groupStateRefresher = refresher,
+        )
+
+        dispatcher.dispatch("mat-throw", owner, byteArrayOf(), Instant.EPOCH)
+
+        assertTrue(
+            "unverifiable-now invitation must not materialize",
+            env.groups.snapshots.value.none { it.groupIdBytes.contentEquals(groupId) },
+        )
+        assertEquals(
+            "a chain-read failure must defer (retry), not reject+drop",
+            listOf(groupId.toList()),
+            refresher.deferred.map { it.toList() },
+        )
+    }
+
+    @Test
+    fun invitation_tyranny_chainBehind_defersInsteadOfReject() = runBlocking {
+        // Admin just anchored epoch 1 and immediately sent the snapshot; our
+        // relayer read still lags at epoch 0. Treat as deferral, not a hard
+        // reject — deferral never materializes without a later exact-epoch
+        // match, so a forgery still can't slip in, while a real lagging read
+        // recovers live instead of only on restart.
+        val env = environment()
+        val realCommitment = realCommitment(epoch = 1uL)
+        val plaintext = encode(invitation(commitment = realCommitment, epoch = 1uL))
+        val refresher = SpyRefresher()
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = FakeInvitationEnvelopeDecrypter(
+                FakeInvitationEnvelopeDecrypter.Mode.Fixed(plaintext),
+            ),
+            groupRepository = env.groups,
+            invitationsRepository = env.invitations,
+            // Chain BEHIND (epoch 0) the claimed epoch 1.
+            chainState = FakeChainStateFor(
+                SepCommitmentEntry(commitment = ByteArray(32) { 0x00 }, epoch = 0uL),
+            ),
+            groupStateRefresher = refresher,
+        )
+
+        dispatcher.dispatch("mat-behind", owner, byteArrayOf(), Instant.EPOCH)
+
+        assertTrue(
+            "chain-behind snapshot must not materialize unverified",
+            env.groups.snapshots.value.none { it.groupIdBytes.contentEquals(groupId) },
+        )
+        assertEquals(
+            "chain-behind must defer (lagging read), not reject+drop",
+            listOf(groupId.toList()),
+            refresher.deferred.map { it.toList() },
+        )
+    }
+
     // ─── helpers ──────────────────────────────────────────────────
 
     private class Env(val groups: GroupRepository, val invitations: IncomingInvitationsRepository)
@@ -160,6 +266,23 @@ class IncomingMessageDispatcherConvergeForwardFfiTest {
 
 private class FakeChainStateFor(private val entry: SepCommitmentEntry) : ChainStateReading {
     override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry = entry
+}
+
+/** Counts reads so a test can assert a redelivery short-circuit never
+ *  re-hits the relayer. */
+private class CountingChainState(private val entry: SepCommitmentEntry) : ChainStateReading {
+    var callCount = 0
+        private set
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry {
+        callCount += 1
+        return entry
+    }
+}
+
+/** Simulates a throttled / offline / unconfigured relayer read. */
+private class ThrowingChainState : ChainStateReading {
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry =
+        throw app.onym.android.chain.ChainReadError.NoActiveRelayer
 }
 
 private class SpyRefresher : GroupStateRefreshing {

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -404,13 +404,21 @@ class OnymApplication : Application() {
         // branches. Reuses the same OkHttp client (with
         // BearerAuthInterceptor) so the relayer's auth token rides
         // along.
-        val chainStateReader = app.onym.android.chain.SepContractChainStateReader(
-            relayers = relayerRepository,
-            contracts = contractsRepository,
-            networkPreference = networkPreference,
-            makeContractTransport = { url ->
-                OkHttpSepContractTransport(httpClient = httpClient, endpointUrl = url)
-            },
+        // Cache + retry around the raw relayer reads. Without this, every
+        // relay reconnect replays the full inbox and each replayed
+        // group-state message fired its own `get_commitment`, storming the
+        // relayer into throttling fresh joins. The raw reader stays
+        // cache-free; the decorator is the single place trading a little
+        // staleness for far fewer relayer calls. See [CachingChainStateReader].
+        val chainStateReader = app.onym.android.chain.CachingChainStateReader(
+            inner = app.onym.android.chain.SepContractChainStateReader(
+                relayers = relayerRepository,
+                contracts = contractsRepository,
+                networkPreference = networkPreference,
+                makeContractTransport = { url ->
+                    OkHttpSepContractTransport(httpClient = httpClient, endpointUrl = url)
+                },
+            ),
         )
         // PR 158: invitee-side push invitations. The dispatcher records
         // decoded GroupInviteOfferPayloads here (never materializing a

--- a/app/src/main/kotlin/app/onym/android/chain/CachingChainStateReader.kt
+++ b/app/src/main/kotlin/app/onym/android/chain/CachingChainStateReader.kt
@@ -1,0 +1,76 @@
+package app.onym.android.chain
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Wraps a [ChainStateReading] with two defenses against the launch-time
+ * `get_commitment` request storm and the relayer throttling it triggers:
+ *
+ *  1. **Bounded retry** — a single transient read failure (relayer 429 /
+ *     network blip) no longer surfaces as "couldn't verify". We retry a
+ *     few times with linear backoff before giving up, so a momentarily
+ *     throttled relayer doesn't make a fresh join silently fail.
+ *  2. **Short TTL cache** — collapses a burst of reads for the *same*
+ *     group (e.g. an invitation plus several member announcements
+ *     replayed together on a relay reconnect) into one round-trip.
+ *
+ * The TTL is deliberately short: a stale entry can only ever make a
+ * caller see an older `(commitment, epoch)`, which the dispatcher treats
+ * as "chain behind → defer + retry" (never a reject), so staleness
+ * self-heals once the entry expires. It is therefore safe to cache
+ * without risking a false rejection — the worst case is a brief deferral.
+ *
+ * [SepContractChainStateReader] itself stays cache-free (chain state is
+ * the source of truth); this decorator is the single place that trades a
+ * little staleness for far fewer relayer calls.
+ *
+ * Mirrors `CachingChainStateReader` from onym-ios PR #169.
+ */
+class CachingChainStateReader(
+    private val inner: ChainStateReading,
+    private val ttlMillis: Long = 10_000,
+    maxAttempts: Int = 3,
+    private val baseRetryDelayMillis: Long = 300,
+    private val now: () -> Long = { System.currentTimeMillis() },
+) : ChainStateReading {
+
+    private val maxAttempts: Int = maxOf(1, maxAttempts)
+    private val mutex = Mutex()
+    /** Keyed by group-id hex — `ByteArray` has identity equality, so it's
+     *  unusable as a map key directly. */
+    private val cache = HashMap<String, CacheEntry>()
+
+    private data class CacheEntry(val entry: SepCommitmentEntry, val at: Long)
+
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry {
+        val key = groupId.toHexLowercase()
+
+        mutex.withLock {
+            val hit = cache[key]
+            if (hit != null && now() - hit.at < ttlMillis) return hit.entry
+        }
+
+        var lastError: Throwable? = null
+        for (attempt in 0 until maxAttempts) {
+            try {
+                val entry = inner.tyrannyCommitment(groupId)
+                mutex.withLock { cache[key] = CacheEntry(entry, now()) }
+                return entry
+            } catch (e: Throwable) {
+                lastError = e
+                // Linear backoff between attempts; no sleep after the last.
+                if (attempt < maxAttempts - 1 && baseRetryDelayMillis > 0) {
+                    delay(baseRetryDelayMillis * (attempt + 1))
+                }
+            }
+        }
+        throw lastError ?: ChainReadError.NoActiveRelayer
+    }
+
+    private companion object {
+        private fun ByteArray.toHexLowercase(): String =
+            buildString(size * 2) { for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF)) }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -388,6 +388,16 @@ class IncomingMessageDispatcher(
             it.groupIdBytes.contentEquals(payload.groupId)
         } ?: return
 
+        // Dedup BEFORE any chain read. The dedup key is BLS pubkey hex,
+        // mirroring the producer-side dictionary key in
+        // `JoinRequestApprover`. Every relay reconnect replays the full
+        // inbox, so an already-applied announcement is re-delivered on
+        // each launch — bailing here keeps those replays from each firing
+        // a `get_commitment` against the relayer (the launch-time storm).
+        // Cheap, local, and idempotent.
+        val key = payload.newMember.blsPub.toHexLowercase()
+        if (group.memberProfiles[key] != null) return  // dedup
+
         // PR 84 trust check: announcement must be signed by the
         // group's known admin. Skipped (best-effort) when the group
         // has no stored admin Ed25519 — happens for governance
@@ -407,8 +417,6 @@ class IncomingMessageDispatcher(
         // commitment. The chain has the truth.
         if (!verifyTyrannyAnnouncement(payload, group)) return
 
-        val key = payload.newMember.blsPub.toHexLowercase()
-        if (group.memberProfiles[key] != null) return  // dedup
         val updated = group.copy(
             memberProfiles = group.memberProfiles + (key to MemberProfile(
                 alias = payload.newMember.alias,
@@ -613,11 +621,36 @@ class IncomingMessageDispatcher(
             return TyrannyInvitationVerification.REJECT
         }
         if (!recomputed.contentEquals(claimed)) return TyrannyInvitationVerification.REJECT
+
+        // Skip the chain read when we've already verified+materialized
+        // this exact (commitment, epoch). Re-confirming what we confirmed
+        // on a prior pass adds nothing — the recompute above already
+        // rejects a replay that swaps the roster while reusing the
+        // commitment (Poseidon would have to collide). This is the
+        // load-bearing fix for the launch-time `get_commitment` storm:
+        // every relay reconnect replays the full inbox, and without this
+        // each replayed invitation re-hit the relayer, tripping its rate
+        // limit and making fresh joins fail until the burst subsided.
+        val existing = groupRepository.snapshots.value.firstOrNull {
+            it.groupIdBytes.contentEquals(invitation.groupId)
+        }
+        if (existing?.commitment?.contentEquals(claimed) == true &&
+            existing.epoch == invitation.epoch
+        ) {
+            return TyrannyInvitationVerification.VERIFIED
+        }
+
         // Verify at current chain state (Option 2). The chain stores only
         // the LATEST (commitment, epoch), so a snapshot is only
         // byte-verifiable when the chain is exactly at its epoch.
-        //   - chain behind the snapshot → impossible for a real anchored
-        //     snapshot; reject.
+        //   - chain BEHIND the snapshot → our read is lagging the admin's
+        //     just-landed `update_commitment` (relayer/indexer catch-up),
+        //     OR a self-consistent forgery claiming a future epoch. We
+        //     can't tell here, so defer + ask the admin rather than
+        //     reject: deferral never materializes without a later exact-
+        //     epoch match, so a forgery still can't get in, while a real
+        //     lagging read recovers. (Previously a hard reject — the root
+        //     cause of "joiner only sees the chat after a restart".)
         //   - chain EXACTLY at the snapshot's epoch → byte-verify the
         //     committed roster. Strong anti-forgery: reproducing
         //     `Poseidon(Poseidon(root, epoch), salt)` needs the random
@@ -629,9 +662,14 @@ class IncomingMessageDispatcher(
         val onchain = try {
             reader.tyrannyCommitment(invitation.groupId)
         } catch (_: Throwable) {
-            return TyrannyInvitationVerification.REJECT
+            // Couldn't reach / read the relayer (throttled, offline, or
+            // unconfigured). NOT evidence of forgery — never reject. Defer
+            // so the verifier retries via the admin-refresh path and the
+            // group materializes once the read succeeds, instead of being
+            // silently dropped until the next relay replay (a restart).
+            return TyrannyInvitationVerification.STALE_NEEDS_REFRESH
         }
-        if (onchain.epoch < invitation.epoch) return TyrannyInvitationVerification.REJECT
+        if (onchain.epoch < invitation.epoch) return TyrannyInvitationVerification.STALE_NEEDS_REFRESH
         if (onchain.epoch == invitation.epoch) {
             return if (onchain.commitment.contentEquals(claimed)) {
                 TyrannyInvitationVerification.VERIFIED
@@ -648,9 +686,14 @@ class IncomingMessageDispatcher(
          *  an exact epoch — safe to materialize. */
         VERIFIED,
 
-        /** Internally consistent and the group exists on chain, but the
-         *  chain has advanced past the snapshot's epoch, so it can't be
-         *  byte-verified. Needs a current-state refresh from the admin. */
+        /** Internally consistent, but we couldn't byte-verify against the
+         *  chain *right now* — the chain advanced past the snapshot, OR
+         *  our read lagged behind it, OR the relayer read failed
+         *  (throttled / offline / unconfigured). None of these is
+         *  evidence of forgery, so we defer and ask the admin for the
+         *  current state rather than dropping. Deferral never materializes
+         *  a group without a later exact-epoch on-chain match, so forgery
+         *  protection is intact. */
         STALE_NEEDS_REFRESH,
 
         /** Forged / unverifiable — drop. */

--- a/app/src/test/kotlin/app/onym/android/chain/CachingChainStateReaderTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chain/CachingChainStateReaderTest.kt
@@ -1,0 +1,119 @@
+package app.onym.android.chain
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Tests for the cache + retry decorator that tames the launch-time
+ * `get_commitment` storm and survives transient relayer throttling.
+ *
+ * Mirrors `CachingChainStateReaderTests` from onym-ios PR #169.
+ */
+class CachingChainStateReaderTest {
+
+    private val groupId = ByteArray(32) { 0x42 }
+
+    @Test
+    fun cacheHit_collapsesRepeatReadsWithinTtl() = runTest {
+        val inner = CountingChainState().apply { setResult(Result.success(entry(epoch = 3uL))) }
+        val reader = CachingChainStateReader(inner = inner, ttlMillis = 60_000, baseRetryDelayMillis = 0)
+
+        reader.tyrannyCommitment(groupId)
+        reader.tyrannyCommitment(groupId)
+
+        assertEquals("second read within TTL is served from cache", 1, inner.callCount)
+    }
+
+    @Test
+    fun cacheExpiry_readsAgainAfterTtl() = runTest {
+        val inner = CountingChainState().apply { setResult(Result.success(entry(epoch = 3uL))) }
+        // Clock the reader off a controllable now() so we can step past TTL.
+        var clock = 1_000_000L
+        val reader = CachingChainStateReader(
+            inner = inner,
+            ttlMillis = 10_000,
+            baseRetryDelayMillis = 0,
+            now = { clock },
+        )
+
+        reader.tyrannyCommitment(groupId)
+        clock += 11_000  // past the 10s TTL
+        reader.tyrannyCommitment(groupId)
+
+        assertEquals("an expired cache entry triggers a fresh read", 2, inner.callCount)
+    }
+
+    @Test
+    fun retry_recoversFromTransientFailure() = runTest {
+        val inner = CountingChainState().apply {
+            // Throw twice, then succeed — within the 3-attempt budget.
+            setSequence(
+                listOf(
+                    Result.failure(ChainReadError.NoActiveRelayer),
+                    Result.failure(ChainReadError.NoActiveRelayer),
+                    Result.success(entry(epoch = 7uL)),
+                ),
+            )
+        }
+        val reader = CachingChainStateReader(
+            inner = inner,
+            ttlMillis = 10_000,
+            maxAttempts = 3,
+            baseRetryDelayMillis = 0,
+        )
+
+        val result = reader.tyrannyCommitment(groupId)
+
+        assertEquals("retry rides out two transient failures", 7uL, result.epoch)
+        assertEquals(3, inner.callCount)
+    }
+
+    @Test
+    fun retry_exhausted_rethrows() = runTest {
+        val inner = CountingChainState().apply {
+            setResult(Result.failure(ChainReadError.NoContractBinding))
+        }
+        val reader = CachingChainStateReader(
+            inner = inner,
+            ttlMillis = 10_000,
+            maxAttempts = 3,
+            baseRetryDelayMillis = 0,
+        )
+
+        try {
+            reader.tyrannyCommitment(groupId)
+            fail("should have thrown after exhausting retries")
+        } catch (e: Throwable) {
+            assertTrue(e is ChainReadError.NoContractBinding)
+        }
+        assertEquals("all attempts are spent before giving up", 3, inner.callCount)
+    }
+
+    private fun entry(epoch: ULong) = SepCommitmentEntry(
+        commitment = ByteArray(32) { 0xCC.toByte() },
+        epoch = epoch,
+    )
+}
+
+/**
+ * Inner reader that counts calls and yields a configurable result (fixed
+ * or a per-call sequence).
+ */
+private class CountingChainState : ChainStateReading {
+    var callCount = 0
+        private set
+    private var fixed: Result<SepCommitmentEntry> = Result.failure(ChainReadError.NoActiveRelayer)
+    private var sequence: ArrayDeque<Result<SepCommitmentEntry>> = ArrayDeque()
+
+    fun setResult(result: Result<SepCommitmentEntry>) { fixed = result }
+    fun setSequence(results: List<Result<SepCommitmentEntry>>) { sequence = ArrayDeque(results) }
+
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry {
+        callCount += 1
+        val next = if (sequence.isNotEmpty()) sequence.removeFirst() else fixed
+        return next.getOrThrow()
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherTest.kt
@@ -505,6 +505,62 @@ class IncomingMessageDispatcherTest {
         )
     }
 
+    @Test
+    fun announcement_tyranny_knownMember_skipsChainRead() = runTest {
+        // The launch-time storm fix: a re-delivered announcement for a
+        // member we already have must dedup BEFORE the chain read, so
+        // inbox replays don't each fire a `get_commitment`.
+        val storedAdmin = ByteArray(32) { 0x10 }
+        val storedAdminHex = storedAdmin.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        val bobKey = newMemberBlsPub.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+        groupStore.replaceForTest(
+            makeGroup(groupId).copy(
+                adminEd25519PubkeyHex = storedAdminHex,
+                memberProfiles = mapOf(
+                    bobKey to MemberProfile(
+                        alias = "Bob",
+                        inboxPublicKey = newMemberInbox,
+                        sendingPubkey = ByteArray(32) { 0x77 },
+                    ),
+                ),
+            ),
+        )
+        groupRepository.reload()
+
+        val payload = MemberAnnouncementPayload(
+            version = 1,
+            groupId = groupId,
+            newMember = MemberAnnouncementPayload.AnnouncedMember(
+                blsPub = newMemberBlsPub,
+                inboxPub = newMemberInbox,
+                alias = "Bob",
+                sendingPub = ByteArray(32) { 0x77 },
+            ),
+            adminAlias = "Alice",
+            commitment = ByteArray(32) { 0x01 },
+            epoch = 0uL,
+        )
+        val plaintext = Json.encodeToString(MemberAnnouncementPayload.serializer(), payload)
+            .toByteArray(Charsets.UTF_8)
+        val countingChain = CountingChainState(
+            SepCommitmentEntry(commitment = ByteArray(32) { 0x01 }, epoch = 0uL),
+        )
+        val dispatcher = IncomingMessageDispatcher(
+            envelopeDecrypter = StubDecrypter(plaintext, senderPub = storedAdmin),
+            groupRepository = groupRepository,
+            invitationsRepository = invitationsRepository,
+            chainState = countingChain,
+        )
+
+        dispatcher.dispatch("m1", ownerIdentity, byteArrayOf(), Instant.EPOCH)
+
+        assertEquals(
+            "known-member announcement must dedup before reading the chain",
+            0,
+            countingChain.callCount,
+        )
+    }
+
     private fun announcementPayload() = MemberAnnouncementPayload(
         version = 1,
         groupId = groupId,
@@ -608,6 +664,17 @@ private class SpyPendingInvites : PendingInvitesRecording {
 
 private class FakeChainState(private val entry: SepCommitmentEntry) : ChainStateReading {
     override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry = entry
+}
+
+/** Records how many times the chain was read — for asserting dedup
+ *  short-circuits never reach the relayer. */
+private class CountingChainState(private val entry: SepCommitmentEntry) : ChainStateReading {
+    var callCount = 0
+        private set
+    override suspend fun tyrannyCommitment(groupId: ByteArray): SepCommitmentEntry {
+        callCount += 1
+        return entry
+    }
 }
 
 private class SpyGroupStateRefresher : GroupStateRefreshing {


### PR DESCRIPTION
Ports iOS PR onymchat/onym-ios#169 to Android. The Kotlin receive-side had the same bug.

## Symptom
A joiner who scans/taps an invite and is approved often **doesn't see the group live** — it only appears after an app restart. The invitation arrives and persists fine (hence restart works); the live materialization is being dropped.

## Root cause (relayer-side, not transport)
- Inbox (Nostr) subscriptions use **no `since` filter** (`NostrInboxTransport.subscriptionFilters`), so every relay reconnect replays the **entire inbox history**.
- The dispatcher did an **uncached `get_commitment`** per replayed Tyranny group-state message (`verifyTyrannyInvitation`, `verifyTyrannyAnnouncement`) — and **before any dedup** (`applyAnnouncement`'s member-key check ran *after* the chain read).
- That self-inflicted burst **throttled the relayer**. A throttled/lagging read was then treated as a **hard reject**, silently dropping the very invitation being verified.
- The same hard-reject hit a legitimate **chain-behind** read: the admin anchors epoch N then immediately sends the snapshot; the joiner's relayer read still lags at N-1 → `onchain.epoch < snapshot.epoch` → reject + drop.

## Fixes (mirror the four in the iOS PR)
1. **Skip the chain read when already locally verified.** `verifyTyrannyInvitation` returns `VERIFIED` without a relayer call if a group with the exact `(commitment, epoch)` is already materialized. The local Poseidon recompute still runs **first**, so a replay that swaps the roster while reusing the commitment is still rejected. This removes nearly all of the startup reads.
2. **Dedup announcements before the chain read.** Moved the BLS-pubkey-hex dedup in `applyAnnouncement` *above* `verifyTyrannyAnnouncement`, so re-delivered known members don't each hit the relayer.
3. **Throttle/lag ⇒ defer, not reject.** A chain-read throw (throttled/offline/unconfigured) and a chain-behind read now return `STALE_NEEDS_REFRESH` (defer + admin-refresh retry via `GroupStateVerifier.deferVerification`) instead of `REJECT`. **Deferral never materializes without a later exact-epoch chain match**, so forgery protection is unchanged — only the false-drop is fixed.
4. **`CachingChainStateReader`** — bounded retry (linear backoff) + short (10s) TTL cache around the raw relayer reads, wired in `OnymApplication`. `SepContractChainStateReader` stays cache-free. A stale cache entry can only ever cause a brief *deferral* (never a false reject, given #3), so caching is safe here.

## Why it's safe (security)
The only `REJECT` paths that remain are genuine cryptographic failures: **missing commitment**, **internal recompute mismatch**, and **commitment mismatch at an exact epoch**. All "couldn't verify *right now*" cases defer and re-verify, and never materialize a group without an exact-epoch on-chain match.

## Test plan
**JVM unit tests (run, green):**
- `CachingChainStateReaderTest` — cache hit within TTL (inner called once), expiry (called again), retry recovers from N transient failures, retry exhausted rethrows.
- `IncomingMessageDispatcherTest.announcement_tyranny_knownMember_skipsChainRead` — known-member announcement replay → chain reader called **0** times.
- All pre-existing dispatcher reject/materialize/converge-forward tests still green.

**FFI tests (compile clean; require an emulator/device to run, like all `*FfiTest`):** added to `IncomingMessageDispatcherConvergeForwardFfiTest` (real Poseidon recompute needs the native `.so`):
- redelivered already-verified invitation → chain reader called **exactly once** across two deliveries.
- chain-read throw → **defers** (SpyRefresher records the groupId), does not materialize.
- chain-behind → **defers**, does not materialize.
- existing exact-epoch-materializes and chain-ahead-defers tests unchanged.

```
./gradlew :app:testDebugUnitTest           # green
./gradlew :app:compileDebugAndroidTestKotlin  # green
```

## Follow-up (not in this PR)
Cap the Nostr replay itself — a `since` / processed-event high-water-mark on the inbox subscription — to cut inbound bandwidth. This PR targets the **relayer RPM**, which was the harmful part (the throttling that dropped joins). The replay cap is a bandwidth optimization on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
