### PR TITLE
feat(chat): message replies — swipe to reply, inset quote, tap to jump

### DIFF
--- a/app/src/main/kotlin/app/onym/android/AppDependencies.kt
+++ b/app/src/main/kotlin/app/onym/android/AppDependencies.kt
@@ -42,6 +42,9 @@ class AppDependencies(
     /** App-wide testnet/mainnet preference. Settings exposes a Switch
      *  bound to this; CreateGroupInteractor reads it per call. */
     val networkPreferenceProvider: NetworkPreferenceProvider,
+    /** Symmetric read-receipt setting, bound to the Settings → Chat
+     *  toggle and read by the dispatcher + chat thread. */
+    val readReceiptsPreferenceProvider: app.onym.android.chats.ReadReceiptsPreferenceProvider,
     val makeCreateGroupViewModel: () -> CreateGroupViewModel,
     /** Chats tab — read-only view over [app.onym.android.group.GroupRepository.snapshots].
      *  Mirrors `makeChatsFlow` from onym-ios PR #30. */

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -323,6 +323,9 @@ class OnymApplication : Application() {
                 app.onym.android.chats.MessageDatabase::class.java,
                 "app.onym.android.messages",
             )
+                .addMigrations(
+                    app.onym.android.chats.MessageDatabaseMigrations.MIGRATION_1_2,
+                )
                 .fallbackToDestructiveMigration()
                 .build()
         } catch (_: Throwable) {
@@ -670,7 +673,9 @@ class OnymApplication : Application() {
                     groupId = groupId,
                     groupRepository = groupRepository,
                     messageRepository = messageRepository,
-                    sendMessage = sender::send,
+                    sendMessage = { gid, body, replyTo ->
+                        sender.send(gid, body, replyTo)
+                    },
                     retryMessage = sender::retry,
                 )
             },

--- a/app/src/main/kotlin/app/onym/android/OnymApplication.kt
+++ b/app/src/main/kotlin/app/onym/android/OnymApplication.kt
@@ -90,6 +90,15 @@ private val Context.nostrRelaysDataStore: DataStore<Preferences> by preferencesD
 )
 
 /**
+ * DataStore Preferences for chat settings (the symmetric read-receipt
+ * toggle). Separate file so it doesn't touch the network / relay
+ * domains.
+ */
+private val Context.chatPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "app.onym.android.chat_prefs",
+)
+
+/**
  * Composition root. Two responsibilities:
  *
  *  - Register the BouncyCastle JCE provider once at process start
@@ -346,6 +355,9 @@ class OnymApplication : Application() {
 
         // App-wide network preference (PR-C follow-up). Constructed
         // here (early) so PR-89's chainStateReader can read it.
+        val readReceiptsPreference = app.onym.android.chats.DataStoreReadReceiptsPreferenceProvider(
+            dataStore = applicationContext.chatPreferencesDataStore,
+        )
         val networkPreference = DataStoreNetworkPreferenceProvider(
             dataStore = applicationContext.networkPreferenceDataStore,
         )
@@ -446,6 +458,12 @@ class OnymApplication : Application() {
         // Resolve a pending verification the moment its fresh snapshot
         // materializes its group (and cancel the timeout).
         groupStateVerifier.start()
+        val chatReceiptSender = app.onym.android.chats.ChatReceiptSender(
+            activeIdentity = identityRepository,
+            identitiesFlow = identityRepository.identities,
+            envelopeSealer = identityRepository,
+            inboxTransport = inboxTransport,
+        )
         val incomingDispatcher = app.onym.android.inbox.IncomingMessageDispatcher(
             envelopeDecrypter = identityRepository,
             groupRepository = groupRepository,
@@ -455,6 +473,8 @@ class OnymApplication : Application() {
             chainState = chainStateReader,
             pendingInvites = pendingInvitesStore,
             groupStateRefresher = groupStateVerifier,
+            receiptSender = chatReceiptSender,
+            readReceiptsEnabled = { readReceiptsPreference.current() },
         )
         // Filter the invites surface to the active identity, and cascade
         // a wipe on identity removal — mirrors the per-identity wiring
@@ -609,6 +629,7 @@ class OnymApplication : Application() {
                 AnchorsPickerViewModel(repository = contractsRepository)
             },
             networkPreferenceProvider = networkPreference,
+            readReceiptsPreferenceProvider = readReceiptsPreference,
             makeCreateGroupViewModel = {
                 val interactor = CreateGroupInteractor(
                     identity = identityRepository,
@@ -677,6 +698,8 @@ class OnymApplication : Application() {
                         sender.send(gid, body, replyTo)
                     },
                     retryMessage = sender::retry,
+                    chatReceiptSender = chatReceiptSender,
+                    readReceiptsEnabled = { readReceiptsPreference.current() },
                 )
             },
             makeIdentitiesViewModel = {

--- a/app/src/main/kotlin/app/onym/android/RootScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/RootScreen.kt
@@ -267,6 +267,12 @@ fun RootScreen(
                 val networkPref by networkFlow.collectAsStateWithLifecycle(
                     initialValue = dependencies.networkPreferenceProvider.current(),
                 )
+                val readReceiptsFlow = remember(dependencies) {
+                    dependencies.readReceiptsPreferenceProvider.flow
+                }
+                val sendReadReceipts by readReceiptsFlow.collectAsStateWithLifecycle(
+                    initialValue = dependencies.readReceiptsPreferenceProvider.current(),
+                )
                 val coroutineScope = rememberCoroutineScope()
                 val identitiesVm: IdentitiesViewModel = viewModel(
                     factory = viewModelFactory {
@@ -291,6 +297,12 @@ fun RootScreen(
                                 if (on) app.onym.android.chain.AppNetwork.Mainnet
                                 else app.onym.android.chain.AppNetwork.Testnet,
                             )
+                        }
+                    },
+                    sendReadReceipts = sendReadReceipts,
+                    onToggleReadReceipts = { on ->
+                        coroutineScope.launch {
+                            dependencies.readReceiptsPreferenceProvider.set(on)
                         }
                     },
                     onNostrRelaysClick = { navController.navigate(ROUTE_NOSTR_RELAYS) },

--- a/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.Icon
@@ -431,6 +432,7 @@ private fun StatusIndicator(
     val tint = when (visual.tint) {
         ChatStatusTint.Muted -> MaterialTheme.colorScheme.onSurfaceVariant
         ChatStatusTint.Error -> MaterialTheme.colorScheme.error
+        ChatStatusTint.Accent -> MaterialTheme.colorScheme.primary
     }
     Icon(
         imageVector = visual.icon,
@@ -464,6 +466,16 @@ internal fun statusVisualFor(status: MessageStatus): StatusVisual? = when (statu
         tint = ChatStatusTint.Muted,
         contentDescription = "Sent",
     )
+    MessageStatus.DELIVERED -> StatusVisual(
+        icon = Icons.Filled.DoneAll,
+        tint = ChatStatusTint.Muted,
+        contentDescription = "Delivered",
+    )
+    MessageStatus.READ -> StatusVisual(
+        icon = Icons.Filled.DoneAll,
+        tint = ChatStatusTint.Accent,
+        contentDescription = "Read",
+    )
     MessageStatus.FAILED -> StatusVisual(
         icon = Icons.Filled.ErrorOutline,
         tint = ChatStatusTint.Error,
@@ -495,7 +507,7 @@ internal data class StatusVisual(
     val contentDescription: String,
 )
 
-internal enum class ChatStatusTint { Muted, Error }
+internal enum class ChatStatusTint { Muted, Error, Accent }
 
 private val BUBBLE_RADIUS = 16.dp
 private val STATUS_ICON_SIZE = 14.dp

--- a/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatBubble.kt
@@ -1,19 +1,30 @@
 package app.onym.android.chats
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.outlined.Schedule
@@ -21,15 +32,30 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /**
  * Chat-thread bubble. Two visual modes driven by [ChatMessage.direction]:
@@ -80,6 +106,10 @@ fun ChatBubble(
     modifier: Modifier = Modifier,
     maxWidthFraction: Float = 0.75f,
     onRetry: (() -> Unit)? = null,
+    reply: ChatReplyQuote? = null,
+    onQuoteTap: (() -> Unit)? = null,
+    isHighlighted: Boolean = false,
+    onSwipeReply: (() -> Unit)? = null,
 ) {
     val isOutgoing = message.direction == MessageDirection.OUTGOING
     // The Chats tab is Material-themed (no OnymTheme provider), so we
@@ -105,14 +135,89 @@ fun ChatBubble(
     }
     val retryEnabled = canRetry(message) && onRetry != null
 
+    // Drag-to-reply: the row follows the finger leftward (clamped),
+    // a reply glyph grows in at the trailing edge, a one-shot haptic
+    // fires as the drag crosses the threshold, and releasing past the
+    // threshold arms the reply; otherwise everything springs back.
+    // Available on every message regardless of direction or status.
+    // Mirrors `ChatBubbleCell` swipe-to-reply from onym-ios PR #175.
+    val scope = rememberCoroutineScope()
+    val haptic = LocalHapticFeedback.current
+    val density = LocalDensity.current
+    val maxTravelPx = with(density) { SWIPE_MAX_TRAVEL.toPx() }
+    val thresholdPx = with(density) { SWIPE_REPLY_THRESHOLD.toPx() }
+    val dragOffset = remember { Animatable(0f) }
+    var dragAccumulated by remember { mutableFloatStateOf(0f) }
+    var swipeArmed by remember { mutableStateOf(false) }
+
     BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 4.dp),
     ) {
         val bubbleMaxWidth = maxWidth * maxWidthFraction
+        if (onSwipeReply != null) {
+            val progress = (-dragOffset.value / thresholdPx).coerceIn(0f, 1f)
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Reply,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(22.dp)
+                    .graphicsLayer {
+                        alpha = progress
+                        val s = 0.6f + 0.4f * progress
+                        scaleX = s
+                        scaleY = s
+                    },
+            )
+        }
+        val swipeModifier = if (onSwipeReply != null) {
+            Modifier.pointerInput(onSwipeReply) {
+                detectHorizontalDragGestures(
+                    onDragStart = {
+                        dragAccumulated = 0f
+                        swipeArmed = false
+                    },
+                    onDragEnd = {
+                        val fire = swipeArmed
+                        swipeArmed = false
+                        dragAccumulated = 0f
+                        scope.launch {
+                            dragOffset.animateTo(0f, spring(dampingRatio = 0.7f))
+                        }
+                        if (fire) onSwipeReply()
+                    },
+                    onDragCancel = {
+                        swipeArmed = false
+                        dragAccumulated = 0f
+                        scope.launch { dragOffset.animateTo(0f, spring(dampingRatio = 0.7f)) }
+                    },
+                ) { change, dragAmount ->
+                    change.consume()
+                    // Leftward only; clamp travel so the row can't be
+                    // dragged off-screen and the armed point reads as a wall.
+                    dragAccumulated = (dragAccumulated + dragAmount)
+                        .coerceIn(-maxTravelPx, 0f)
+                    scope.launch { dragOffset.snapTo(dragAccumulated) }
+                    val pastThreshold = -dragAccumulated >= thresholdPx
+                    if (pastThreshold && !swipeArmed) {
+                        swipeArmed = true
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    } else if (!pastThreshold) {
+                        swipeArmed = false
+                    }
+                }
+            }
+        } else {
+            Modifier
+        }
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset { IntOffset(dragOffset.value.roundToInt(), 0) }
+                .then(swipeModifier),
             horizontalArrangement = if (isOutgoing) Arrangement.End else Arrangement.Start,
         ) {
             Column(
@@ -144,6 +249,11 @@ fun ChatBubble(
                     textColor = textColor,
                     messageId = message.id,
                     onClick = if (retryEnabled) onRetry else null,
+                    reply = reply,
+                    replyAccentColor = reply?.accent?.color(darkTheme),
+                    isOutgoing = isOutgoing,
+                    isHighlighted = isHighlighted,
+                    onQuoteTap = onQuoteTap,
                 )
                 if (isOutgoing) {
                     val visual = statusVisualFor(message.status)
@@ -166,25 +276,150 @@ private fun BubbleBody(
     textColor: Color,
     messageId: java.util.UUID,
     onClick: (() -> Unit)?,
+    reply: ChatReplyQuote?,
+    replyAccentColor: Color?,
+    isOutgoing: Boolean,
+    isHighlighted: Boolean,
+    onQuoteTap: (() -> Unit)?,
 ) {
+    // Brief background pulse when the host scrolls here from a tapped
+    // quote — blends the fill toward the surface tint and animates
+    // back once the host clears the highlight. Mirrors iOS PR #174's
+    // `flashHighlight()`.
+    val highlightTarget = if (isHighlighted) {
+        lerp(fill, MaterialTheme.colorScheme.onSurface, HIGHLIGHT_BLEND)
+    } else {
+        fill
+    }
+    val animatedFill by animateColorAsState(
+        targetValue = highlightTarget,
+        animationSpec = tween(durationMillis = 220),
+        label = "bubbleHighlight",
+    )
     val baseModifier = Modifier
         .clip(RoundedCornerShape(BUBBLE_RADIUS))
-        .background(fill)
+        .background(animatedFill)
     val clickableModifier = if (onClick != null) {
         baseModifier.clickable(onClick = onClick)
     } else {
         baseModifier
     }
-    Box(
+    Column(
         modifier = clickableModifier
             .padding(horizontal = 12.dp, vertical = 8.dp)
             .testTag("chat_thread.bubble.$messageId"),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
+        if (reply != null) {
+            ReplyQuoteInset(
+                reply = reply,
+                replyAccentColor = replyAccentColor,
+                isOutgoing = isOutgoing,
+                onAccentColor = textColor,
+                messageId = messageId,
+                // Only an available target is worth jumping to.
+                onTap = if (!reply.isUnavailable) onQuoteTap else null,
+            )
+        }
         Text(
             text = body,
             color = textColor,
             style = MaterialTheme.typography.bodyMedium,
         )
+    }
+}
+
+/**
+ * Inset quote pinned across the top of a bubble that replies to
+ * another message: a thin accent bar, the quoted sender's
+ * name, and a one-line snippet of the quoted body.
+ *
+ * Colors track the bubble direction. An outgoing bubble is a solid
+ * accent fill, so the quote reads in the on-accent color
+ * ([onAccentColor]); an incoming bubble is a light tint, so the quote
+ * uses the quoted sender's own accent ([replyAccentColor]). An
+ * [ChatReplyQuote.isUnavailable] target gets a muted, untappable
+ * "Message unavailable" placeholder.
+ *
+ * Mirrors `ChatBubbleCell.applyReplyQuote` from onym-ios PR #174.
+ */
+@Composable
+private fun ReplyQuoteInset(
+    reply: ChatReplyQuote,
+    replyAccentColor: Color?,
+    isOutgoing: Boolean,
+    onAccentColor: Color,
+    messageId: java.util.UUID,
+    onTap: (() -> Unit)?,
+) {
+    val accent = replyAccentColor ?: MaterialTheme.colorScheme.primary
+    val barColor: Color
+    val nameColor: Color
+    val snippetColor: Color
+    val nameText: String
+    val snippetText: String
+    if (reply.isUnavailable) {
+        val muted = if (isOutgoing) {
+            onAccentColor.copy(alpha = 0.7f)
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+        barColor = muted
+        nameColor = muted
+        snippetColor = muted
+        nameText = "Message"
+        snippetText = "Message unavailable"
+    } else {
+        barColor = if (isOutgoing) onAccentColor else accent
+        nameColor = if (isOutgoing) onAccentColor else accent
+        snippetColor = if (isOutgoing) {
+            onAccentColor.copy(alpha = 0.85f)
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+        nameText = reply.name
+        snippetText = reply.snippet
+    }
+
+    val tapModifier = if (onTap != null) {
+        Modifier.clickable(onClick = onTap)
+    } else {
+        Modifier
+    }
+    Row(
+        modifier = Modifier
+            .height(IntrinsicSize.Min)
+            .then(tapModifier)
+            .testTag("chat_thread.quote.$messageId"),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(3.dp)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(barColor),
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+            Text(
+                text = nameText,
+                color = nameColor,
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("chat_thread.quote.name.$messageId"),
+            )
+            Text(
+                text = snippetText,
+                color = snippetColor,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("chat_thread.quote.snippet.$messageId"),
+            )
+        }
     }
 }
 
@@ -264,6 +499,17 @@ internal enum class ChatStatusTint { Muted, Error }
 
 private val BUBBLE_RADIUS = 16.dp
 private val STATUS_ICON_SIZE = 14.dp
+
+/** How far the bubble fill blends toward the surface tint during the
+ *  scroll-to-quote highlight pulse. */
+private const val HIGHLIGHT_BLEND = 0.25f
+
+/** Drag distance past which releasing arms a reply. */
+private val SWIPE_REPLY_THRESHOLD = 56.dp
+
+/** How far the row can travel — past the threshold it resists so the
+ *  gesture has a clear "armed" ceiling. */
+private val SWIPE_MAX_TRAVEL = 72.dp
 
 /** Incoming-bubble tint opacity over the background. Low enough that
  *  the body text stays readable on top, high enough that the sender's

--- a/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatInputPanel.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -61,6 +63,7 @@ fun ChatInputPanel(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     maxLines: Int = MAX_LINES,
+    focusRequester: FocusRequester? = null,
 ) {
     var text by remember { mutableStateOf("") }
     val sendBody = trimmedSendBody(text)
@@ -80,6 +83,13 @@ fun ChatInputPanel(
             modifier = Modifier
                 .weight(1f)
                 .clip(RoundedCornerShape(BUBBLE_CORNER))
+                .then(
+                    if (focusRequester != null) {
+                        Modifier.focusRequester(focusRequester)
+                    } else {
+                        Modifier
+                    },
+                )
                 .testTag("chat_thread.input_field"),
             enabled = enabled,
             placeholder = { Text("Message") },

--- a/app/src/main/kotlin/app/onym/android/chats/ChatMessage.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMessage.kt
@@ -42,5 +42,12 @@ data class ChatMessage(
     val sentAtMillis: Long,
     val direction: MessageDirection,
     val status: MessageStatus,
+    /** The message this one replies to, if any. Mirrors
+     *  [ChatMessagePayload.replyToMessageId]. Only the target ID is
+     *  stored — the UI resolves the quoted sender + body by looking
+     *  this up among the group's other messages at render time, so a
+     *  target that isn't on this device renders as "Message
+     *  unavailable" instead of carrying a stale copy of its text. */
+    val replyToMessageId: UUID? = null,
     val groupType: SepGroupType,
 )

--- a/app/src/main/kotlin/app/onym/android/chats/ChatMessagePayload.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatMessagePayload.kt
@@ -81,6 +81,25 @@ data class ChatMessagePayload(
      *  cross-platform. */
     @SerialName("sent_at_millis")
     val sentAtMillis: Long,
+    /**
+     * The message this one replies to, if any. Optional + additive,
+     * so it ships under `version = 1`: a sender that omits it decodes
+     * to `null` on any receiver (the `= null` default kicks in for a
+     * missing key), and an older receiver decoding a payload that
+     * carries it just ignores the unknown key. Only the target's ID
+     * travels — the receiver resolves the quoted sender + body from
+     * its own local store at render time, so a dangling ref (target
+     * never delivered) degrades to "message unavailable" rather than
+     * carrying stale text.
+     *
+     * Wire key is snake_case `reply_to_message_id`; the value is the
+     * uppercase canonical UUID string (same encoding as [messageId])
+     * or `null`. Matches `ChatMessagePayload.replyToMessageID` from
+     * onym-ios PR #173.
+     */
+    @SerialName("reply_to_message_id")
+    @Serializable(with = UuidStringSerializer::class)
+    val replyToMessageId: UUID? = null,
     val variant: ChatMessageVariant,
 ) {
     override fun equals(other: Any?): Boolean {
@@ -91,6 +110,7 @@ data class ChatMessagePayload(
             groupId.contentEquals(other.groupId) &&
             senderBlsPubkeyHex == other.senderBlsPubkeyHex &&
             sentAtMillis == other.sentAtMillis &&
+            replyToMessageId == other.replyToMessageId &&
             variant == other.variant
     }
 
@@ -100,6 +120,7 @@ data class ChatMessagePayload(
         h = 31 * h + groupId.contentHashCode()
         h = 31 * h + senderBlsPubkeyHex.hashCode()
         h = 31 * h + sentAtMillis.hashCode()
+        h = 31 * h + replyToMessageId.hashCode()
         h = 31 * h + variant.hashCode()
         return h
     }

--- a/app/src/main/kotlin/app/onym/android/chats/ChatReceiptPayload.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatReceiptPayload.kt
@@ -1,0 +1,76 @@
+package app.onym.android.chats
+
+import app.onym.android.identity.Base64ByteArraySerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+/**
+ * Delivery / read receipt sent back to a message's original sender.
+ * Sealed + shipped over the same [app.onym.android.transport.InboxTransport]
+ * path as [ChatMessagePayload], addressed to the sender's inbox key.
+ *
+ * The receiver of a chat message emits [Kind.DELIVERED] as soon as it
+ * persists the message; it emits [Kind.READ] when the user opens the
+ * thread (gated by the symmetric read-receipt setting). The original
+ * sender decodes this and *raises* the matching outgoing message's
+ * status — receipts never downgrade (see [MessageStatus.deliveryRank]).
+ *
+ * Wire-format disjoint from every other inbox payload: the required
+ * `kind` + `message_ids` keys appear in no other type, and it carries
+ * neither [ChatMessagePayload]'s `variant`/`message_id` nor the invite
+ * payloads' fields, so the dispatcher's trial-decode fast-paths can't
+ * cross-match it (even under `ignoreUnknownKeys`).
+ *
+ * Byte-compatible with `ChatReceiptPayload.swift` on onym-ios:
+ *  - `group_id` is base64 (matching iOS `Data`),
+ *  - `message_ids` are uppercase canonical UUID strings,
+ *  - `kind` is `"delivered"` / `"read"`.
+ */
+@Serializable
+data class ChatReceiptPayload(
+    val version: Int,
+    @SerialName("group_id")
+    @Serializable(with = Base64ByteArraySerializer::class)
+    val groupId: ByteArray,
+    /** BLS pubkey hex of the party emitting the receipt (the recipient
+     *  of the original message). Informational under v1 — any
+     *  recipient's receipt raises the sender's status — but recorded so
+     *  per-member delivered/read tracking can land later without a wire
+     *  bump. */
+    @SerialName("sender_bls_pubkey_hex")
+    val senderBlsPubkeyHex: String,
+    val kind: Kind,
+    /** Messages being acknowledged. Batched so opening a thread with
+     *  many unread messages ships one receipt, not one per message. */
+    @SerialName("message_ids")
+    val messageIds: List<@Serializable(with = UuidStringSerializer::class) UUID>,
+) {
+    @Serializable
+    enum class Kind {
+        @SerialName("delivered")
+        DELIVERED,
+
+        @SerialName("read")
+        READ,
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ChatReceiptPayload) return false
+        return version == other.version &&
+            groupId.contentEquals(other.groupId) &&
+            senderBlsPubkeyHex == other.senderBlsPubkeyHex &&
+            kind == other.kind &&
+            messageIds == other.messageIds
+    }
+
+    override fun hashCode(): Int {
+        var h = version
+        h = 31 * h + groupId.contentHashCode()
+        h = 31 * h + senderBlsPubkeyHex.hashCode()
+        h = 31 * h + kind.hashCode()
+        h = 31 * h + messageIds.hashCode()
+        return h
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatReceiptSender.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatReceiptSender.kt
@@ -1,0 +1,95 @@
+package app.onym.android.chats
+
+import app.onym.android.identity.ActiveIdentityProvider
+import app.onym.android.identity.IdentityRepository
+import app.onym.android.identity.IdentitySummary
+import app.onym.android.identity.InvitationEnvelopeSealer
+import app.onym.android.transport.InboxTransport
+import app.onym.android.transport.TransportInboxId
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.util.UUID
+
+/**
+ * Seals + ships [ChatReceiptPayload]s back to a message's sender.
+ * Used by the dispatcher (delivered receipts on receive) and the chat
+ * thread (read receipts on view). Best-effort: a failed seal or send
+ * is swallowed — a missing receipt only costs a check mark, never
+ * correctness.
+ *
+ * Mirrors `ChatReceiptSender.swift` from onym-ios.
+ */
+interface ChatReceiptSending {
+    suspend fun send(
+        kind: ChatReceiptPayload.Kind,
+        messageIds: List<UUID>,
+        groupId: ByteArray,
+        recipientInboxKey: ByteArray,
+    )
+}
+
+/** Default no-op so dispatcher / VM test constructions that don't
+ *  exercise receipts can leave it unset. */
+class NoopChatReceiptSender : ChatReceiptSending {
+    override suspend fun send(
+        kind: ChatReceiptPayload.Kind,
+        messageIds: List<UUID>,
+        groupId: ByteArray,
+        recipientInboxKey: ByteArray,
+    ) = Unit
+}
+
+class ChatReceiptSender(
+    private val activeIdentity: ActiveIdentityProvider,
+    private val identitiesFlow: StateFlow<List<IdentitySummary>>,
+    private val envelopeSealer: InvitationEnvelopeSealer,
+    private val inboxTransport: InboxTransport,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ChatReceiptSending {
+
+    override suspend fun send(
+        kind: ChatReceiptPayload.Kind,
+        messageIds: List<UUID>,
+        groupId: ByteArray,
+        recipientInboxKey: ByteArray,
+    ) = withContext(ioDispatcher) {
+        if (messageIds.isEmpty()) return@withContext
+        val activeId = activeIdentity.currentIdentityId.value ?: return@withContext
+        val me = identitiesFlow.value.firstOrNull { it.id == activeId } ?: return@withContext
+        val payload = ChatReceiptPayload(
+            version = 1,
+            groupId = groupId,
+            senderBlsPubkeyHex = me.blsPublicKey.toHexLowercase(),
+            kind = kind,
+            messageIds = messageIds,
+        )
+        val bytes = try {
+            jsonFormat.encodeToString(ChatReceiptPayload.serializer(), payload)
+                .toByteArray(Charsets.UTF_8)
+        } catch (_: Throwable) {
+            return@withContext
+        }
+        val sealed = try {
+            envelopeSealer.sealInvitation(bytes, recipientInboxKey)
+        } catch (_: Throwable) {
+            return@withContext
+        }
+        val tag = TransportInboxId(IdentityRepository.inboxTag(recipientInboxKey))
+        try {
+            inboxTransport.send(sealed, tag)
+        } catch (_: Throwable) {
+            // best-effort
+        }
+    }
+
+    private companion object {
+        private val jsonFormat = Json { encodeDefaults = true }
+
+        fun ByteArray.toHexLowercase(): String = buildString(size * 2) {
+            for (b in this@toHexLowercase) append("%02x".format(b.toInt() and 0xFF))
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatReplyBanner.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatReplyBanner.kt
@@ -1,0 +1,95 @@
+package app.onym.android.chats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+/**
+ * "Replying to {name}" banner shown above the composer while a reply
+ * is armed: an accent bar, the title, a one-line snippet of the
+ * quoted body, and a cancel button. The [accent] colors the bar +
+ * title so the banner matches the bubble's quote.
+ *
+ * Mirrors `ChatInputPanelView`'s reply banner from onym-ios PR #175.
+ */
+@Composable
+fun ChatReplyBanner(
+    name: String,
+    snippet: String,
+    accent: Color,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(start = 12.dp, top = 6.dp, bottom = 6.dp, end = 4.dp)
+            .testTag("chat_thread.reply_banner"),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(3.dp)
+                .height(36.dp)
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(accent),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(1.dp),
+        ) {
+            Text(
+                text = "Replying to $name",
+                color = accent,
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("chat_thread.reply_banner.title"),
+            )
+            Text(
+                text = snippet,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.testTag("chat_thread.reply_banner.snippet"),
+            )
+        }
+        IconButton(
+            onClick = onCancel,
+            modifier = Modifier.testTag("chat_thread.reply_banner.cancel"),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Cancel reply",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatReplyQuote.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatReplyQuote.kt
@@ -1,0 +1,94 @@
+package app.onym.android.chats
+
+import app.onym.android.group.MemberProfile
+import app.onym.android.group.OnymAccent
+import java.util.UUID
+
+/**
+ * Resolved quote shown at the top of a bubble that replies to an
+ * earlier message — the inset preview. Built by the chat thread
+ * screen by looking the reply target up in the loaded
+ * message list; [ChatBubble] just renders it.
+ *
+ * The target is resolved *live* (not snapshotted into the payload,
+ * per onym-ios PR #173), so when it isn't on this device the screen
+ * hands over [Unavailable] and the bubble renders a muted placeholder
+ * instead of a real sender + snippet.
+ *
+ * Mirrors `ChatReplyQuote` from onym-ios PR #174.
+ */
+data class ChatReplyQuote(
+    /** Quoted sender's display name (alias or BLS fingerprint). */
+    val name: String,
+    /** Quoted message body, rendered on a single truncated line. */
+    val snippet: String,
+    /** Quoted sender's accent — colors the leading bar and the name,
+     *  so the quote reads as "from that person" at a glance. */
+    val accent: OnymAccent,
+    /** The reply target isn't in the local store (never delivered, or
+     *  deleted). Renders a muted "Message unavailable" placeholder and
+     *  the quote isn't tappable. */
+    val isUnavailable: Boolean,
+) {
+    companion object {
+        /** Placeholder for a reply whose target this device doesn't
+         *  have. */
+        val Unavailable = ChatReplyQuote(
+            name = "",
+            snippet = "",
+            accent = OnymAccent.Blue,
+            isUnavailable = true,
+        )
+    }
+}
+
+/**
+ * Resolve the reply quote for one [message], if it replies to another.
+ * The target is looked up *live* in [messagesById] (the current
+ * thread snapshot, keyed by [ChatMessage.id]):
+ *   - found → quote carries the target's sender name + accent + the
+ *     target body as a one-line snippet;
+ *   - not on this device (never delivered / deleted) →
+ *     [ChatReplyQuote.Unavailable] placeholder.
+ * Returns `null` for a non-reply message.
+ *
+ * Pure function — the screen calls it inside a `remember(...)` and
+ * feeds the result to each bubble, so a unit test exercises the
+ * resolution policy without standing up Compose. Mirrors
+ * `ChatThreadViewController.replyQuote(for:)` from onym-ios PR #174;
+ * on iOS the controller owns this, on Android the screen does.
+ */
+internal fun resolveReplyQuote(
+    message: ChatMessage,
+    messagesById: Map<UUID, ChatMessage>,
+    memberProfiles: Map<String, MemberProfile>,
+): ChatReplyQuote? {
+    val targetId = message.replyToMessageId ?: return null
+    val target = messagesById[targetId] ?: return ChatReplyQuote.Unavailable
+    return ChatReplyQuote(
+        name = senderName(target.senderBlsPubkeyHex, memberProfiles),
+        snippet = target.body,
+        accent = OnymAccent.forSender(target.senderBlsPubkeyHex),
+        isUnavailable = false,
+    )
+}
+
+/**
+ * Build the per-message reply quote map over [messages] + the group's
+ * [memberProfiles]. Only reply messages get an entry; non-replies are
+ * absent (the bubble shows no quote). Pure function so the screen can
+ * `remember(messages, memberProfiles)` it alongside the sender
+ * displays. Mirrors [buildSenderDisplays].
+ */
+internal fun buildReplyQuotes(
+    messages: List<ChatMessage>,
+    memberProfiles: Map<String, MemberProfile>,
+): Map<UUID, ChatReplyQuote> {
+    val byId = messages.associateBy { it.id }
+    val out = HashMap<UUID, ChatReplyQuote>()
+    for (message in messages) {
+        val quote = resolveReplyQuote(message, byId, memberProfiles) ?: continue
+        out[message.id] = quote
+    }
+    return out
+}

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadScreen.kt
@@ -1,5 +1,6 @@
 package app.onym.android.chats
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -30,15 +31,19 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.onym.android.group.MemberProfile
+import app.onym.android.group.OnymAccent
+import kotlinx.coroutines.launch
 
 /**
  * Compose chat-thread screen. Tapping a group in the Chats tab
@@ -68,6 +73,7 @@ fun ChatThreadScreen(
 ) {
     val group by viewModel.group.collectAsStateWithLifecycle()
     val messages by viewModel.messages.collectAsStateWithLifecycle()
+    val replyingTo by viewModel.replyingTo.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -118,6 +124,9 @@ fun ChatThreadScreen(
                 padding = padding,
                 onSend = viewModel::send,
                 onRetry = viewModel::retry,
+                replyingTo = replyingTo,
+                onArmReply = viewModel::armReply,
+                onCancelReply = viewModel::cancelReply,
             )
         }
     }
@@ -130,6 +139,9 @@ private fun ChatThreadBody(
     padding: PaddingValues,
     onSend: (String) -> Unit,
     onRetry: (java.util.UUID) -> Unit,
+    replyingTo: java.util.UUID?,
+    onArmReply: (java.util.UUID) -> Unit,
+    onCancelReply: () -> Unit,
 ) {
     val listState = rememberLazyListState()
     // Defensive sort. The repository's contract is ascending by
@@ -146,6 +158,33 @@ private fun ChatThreadBody(
     // live profile update — so headers repaint in place.
     val senderDisplays = remember(sortedMessages, memberProfiles) {
         buildSenderDisplays(sortedMessages, memberProfiles)
+    }
+    // Per-message reply quote, resolved live from the loaded list (a
+    // ref to a message we don't have → "Message unavailable"). Plus an
+    // id→index map so tapping a quote can scroll to the original.
+    val replyQuotes = remember(sortedMessages, memberProfiles) {
+        buildReplyQuotes(sortedMessages, memberProfiles)
+    }
+    val indexById = remember(sortedMessages) {
+        sortedMessages.withIndex().associate { (index, message) -> message.id to index }
+    }
+
+    // Tapping a quote scrolls the replied-to message into view and
+    // briefly flashes it. No-op if the target isn't in the current
+    // snapshot (pruned, or never arrived). Mirrors
+    // `ChatThreadViewController.scrollAndHighlight` from onym-ios #174.
+    val coroutineScope = rememberCoroutineScope()
+    var highlightedId by remember { mutableStateOf<java.util.UUID?>(null) }
+    val scrollToAndHighlight: (java.util.UUID) -> Unit = remember(indexById) {
+        target@{ targetId ->
+            val index = indexById[targetId] ?: return@target
+            coroutineScope.launch {
+                listState.animateScrollToItem(index)
+                highlightedId = targetId
+                kotlinx.coroutines.delay(HIGHLIGHT_HOLD_MILLIS)
+                if (highlightedId == targetId) highlightedId = null
+            }
+        }
     }
 
     // Auto-scroll behavior:
@@ -265,19 +304,45 @@ private fun ChatThreadBody(
                         message = message,
                         sender = senderDisplays[message.id] ?: ChatSenderDisplay.Unknown,
                         onRetry = { onRetry(message.id) },
+                        reply = replyQuotes[message.id],
+                        onQuoteTap = message.replyToMessageId?.let { targetId ->
+                            { scrollToAndHighlight(targetId) }
+                        },
+                        isHighlighted = message.id == highlightedId,
+                        onSwipeReply = { onArmReply(message.id) },
                     )
                 }
             }
         }
         HorizontalDivider(thickness = 0.5.dp)
-        // PR A8 wires the Send button end-to-end. The VM's send
-        // does the trim guard + optimistic insert + status flip
-        // through SendMessageInteractor (PR A4). SendMessageError
-        // routes into viewModel.lastSendError, which the UI doesn't
-        // surface yet — network / fan-out failures land as
-        // MessageStatus.FAILED on the bubble (visual indicator
-        // lands in a later PR).
-        ChatInputPanel(onSend = onSend)
+        // Reply banner sits between the message list and the composer
+        // while a reply is armed. Resolved live from the loaded
+        // messages; if the target vanished, the banner just doesn't show.
+        val replyTarget = replyingTo?.let { id -> sortedMessages.firstOrNull { it.id == id } }
+        val composerFocus = remember { FocusRequester() }
+        if (replyTarget != null) {
+            ChatReplyBanner(
+                name = senderName(replyTarget.senderBlsPubkeyHex, memberProfiles),
+                snippet = replyTarget.body,
+                accent = OnymAccent.forSender(replyTarget.senderBlsPubkeyHex)
+                    .color(isSystemInDarkTheme()),
+                onCancel = onCancelReply,
+            )
+        }
+        // Raise the keyboard + focus the composer the moment a reply
+        // is armed, so the user can type straight away. iOS calls
+        // `focusComposer()` from `armReply`.
+        LaunchedEffect(replyingTo) {
+            if (replyingTo != null) {
+                runCatching { composerFocus.requestFocus() }
+            }
+        }
+        // The VM's send does the trim guard + optimistic insert +
+        // status flip through SendMessageInteractor, and threads the
+        // armed reply target so the sent message renders its quote.
+        // SendMessageError routes into viewModel.lastSendError; network
+        // / fan-out failures land as MessageStatus.FAILED on the bubble.
+        ChatInputPanel(onSend = onSend, focusRequester = composerFocus)
     }
 }
 
@@ -308,6 +373,10 @@ internal fun isNearBottom(
  *  the auto-scroll heuristic. 2 = the user is reading the last or
  *  second-to-last message. */
 internal const val NEAR_BOTTOM_INDEX_THRESHOLD = 2
+
+/** How long a quote-tapped message stays highlighted after the scroll
+ *  settles before the pulse fades. */
+private const val HIGHLIGHT_HOLD_MILLIS = 900L
 
 /**
  * Decides whether a frame of the IME-rise animation should re-pin the

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
@@ -31,7 +31,11 @@ class ChatThreadViewModel(
     val groupId: String,
     private val groupRepository: GroupRepository,
     private val messageRepository: MessageRepository,
-    private val sendMessage: suspend (groupId: String, body: String) -> Unit,
+    private val sendMessage: suspend (
+        groupId: String,
+        body: String,
+        replyToMessageId: java.util.UUID?,
+    ) -> Unit,
     private val retryMessage: suspend (groupId: String, messageId: java.util.UUID) -> Unit = { _, _ -> },
 ) : ViewModel() {
 
@@ -69,18 +73,39 @@ class ChatThreadViewModel(
      *  on the next successful send or via [clearError]. */
     val lastSendError: StateFlow<String?> = _lastSendError.asStateFlow()
 
+    private val _replyingTo = MutableStateFlow<java.util.UUID?>(null)
+    /** The message the composer is currently replying to, if any. Set
+     *  by a swipe-to-reply on a bubble ([armReply]), cleared on cancel
+     *  ([cancelReply]) or after a send. The screen resolves the quoted
+     *  sender + snippet from [messages] and shows the composer banner
+     *  while this is non-null. */
+    val replyingTo: StateFlow<java.util.UUID?> = _replyingTo.asStateFlow()
+
+    /** Arm a reply to [messageId]. The screen reveals the "Replying
+     *  to {name}" banner and focuses the composer. */
+    fun armReply(messageId: java.util.UUID) { _replyingTo.value = messageId }
+
+    /** Disarm the reply (cancel button, or post-send). */
+    fun cancelReply() { _replyingTo.value = null }
+
     /**
      * Fire-and-forget send. The interactor handles the optimistic
      * insert + status flip; the UI gets pending → sent / failed
      * transitions through [messages] without any extra wiring here.
+     *
+     * Threads the currently-armed reply target (if any) into the
+     * interactor so the sent message renders its quote, then clears
+     * the reply immediately so the banner drops on tap.
      */
     fun send(body: String) {
         val trimmed = body.trim()
         if (trimmed.isEmpty()) return
+        val replyTarget = _replyingTo.value
+        _replyingTo.value = null
         viewModelScope.launch {
             _sendInFlight.value = true
             try {
-                sendMessage(groupId, trimmed)
+                sendMessage(groupId, trimmed, replyTarget)
                 _lastSendError.value = null
             } catch (e: SendMessageError) {
                 _lastSendError.value = e.message ?: e.javaClass.simpleName

--- a/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ChatThreadViewModel.kt
@@ -37,7 +37,19 @@ class ChatThreadViewModel(
         replyToMessageId: java.util.UUID?,
     ) -> Unit,
     private val retryMessage: suspend (groupId: String, messageId: java.util.UUID) -> Unit = { _, _ -> },
+    /** Ships read receipts for incoming messages the user is viewing.
+     *  Defaulted to a no-op so tests that don't exercise receipts keep
+     *  their construction sites unchanged. */
+    private val chatReceiptSender: ChatReceiptSending = NoopChatReceiptSender(),
+    /** Symmetric read-receipt gate — when `false`, no read receipts are
+     *  emitted (and, on the receive side, none are honored). */
+    private val readReceiptsEnabled: () -> Boolean = { true },
 ) : ViewModel() {
+
+    /** Incoming message ids we've already emitted a read receipt for,
+     *  so re-emissions of the messages flow while the thread stays open
+     *  don't re-send. Touched only from the single messages collector. */
+    private val ackedReadIds = mutableSetOf<java.util.UUID>()
 
     /** Latest snapshot of the [ChatGroup] this thread renders.
      *  `null` when no group with [groupId] exists on this device
@@ -58,7 +70,14 @@ class ChatThreadViewModel(
     val messages: StateFlow<List<ChatMessage>> = MutableStateFlow<List<ChatMessage>>(emptyList())
         .also { initial ->
             viewModelScope.launch {
-                messageRepository.snapshots(groupId).collect { initial.value = it }
+                messageRepository.snapshots(groupId).collect {
+                    initial.value = it
+                    // The thread is on-screen while this collector runs,
+                    // so any incoming message here is "read". Gated by
+                    // the symmetric setting, batched per sender, deduped
+                    // via [ackedReadIds].
+                    sendReadReceipts(it)
+                }
             }
         }
         .asStateFlow()
@@ -118,6 +137,34 @@ class ChatThreadViewModel(
     }
 
     fun clearError() { _lastSendError.value = null }
+
+    /**
+     * Emit READ receipts for incoming messages the user is now looking
+     * at. No-op when the symmetric setting is off. Groups unacked
+     * incoming ids by sender and ships one receipt per sender to that
+     * sender's inbox key (resolved from the group's member profiles).
+     */
+    private suspend fun sendReadReceipts(snapshot: List<ChatMessage>) {
+        if (!readReceiptsEnabled()) return
+        val grp = group.value ?: return
+        val bySender = LinkedHashMap<String, MutableList<java.util.UUID>>()
+        for (message in snapshot) {
+            if (message.direction == MessageDirection.INCOMING && message.id !in ackedReadIds) {
+                bySender.getOrPut(message.senderBlsPubkeyHex) { mutableListOf() }.add(message.id)
+            }
+        }
+        if (bySender.isEmpty()) return
+        for ((senderHex, ids) in bySender) {
+            val inbox = grp.memberProfiles[senderHex]?.inboxPublicKey ?: continue
+            chatReceiptSender.send(
+                kind = ChatReceiptPayload.Kind.READ,
+                messageIds = ids,
+                groupId = grp.groupIdBytes,
+                recipientInboxKey = inbox,
+            )
+            ackedReadIds.addAll(ids)
+        }
+    }
 
     /**
      * Fire-and-forget retry on a previously-failed outgoing message.

--- a/app/src/main/kotlin/app/onym/android/chats/MessageDatabase.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageDatabase.kt
@@ -23,9 +23,34 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [PersistedMessage::class],
-    version = 1,
+    // v2 (reply-to): adds the nullable `replyToMessageId` TEXT column
+    // — onym-ios #173 parity. Additive + non-destructive; existing
+    // rows decode to a null reply target (a non-reply message).
+    version = 2,
     exportSchema = false,
 )
 abstract class MessageDatabase : RoomDatabase() {
     abstract fun messageDao(): MessageDao
+}
+
+/**
+ * Hand-rolled migrations for [MessageDatabase]. Wired into the
+ * production builder in [app.onym.android.OnymApplication]; the
+ * in-memory test builder skips them (each test starts on the latest
+ * schema). Sibling to
+ * [app.onym.android.group.GroupDatabaseMigrations].
+ */
+object MessageDatabaseMigrations {
+    /**
+     * v1 → v2: introduce `replyToMessageId` (nullable TEXT) holding
+     * the UUID string of the replied-to message. Existing rows decode
+     * to a null reply target; the column fills in only on rows
+     * written by a reply-aware sender. Mirrors the SwiftData
+     * lightweight migration in onym-ios PR #173.
+     */
+    val MIGRATION_1_2 = object : androidx.room.migration.Migration(1, 2) {
+        override fun migrate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE messages ADD COLUMN replyToMessageId TEXT")
+        }
+    }
 }

--- a/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageRepository.kt
@@ -137,6 +137,23 @@ class MessageRepository(
     }
 
     /**
+     * Raise an outgoing message's delivery status from an inbound
+     * receipt, never lowering it. No-op unless the row exists, is
+     * outgoing, and [to] sits strictly higher on the delivery ladder
+     * than the current value — so a late DELIVERED after READ, a
+     * duplicate receipt, or a receipt for an unknown / incoming /
+     * failed row all do nothing. See [MessageStatus.deliveryRank].
+     */
+    suspend fun upgradeStatus(id: UUID, to: MessageStatus) {
+        val newRank = to.deliveryRank ?: return
+        val message = store.findById(id) ?: return
+        if (message.direction != MessageDirection.OUTGOING) return
+        val currentRank = message.status.deliveryRank ?: return
+        if (newRank <= currentRank) return
+        updateStatus(id, to)
+    }
+
+    /**
      * Cascade entry point for identity removal. The store is
      * already wiped by [registerRemovalListener]'s closure; this
      * method just refreshes every cached group so subscribers see

--- a/app/src/main/kotlin/app/onym/android/chats/MessageStatus.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/MessageStatus.kt
@@ -4,11 +4,46 @@ package app.onym.android.chats
  * Lifecycle stage of a chat message on the local device:
  *  - [PENDING] — outgoing, queued, not yet acknowledged by any
  *    relay.
- *  - [SENT] — outgoing, at least one relay accepted.
+ *  - [SENT] — outgoing, at least one relay accepted. Single check.
+ *  - [DELIVERED] — outgoing, a recipient's device received +
+ *    decrypted the message and sent back a delivered receipt.
+ *    Double check.
+ *  - [READ] — outgoing, a recipient opened the thread and sent back
+ *    a read receipt (gated by the symmetric read-receipt setting).
+ *    Accent double check.
  *  - [FAILED] — outgoing, every relay rejected (or the seal step
  *    threw). Retry path lives outside this enum.
  *  - [RECEIVED] — incoming, decrypted and persisted locally.
  *
+ * DELIVERED / READ are appended (not inserted) so the Room name-string
+ * persistence ([RoomMessageStore] stores `status.name`) needs no
+ * migration.
+ *
  * Mirrors `MessageStatus.swift` from onym-ios PR #148.
  */
-enum class MessageStatus { PENDING, SENT, FAILED, RECEIVED }
+enum class MessageStatus {
+    PENDING,
+    SENT,
+    FAILED,
+    RECEIVED,
+    DELIVERED,
+    READ,
+    ;
+
+    /**
+     * Position on the outgoing delivery ladder
+     * (`PENDING → SENT → DELIVERED → READ`). Receipts only ever
+     * *raise* the status — a late DELIVERED after READ must not move
+     * it back — so callers compare ranks before applying. `null` for
+     * statuses off the ladder ([FAILED], [RECEIVED]), which receipts
+     * never transition to.
+     */
+    val deliveryRank: Int?
+        get() = when (this) {
+            PENDING -> 0
+            SENT -> 1
+            DELIVERED -> 2
+            READ -> 3
+            FAILED, RECEIVED -> null
+        }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/PersistedMessage.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/PersistedMessage.kt
@@ -22,6 +22,12 @@ import androidx.room.PrimaryKey
  *  - [directionRaw], [statusRaw], [groupTypeRaw] — small enums
  *    persisted as their enum-name / wireValue strings; not
  *    user-identifying.
+ *  - [replyToMessageId] — optional UUID string of the replied-to
+ *    message. Plain (not sensitive — it's just a pointer to another
+ *    row in this same table) and left queryable for a future
+ *    "replies to X" lookup. Nullable, so adding it is a non-
+ *    destructive `ALTER TABLE ADD COLUMN` (see
+ *    [MessageDatabaseMigrations.MIGRATION_1_2]).
  *
  * Encrypted columns (`StorageEncryption.encrypt`):
  *  - [encryptedSenderBlsPubkeyHex] — sender identity claim.
@@ -47,6 +53,7 @@ data class PersistedMessage(
     val groupTypeRaw: String,
     val encryptedSenderBlsPubkeyHex: ByteArray,
     val encryptedBody: ByteArray,
+    val replyToMessageId: String? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -59,7 +66,8 @@ data class PersistedMessage(
             statusRaw == other.statusRaw &&
             groupTypeRaw == other.groupTypeRaw &&
             encryptedSenderBlsPubkeyHex.contentEquals(other.encryptedSenderBlsPubkeyHex) &&
-            encryptedBody.contentEquals(other.encryptedBody)
+            encryptedBody.contentEquals(other.encryptedBody) &&
+            replyToMessageId == other.replyToMessageId
     }
 
     override fun hashCode(): Int {
@@ -72,6 +80,7 @@ data class PersistedMessage(
         h = 31 * h + groupTypeRaw.hashCode()
         h = 31 * h + encryptedSenderBlsPubkeyHex.contentHashCode()
         h = 31 * h + encryptedBody.contentHashCode()
+        h = 31 * h + (replyToMessageId?.hashCode() ?: 0)
         return h
     }
 }

--- a/app/src/main/kotlin/app/onym/android/chats/ReadReceiptsPreference.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/ReadReceiptsPreference.kt
@@ -1,0 +1,64 @@
+package app.onym.android.chats
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+
+/**
+ * The single symmetric read-receipt setting (default ON). Gates BOTH
+ * sending your read receipts and honoring inbound ones, so you only
+ * see others' read status if you also share yours. Delivered receipts
+ * are unconditional and not covered here.
+ *
+ * Read-only seam over the store so the dispatcher / VM depend on this
+ * rather than DataStore directly and tests can swap it. Mirrors the
+ * shape of [app.onym.android.chain.NetworkPreferenceProvider].
+ */
+interface ReadReceiptsPreferenceProvider {
+    /** Synchronous one-shot read (default `true`). */
+    fun current(): Boolean
+
+    /** Reactive read for the Settings toggle. */
+    val flow: Flow<Boolean>
+
+    suspend fun set(enabled: Boolean)
+}
+
+/** Production impl — DataStore Preferences, default ON when unset. */
+class DataStoreReadReceiptsPreferenceProvider(
+    private val dataStore: DataStore<Preferences>,
+) : ReadReceiptsPreferenceProvider {
+
+    override fun current(): Boolean = runBlocking {
+        dataStore.data.first()[SEND_READ_RECEIPTS] ?: true
+    }
+
+    override val flow: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[SEND_READ_RECEIPTS] ?: true
+    }
+
+    override suspend fun set(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[SEND_READ_RECEIPTS] = enabled }
+    }
+
+    companion object {
+        val SEND_READ_RECEIPTS = booleanPreferencesKey("onym.chat.sendReadReceipts")
+    }
+}
+
+/** Test fake — returns whatever was passed in. */
+class StaticReadReceiptsPreferenceProvider(
+    private val value: Boolean,
+) : ReadReceiptsPreferenceProvider {
+    override fun current(): Boolean = value
+    override val flow: Flow<Boolean> = flowOf(value)
+    override suspend fun set(enabled: Boolean) {
+        throw UnsupportedOperationException("StaticReadReceiptsPreferenceProvider is read-only")
+    }
+}

--- a/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/RoomMessageStore.kt
@@ -63,6 +63,9 @@ class RoomMessageStore(
         groupTypeRaw = message.groupType.wireValue,
         encryptedSenderBlsPubkeyHex = encryption.encrypt(message.senderBlsPubkeyHex),
         encryptedBody = encryption.encrypt(message.body),
+        // Plain pointer to another row — not sensitive, so no
+        // encryption. Stored as the UUID string; null for a non-reply.
+        replyToMessageId = message.replyToMessageId?.toString(),
     )
 
     /** Tolerant decode: a row whose encrypted columns fail to
@@ -78,6 +81,11 @@ class RoomMessageStore(
             ?: return null
         val groupType = SepGroupType.fromWire(row.groupTypeRaw) ?: return null
         val id = try { UUID.fromString(row.id) } catch (_: Throwable) { return null }
+        // A malformed reply pointer (somehow non-UUID) degrades to no
+        // reply rather than dropping the whole row — the message body
+        // is the important part; the quote just won't render.
+        val replyToMessageId = row.replyToMessageId
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
         return ChatMessage(
             id = id,
             groupId = row.groupId,
@@ -87,6 +95,7 @@ class RoomMessageStore(
             sentAtMillis = row.sentAt,
             direction = direction,
             status = status,
+            replyToMessageId = replyToMessageId,
             groupType = groupType,
         )
     }

--- a/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
+++ b/app/src/main/kotlin/app/onym/android/chats/SendMessageInteractor.kt
@@ -64,7 +64,11 @@ class SendMessageInteractor(
      * want the optimistic `PENDING` view subscribe to
      * [MessageRepository.snapshots] instead.
      */
-    suspend fun send(groupId: String, body: String): ChatMessage = withContext(ioDispatcher) {
+    suspend fun send(
+        groupId: String,
+        body: String,
+        replyToMessageId: UUID? = null,
+    ): ChatMessage = withContext(ioDispatcher) {
         if (body.isEmpty()) throw SendMessageError.EmptyBody
 
         val activeIdentityId = activeIdentity.currentIdentityId.value
@@ -96,6 +100,7 @@ class SendMessageInteractor(
             groupId = group.groupIdBytes,
             senderBlsPubkeyHex = myBlsHex,
             sentAtMillis = sentAtMillis,
+            replyToMessageId = replyToMessageId,
             variant = variant,
         )
 
@@ -109,6 +114,7 @@ class SendMessageInteractor(
             sentAtMillis = sentAtMillis,
             direction = MessageDirection.OUTGOING,
             status = MessageStatus.PENDING,
+            replyToMessageId = replyToMessageId,
             groupType = group.groupType,
         )
         messageRepository.append(pending)
@@ -172,14 +178,17 @@ class SendMessageInteractor(
         // in-flight clock before the network round-trip.
         messageRepository.updateStatus(messageId, MessageStatus.PENDING)
 
-        // Preserve the original messageId + sentAt so receivers
-        // dedup against any prior delivery via their dispatcher.
+        // Preserve the original messageId + sentAt + reply target so
+        // receivers dedup against any prior delivery via their
+        // dispatcher and the re-sent message still quotes the same
+        // original.
         val payload = ChatMessagePayload(
             version = 1,
             messageId = messageId,
             groupId = group.groupIdBytes,
             senderBlsPubkeyHex = myBlsHex,
             sentAtMillis = message.sentAtMillis,
+            replyToMessageId = message.replyToMessageId,
             variant = variant,
         )
         val recipients = recipientInboxKeysFor(group, myBlsHex)

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -6,7 +6,10 @@ import app.onym.android.chain.SepTier
 import app.onym.android.chats.ChatMessage
 import app.onym.android.chats.ChatMessagePayload
 import app.onym.android.chats.ChatMessageVariant
+import app.onym.android.chats.ChatReceiptPayload
+import app.onym.android.chats.ChatReceiptSending
 import app.onym.android.chats.MessageDirection
+import app.onym.android.chats.NoopChatReceiptSender
 import app.onym.android.chats.MessageRepository
 import app.onym.android.chats.MessageStatus
 import app.onym.android.group.ChatGroup
@@ -91,6 +94,15 @@ class IncomingMessageDispatcher(
      *  [GroupStateRefreshRequest]s are answered here on the admin side.
      *  Defaulted to a no-op for the same reason as [pendingInvites]. */
     private val groupStateRefresher: GroupStateRefreshing = NoopGroupStateRefresher(),
+    /** Ships a delivered receipt back to a chat message's sender the
+     *  moment we persist it. Defaulted to a no-op so existing
+     *  dispatcher tests keep their construction sites unchanged. */
+    private val receiptSender: ChatReceiptSending = NoopChatReceiptSender(),
+    /** Symmetric read-receipt gate: an inbound READ receipt only
+     *  raises a message to [MessageStatus.READ] when this device also
+     *  sends read receipts. Defaulted to `true` (the shipping
+     *  default). */
+    private val readReceiptsEnabled: () -> Boolean = { true },
 ) {
 
     suspend fun dispatch(
@@ -170,6 +182,17 @@ class IncomingMessageDispatcher(
         val avatarUpdate = tryDecodeGroupAvatar(envelope.plaintext)
         if (avatarUpdate != null) {
             applyAvatar(avatarUpdate, envelope.senderEd25519PublicKey)
+            return
+        }
+
+        // Fast path: ChatReceiptPayload — a peer acking one of OUR
+        // messages as delivered / read. Wire-shape-disjoint from every
+        // other payload (unique `kind` + `message_ids` keys), so the
+        // trial-decode can't steal a different payload even under
+        // ignoreUnknownKeys.
+        val receipt = tryDecodeReceipt(envelope.plaintext)
+        if (receipt != null) {
+            applyReceipt(receipt)
             return
         }
 
@@ -503,6 +526,35 @@ class IncomingMessageDispatcher(
         null
     }
 
+    private fun tryDecodeReceipt(bytes: ByteArray): ChatReceiptPayload? = try {
+        permissiveJson.decodeFromString(
+            ChatReceiptPayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
+    } catch (_: Throwable) {
+        null
+    }
+
+    /**
+     * Apply an inbound receipt: raise the acked outgoing messages to
+     * DELIVERED / READ (monotonic — [MessageRepository.upgradeStatus]
+     * enforces the ladder). READ receipts are honored only when this
+     * device also sends them (symmetric).
+     */
+    private suspend fun applyReceipt(receipt: ChatReceiptPayload) {
+        val messages = messageRepository ?: return
+        val newStatus = when (receipt.kind) {
+            ChatReceiptPayload.Kind.DELIVERED -> MessageStatus.DELIVERED
+            ChatReceiptPayload.Kind.READ -> {
+                if (!readReceiptsEnabled()) return
+                MessageStatus.READ
+            }
+        }
+        for (id in receipt.messageIds) {
+            messages.upgradeStatus(id, newStatus)
+        }
+    }
+
     /**
      * Persist an inbound chat message after running the full trust
      * chain. Drops silently (no fall-through) on any failure — the
@@ -573,6 +625,16 @@ class IncomingMessageDispatcher(
         // canonical sort key today.
         @Suppress("UNUSED_VARIABLE") val _receivedAt = receivedAt
         messages.append(message)
+
+        // Ack the sender: delivered now (unconditional — it only
+        // reveals a device received the ciphertext). Read receipts are
+        // sent later, when the user opens the thread.
+        receiptSender.send(
+            kind = ChatReceiptPayload.Kind.DELIVERED,
+            messageIds = listOf(payload.messageId),
+            groupId = payload.groupId,
+            recipientInboxKey = profile.inboxPublicKey,
+        )
     }
 
     private fun variantMatchesGroup(

--- a/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
+++ b/app/src/main/kotlin/app/onym/android/inbox/IncomingMessageDispatcher.kt
@@ -559,6 +559,13 @@ class IncomingMessageDispatcher(
             sentAtMillis = payload.sentAtMillis,
             direction = MessageDirection.INCOMING,
             status = MessageStatus.RECEIVED,
+            // Pointer to the quoted message, resolved against the local
+            // store at render time. No trust gate needed: a ref to a
+            // message we never received (or a forged one) just renders
+            // as "Message unavailable" — it can't pull in content from
+            // outside this group because rendering only resolves local
+            // rows.
+            replyToMessageId = payload.replyToMessageId,
             groupType = group.groupType,
         )
         // Use the receivedAt timestamp only for the "ordering by

--- a/app/src/main/kotlin/app/onym/android/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/app/onym/android/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Anchor
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Public
@@ -84,6 +85,10 @@ fun SettingsScreen(
      *  → "Use Mainnet" Switch. */
     useMainnet: Boolean,
     onToggleMainnet: (Boolean) -> Unit,
+    /** Symmetric read-receipt setting. Bound to the Settings → Chat
+     *  → "Send read receipts" Switch. */
+    sendReadReceipts: Boolean = true,
+    onToggleReadReceipts: (Boolean) -> Unit = {},
     /** Settings → Transport → Nostr Relays entry. PR 87. */
     onNostrRelaysClick: (() -> Unit)? = null,
     /** Live count of configured Nostr relays — drives the Settings
@@ -246,6 +251,33 @@ fun SettingsScreen(
                         else R.string.settings_use_mainnet_off_footer,
                     )
                 )
+            }
+
+            // ─── CHAT ──────────────────────────────────────────────
+            item { SettingsSectionLabel("CHAT") }
+            item {
+                SettingsCard {
+                    SettingsRow(
+                        leading = {
+                            SettingsTileBox(
+                                icon = Icons.Filled.DoneAll,
+                                background = if (sendReadReceipts) SettingsTile.Indigo else SettingsTile.Gray,
+                            )
+                        },
+                        title = "Send read receipts",
+                        subtitle = "You'll only see others' read status if this is on",
+                        showChevron = false,
+                        trailing = {
+                            Switch(
+                                checked = sendReadReceipts,
+                                onCheckedChange = onToggleReadReceipts,
+                                modifier = Modifier.testTag("settings.read_receipts_toggle"),
+                            )
+                        },
+                        onClick = { onToggleReadReceipts(!sendReadReceipts) },
+                        isLast = true,
+                    )
+                }
             }
 
             // ─── APP ───────────────────────────────────────────────

--- a/app/src/test/kotlin/app/onym/android/chats/ChatBubbleStatusTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatBubbleStatusTest.kt
@@ -2,6 +2,7 @@ package app.onym.android.chats
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.outlined.Schedule
 import app.onym.android.chain.SepGroupType
@@ -41,6 +42,22 @@ class ChatBubbleStatusTest {
         assertNotNull(visual)
         assertEquals(Icons.Filled.Check, visual!!.icon)
         assertEquals(ChatStatusTint.Muted, visual.tint)
+    }
+
+    @Test
+    fun statusVisualFor_delivered_isMutedDoubleCheck() {
+        val visual = statusVisualFor(MessageStatus.DELIVERED)
+        assertNotNull(visual)
+        assertEquals(Icons.Filled.DoneAll, visual!!.icon)
+        assertEquals(ChatStatusTint.Muted, visual.tint)
+    }
+
+    @Test
+    fun statusVisualFor_read_isAccentDoubleCheck() {
+        val visual = statusVisualFor(MessageStatus.READ)
+        assertNotNull(visual)
+        assertEquals(Icons.Filled.DoneAll, visual!!.icon)
+        assertEquals(ChatStatusTint.Accent, visual.tint)
     }
 
     @Test

--- a/app/src/test/kotlin/app/onym/android/chats/ChatMessagePayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatMessagePayloadTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -48,6 +49,92 @@ class ChatMessagePayloadTest {
         val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), encoded)
         assertEquals(original, decoded)
         assertEquals("héllo 🌍 ñ 中文", (decoded.variant as ChatMessageVariant.Tyranny).body)
+    }
+
+    // ─── reply reference ──────────────────────────────────────────
+
+    @Test
+    fun roundtrip_replyRef_preservesTargetId() {
+        val target = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        val original = samplePayload(body = "agreed", replyToMessageId = target)
+        val encoded = strictJson.encodeToString(ChatMessagePayload.serializer(), original)
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), encoded)
+        assertEquals(target, decoded.replyToMessageId)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun wireFormat_replyKeyIsSnakeCaseUppercaseUuid() {
+        val target = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        val encoded = strictJson.encodeToString(
+            ChatMessagePayload.serializer(),
+            samplePayload(body = "hi", replyToMessageId = target),
+        )
+        val root = strictJson.parseToJsonElement(encoded).jsonObject
+        assertEquals(
+            "reply target wires under snake_case key as uppercase canonical UUID",
+            "22222222-2222-2222-2222-222222222222",
+            root["reply_to_message_id"]!!.jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun decode_missingReplyKey_isNull() {
+        // Backward compat: a payload from an older sender (pre-replies)
+        // has no `reply_to_message_id` — it must decode to null, not throw.
+        val json = """
+            {
+              "version": 1,
+              "message_id": "11111111-1111-1111-1111-111111111111",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "variant": { "kind": "tyranny", "body": "hi" }
+            }
+        """.trimIndent()
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+        assertNull(decoded.replyToMessageId)
+    }
+
+    @Test
+    fun decode_explicitNullReplyKey_isNull() {
+        // An explicit `null` (how a non-reply message from a reply-aware
+        // sender wires) must also decode to null.
+        val json = """
+            {
+              "version": 1,
+              "message_id": "11111111-1111-1111-1111-111111111111",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "reply_to_message_id": null,
+              "variant": { "kind": "tyranny", "body": "hi" }
+            }
+        """.trimIndent()
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+        assertNull(decoded.replyToMessageId)
+    }
+
+    @Test
+    fun decode_replyKey_acceptsLowercaseUuid() {
+        // Decoders accept any case (UUID.fromString); the iOS twin only
+        // ever emits uppercase, but be tolerant on the way in.
+        val json = """
+            {
+              "version": 1,
+              "message_id": "11111111-1111-1111-1111-111111111111",
+              "group_id": "${b64ZeroBytes(32)}",
+              "sender_bls_pubkey_hex": "${"ab".repeat(48)}",
+              "sent_at_millis": 0,
+              "reply_to_message_id": "22222222-2222-2222-2222-222222222222",
+              "variant": { "kind": "tyranny", "body": "hi" }
+            }
+        """.trimIndent()
+        val decoded = strictJson.decodeFromString(ChatMessagePayload.serializer(), json)
+        assertEquals(
+            UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            decoded.replyToMessageId,
+        )
     }
 
     // ─── wire-format pin ──────────────────────────────────────────
@@ -211,12 +298,16 @@ class ChatMessagePayloadTest {
 
     // ─── helpers ──────────────────────────────────────────────────
 
-    private fun samplePayload(body: String): ChatMessagePayload = ChatMessagePayload(
+    private fun samplePayload(
+        body: String,
+        replyToMessageId: UUID? = null,
+    ): ChatMessagePayload = ChatMessagePayload(
         version = 1,
         messageId = UUID.fromString("12345678-1234-1234-1234-123456789ABC"),
         groupId = ByteArray(32) { (it * 7).toByte() },
         senderBlsPubkeyHex = "ab".repeat(48),
         sentAtMillis = 1_700_000_000_000L,
+        replyToMessageId = replyToMessageId,
         variant = ChatMessageVariant.Tyranny(body = body),
     )
 

--- a/app/src/test/kotlin/app/onym/android/chats/ChatReceiptPayloadTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatReceiptPayloadTest.kt
@@ -1,0 +1,49 @@
+package app.onym.android.chats
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Wire-format tests for [ChatReceiptPayload]. Pins the snake_case keys
+ * + kind spelling so the receipt stays byte-compatible with the iOS
+ * twin (`ChatReceiptPayload.swift`).
+ */
+class ChatReceiptPayloadTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun roundTrips() {
+        val original = ChatReceiptPayload(
+            version = 1,
+            groupId = byteArrayOf(1, 2, 3),
+            senderBlsPubkeyHex = "ab".repeat(48),
+            kind = ChatReceiptPayload.Kind.READ,
+            messageIds = listOf(UUID.randomUUID(), UUID.randomUUID()),
+        )
+        val encoded = json.encodeToString(ChatReceiptPayload.serializer(), original)
+        val decoded = json.decodeFromString(ChatReceiptPayload.serializer(), encoded)
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun wireKeysAndKindMatchIos() {
+        val encoded = json.encodeToString(
+            ChatReceiptPayload.serializer(),
+            ChatReceiptPayload(
+                version = 1,
+                groupId = byteArrayOf(9),
+                senderBlsPubkeyHex = "aa".repeat(48),
+                kind = ChatReceiptPayload.Kind.DELIVERED,
+                messageIds = listOf(UUID.randomUUID()),
+            ),
+        )
+        assertTrue(encoded.contains("\"group_id\""))
+        assertTrue(encoded.contains("\"sender_bls_pubkey_hex\""))
+        assertTrue(encoded.contains("\"message_ids\""))
+        assertTrue(encoded.contains("\"delivered\""))
+    }
+}

--- a/app/src/test/kotlin/app/onym/android/chats/ChatReplyQuoteTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatReplyQuoteTest.kt
@@ -1,0 +1,99 @@
+package app.onym.android.chats
+
+import app.onym.android.chain.SepGroupType
+import app.onym.android.group.MemberProfile
+import app.onym.android.group.OnymAccent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import java.util.UUID
+import org.junit.Test
+
+/**
+ * Pin for the live reply-quote resolution
+ * ([resolveReplyQuote] / [buildReplyQuotes]). The quote is resolved
+ * against the loaded message list — never snapshotted on the wire —
+ * so a target that isn't present degrades to "Message unavailable".
+ *
+ * Mirrors the `replyQuote(for:)` controller tests from onym-ios PR #174.
+ */
+class ChatReplyQuoteTest {
+
+    private val aliceBls = "aa".repeat(48)
+    private val bobBls = "cc".repeat(48)
+    private val profiles = mapOf(
+        aliceBls to MemberProfile(
+            alias = "Alice",
+            inboxPublicKey = ByteArray(32) { 0x22 },
+            sendingPubkey = ByteArray(32) { 0x33 },
+        ),
+    )
+
+    @Test
+    fun resolve_nonReply_isNull() {
+        val message = message(sender = bobBls, body = "hi", replyTo = null)
+        assertNull(resolveReplyQuote(message, mapOf(message.id to message), profiles))
+    }
+
+    @Test
+    fun resolve_foundTarget_carriesSenderNameSnippetAndAccent() {
+        val original = message(sender = aliceBls, body = "the original")
+        val reply = message(sender = bobBls, body = "agreed", replyTo = original.id)
+        val byId = mapOf(original.id to original, reply.id to reply)
+
+        val quote = resolveReplyQuote(reply, byId, profiles)!!
+        assertFalse(quote.isUnavailable)
+        assertEquals("Alice", quote.name)
+        assertEquals("the original", quote.snippet)
+        // Accent tracks the *quoted* sender (Alice), not the replier.
+        assertEquals(OnymAccent.forSender(aliceBls), quote.accent)
+    }
+
+    @Test
+    fun resolve_unknownTarget_isUnavailable() {
+        val reply = message(sender = bobBls, body = "agreed", replyTo = UUID.randomUUID())
+        val quote = resolveReplyQuote(reply, mapOf(reply.id to reply), profiles)!!
+        assertTrue("a reply to a message we don't have is unavailable", quote.isUnavailable)
+    }
+
+    @Test
+    fun resolve_targetSenderWithoutAlias_fallsBackToFingerprint() {
+        // Bob has no profile entry → name falls back to the BLS
+        // fingerprint, same as the members list.
+        val original = message(sender = bobBls, body = "no alias here")
+        val reply = message(sender = aliceBls, body = "ok", replyTo = original.id)
+        val byId = mapOf(original.id to original, reply.id to reply)
+
+        val quote = resolveReplyQuote(reply, byId, profiles)!!
+        assertEquals("BLS " + bobBls.take(8), quote.name)
+    }
+
+    @Test
+    fun buildReplyQuotes_onlyIncludesReplies() {
+        val original = message(sender = aliceBls, body = "first")
+        val reply = message(sender = bobBls, body = "second", replyTo = original.id)
+        val plain = message(sender = aliceBls, body = "third")
+
+        val quotes = buildReplyQuotes(listOf(original, reply, plain), profiles)
+        assertEquals("only the reply gets a quote", setOf(reply.id), quotes.keys)
+        assertEquals("first", quotes[reply.id]!!.snippet)
+    }
+
+    private fun message(
+        sender: String,
+        body: String,
+        replyTo: UUID? = null,
+    ): ChatMessage = ChatMessage(
+        id = UUID.randomUUID(),
+        groupId = "aa".repeat(32),
+        ownerIdentityId = "owner",
+        senderBlsPubkeyHex = sender,
+        body = body,
+        sentAtMillis = 1_700_000_000_000L,
+        direction = MessageDirection.INCOMING,
+        status = MessageStatus.RECEIVED,
+        replyToMessageId = replyTo,
+        groupType = SepGroupType.TYRANNY,
+    )
+}

--- a/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/ChatThreadViewModelTest.kt
@@ -107,7 +107,7 @@ class ChatThreadViewModelTest {
         fixture.seedGroup(groupIdHex)
         val captured = mutableListOf<Pair<String, String>>()
         val vm = fixture.makeViewModel(
-            send = { gid, body -> captured.add(gid to body) },
+            send = { gid, body, _ -> captured.add(gid to body) },
         )
 
         vm.send("  hello world  ")
@@ -121,7 +121,7 @@ class ChatThreadViewModelTest {
         fixture.seedGroup(groupIdHex)
         val captured = mutableListOf<Pair<String, String>>()
         val vm = fixture.makeViewModel(
-            send = { gid, body -> captured.add(gid to body) },
+            send = { gid, body, _ -> captured.add(gid to body) },
         )
 
         vm.send("")
@@ -137,7 +137,7 @@ class ChatThreadViewModelTest {
         val fixture = newFixture()
         fixture.seedGroup(groupIdHex)
         val vm = fixture.makeViewModel(
-            send = { _, _ -> throw SendMessageError.SenderNotAMember },
+            send = { _, _, _ -> throw SendMessageError.SenderNotAMember },
         )
 
         vm.send("hi")
@@ -149,7 +149,7 @@ class ChatThreadViewModelTest {
         val fixture = newFixture()
         fixture.seedGroup(groupIdHex)
         val vm = fixture.makeViewModel(
-            send = { _, _ -> throw SendMessageError.EmptyBody },
+            send = { _, _, _ -> throw SendMessageError.EmptyBody },
         )
         vm.send("hi")
         assertNotNull(vm.lastSendError.value)
@@ -164,7 +164,7 @@ class ChatThreadViewModelTest {
         fixture.seedGroup(groupIdHex)
         var shouldThrow = true
         val vm = fixture.makeViewModel(
-            send = { _, _ ->
+            send = { _, _, _ ->
                 if (shouldThrow) throw SendMessageError.SenderNotAMember
             },
         )
@@ -174,6 +174,69 @@ class ChatThreadViewModelTest {
         shouldThrow = false
         vm.send("second")  // succeeds → error cleared
         assertNull(vm.lastSendError.value)
+    }
+
+    // ─── reply threading ─────────────────────────────────────────
+
+    @Test
+    fun armReply_setsReplyingTo_cancelClearsIt() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val vm = fixture.makeViewModel()
+
+        val target = UUID.randomUUID()
+        vm.armReply(target)
+        assertEquals(target, vm.replyingTo.value)
+
+        vm.cancelReply()
+        assertNull(vm.replyingTo.value)
+    }
+
+    @Test
+    fun send_afterArming_forwardsReplyTarget_andClearsIt() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        val captured = mutableListOf<Triple<String, String, UUID?>>()
+        val vm = fixture.makeViewModel(
+            send = { gid, body, replyTo -> captured.add(Triple(gid, body, replyTo)) },
+        )
+
+        val target = UUID.randomUUID()
+        vm.armReply(target)
+        vm.send("agreed")
+
+        assertEquals(1, captured.size)
+        assertEquals(Triple(groupIdHex, "agreed", target), captured.single())
+        // Banner drops the moment the reply is sent.
+        assertNull("send must clear the armed reply", vm.replyingTo.value)
+    }
+
+    @Test
+    fun send_withoutArming_carriesNoReplyTarget() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        var capturedTarget: UUID? = UUID.randomUUID()  // sentinel
+        val vm = fixture.makeViewModel(
+            send = { _, _, replyTo -> capturedTarget = replyTo },
+        )
+
+        vm.send("plain")
+        assertNull("a non-reply send must carry no target", capturedTarget)
+    }
+
+    @Test
+    fun cancelReply_thenSend_carriesNoTarget() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(groupIdHex)
+        var capturedTarget: UUID? = UUID.randomUUID()  // sentinel
+        val vm = fixture.makeViewModel(
+            send = { _, _, replyTo -> capturedTarget = replyTo },
+        )
+
+        vm.armReply(UUID.randomUUID())
+        vm.cancelReply()
+        vm.send("plain")
+        assertNull("after cancelling, a send must carry no reply target", capturedTarget)
     }
 
     // ─── retry action ────────────────────────────────────────────
@@ -275,7 +338,7 @@ class ChatThreadViewModelTest {
         }
 
         fun makeViewModel(
-            send: suspend (String, String) -> Unit = { _, _ -> },
+            send: suspend (String, String, UUID?) -> Unit = { _, _, _ -> },
             retry: suspend (String, UUID) -> Unit = { _, _ -> },
         ) = ChatThreadViewModel(
             groupId = groupIdHex,

--- a/app/src/test/kotlin/app/onym/android/chats/MessageRepositoryTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/MessageRepositoryTest.kt
@@ -206,6 +206,52 @@ class MessageRepositoryTest {
 
     // ─── helpers ──────────────────────────────────────────────────
 
+    // ─── upgradeStatus() (delivery / read receipts) ───────────────
+
+    @Test
+    fun upgradeStatus_raisesAlongTheLadder() = runTest {
+        val store = InMemoryMessageStore()
+        val msg = makeMessage(owner = aliceId, group = groupA, body = "m")
+            .copy(status = MessageStatus.SENT)
+        store.preload(listOf(msg))
+        val repo = makeRepo(store, aliceId)
+        val flow = repo.snapshots(groupA)
+
+        repo.upgradeStatus(msg.id, MessageStatus.DELIVERED)
+        assertEquals(MessageStatus.DELIVERED, flow.first().first().status)
+
+        repo.upgradeStatus(msg.id, MessageStatus.READ)
+        assertEquals(MessageStatus.READ, flow.first().first().status)
+    }
+
+    @Test
+    fun upgradeStatus_neverDowngrades() = runTest {
+        val store = InMemoryMessageStore()
+        val msg = makeMessage(owner = aliceId, group = groupA, body = "m")
+            .copy(status = MessageStatus.READ)
+        store.preload(listOf(msg))
+        val repo = makeRepo(store, aliceId)
+        val flow = repo.snapshots(groupA)
+
+        // A late delivered receipt arriving after read must not lower it.
+        repo.upgradeStatus(msg.id, MessageStatus.DELIVERED)
+        assertEquals(MessageStatus.READ, flow.first().first().status)
+    }
+
+    @Test
+    fun upgradeStatus_ignoresIncomingAndUnknown() = runTest {
+        val store = InMemoryMessageStore()
+        val incoming = makeMessage(owner = aliceId, group = groupA, body = "in")
+            .copy(direction = MessageDirection.INCOMING, status = MessageStatus.RECEIVED)
+        store.preload(listOf(incoming))
+        val repo = makeRepo(store, aliceId)
+        val flow = repo.snapshots(groupA)
+
+        repo.upgradeStatus(incoming.id, MessageStatus.DELIVERED)
+        repo.upgradeStatus(UUID.randomUUID(), MessageStatus.DELIVERED)  // unknown id
+        assertEquals(MessageStatus.RECEIVED, flow.first().first().status)
+    }
+
     private fun makeRepo(
         store: InMemoryMessageStore,
         active: IdentityId?,

--- a/app/src/test/kotlin/app/onym/android/chats/RoomMessageStoreTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/RoomMessageStoreTest.kt
@@ -72,6 +72,24 @@ class RoomMessageStoreTest {
         assertEquals(MessageDirection.OUTGOING, first.direction)
         assertEquals(MessageStatus.PENDING, first.status)
         assertEquals(SepGroupType.TYRANNY, first.groupType)
+        assertNull("a non-reply message round-trips a null reply target", first.replyToMessageId)
+    }
+
+    // ─── reply reference round-trip ───────────────────────────────
+
+    @Test
+    fun insert_thenList_roundtripsReplyTarget() = runTest {
+        val target = UUID.randomUUID()
+        val msg = makeMessage(body = "agreed", replyToMessageId = target)
+        store.insert(msg)
+
+        val first = store.listForGroup(msg.ownerIdentityId, msg.groupId).single()
+        assertEquals(target, first.replyToMessageId)
+        // The pointer is a plain column — readable on the raw row too.
+        assertEquals(
+            target.toString(),
+            db.messageDao().findById(msg.id.toString())!!.replyToMessageId,
+        )
     }
 
     // ─── encryption-at-rest ───────────────────────────────────────
@@ -236,6 +254,7 @@ class RoomMessageStoreTest {
         group: String = "aa".repeat(32),
         sender: String = "cc".repeat(48),
         sentAtMillis: Long = 1_700_000_000_000L,
+        replyToMessageId: UUID? = null,
     ): ChatMessage = ChatMessage(
         id = UUID.randomUUID(),
         groupId = group,
@@ -245,6 +264,7 @@ class RoomMessageStoreTest {
         sentAtMillis = sentAtMillis,
         direction = MessageDirection.OUTGOING,
         status = MessageStatus.PENDING,
+        replyToMessageId = replyToMessageId,
         groupType = SepGroupType.TYRANNY,
     )
 }

--- a/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
+++ b/app/src/test/kotlin/app/onym/android/chats/SendMessageInteractorTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -73,6 +74,65 @@ class SendMessageInteractorTest {
             sends.single().inbox,
         )
     }
+
+    // ─── reply reference rides the send + survives retry ─────────
+
+    @Test
+    fun send_withReplyTarget_carriesRefOnPayloadAndPersistedRow() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val target = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+        val result = fixture.interactor.send(groupIdHex, "agreed", replyToMessageId = target)
+
+        // The optimistic + persisted row carries the ref.
+        assertEquals(target, result.replyToMessageId)
+        assertEquals(
+            target,
+            fixture.messageStore.listForGroup(activeId.value, groupIdHex).single().replyToMessageId,
+        )
+        // …and it rides the wire payload (RecordingSealer passes the
+        // JSON bytes through untouched).
+        val shipped = decodeShipped(fixture.transport.sends().single().payload)
+        assertEquals(target, shipped.replyToMessageId)
+    }
+
+    @Test
+    fun send_withoutReplyTarget_shipsNullRef() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+
+        fixture.interactor.send(groupIdHex, "plain")
+
+        assertNull(decodeShipped(fixture.transport.sends().single().payload).replyToMessageId)
+    }
+
+    @Test
+    fun retry_preservesReplyTarget() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(includePeer = true)
+        val target = UUID.fromString("33333333-3333-3333-3333-333333333333")
+        val failed = makePersisted(
+            status = MessageStatus.FAILED,
+            body = "first try",
+            replyToMessageId = target,
+        )
+        fixture.messageStore.preload(listOf(failed))
+
+        fixture.interactor.retry(groupIdHex, failed.id)
+
+        // The re-sent message still quotes the same original.
+        val shipped = decodeShipped(fixture.transport.sends().single().payload)
+        assertEquals(target, shipped.replyToMessageId)
+    }
+
+    private val shippedJson = Json { ignoreUnknownKeys = true }
+
+    private fun decodeShipped(bytes: ByteArray): ChatMessagePayload =
+        shippedJson.decodeFromString(
+            ChatMessagePayload.serializer(),
+            bytes.toString(Charsets.UTF_8),
+        )
 
     // ─── self-recipient is skipped ────────────────────────────────
 
@@ -317,6 +377,7 @@ class SendMessageInteractorTest {
         status: MessageStatus,
         direction: MessageDirection = MessageDirection.OUTGOING,
         body: String,
+        replyToMessageId: UUID? = null,
     ): ChatMessage = ChatMessage(
         id = UUID.randomUUID(),
         groupId = groupIdHex,
@@ -326,6 +387,7 @@ class SendMessageInteractorTest {
         sentAtMillis = 1_699_000_000_000L,
         direction = direction,
         status = status,
+        replyToMessageId = replyToMessageId,
         groupType = SepGroupType.TYRANNY,
     )
 

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
@@ -72,9 +72,27 @@ class IncomingMessageDispatcherChatMessageTest {
         assertEquals(MessageDirection.INCOMING, msg.direction)
         assertEquals(MessageStatus.RECEIVED, msg.status)
         assertEquals(senderBlsHex, msg.senderBlsPubkeyHex)
+        assertNull("a non-reply inbound message carries no reply target", msg.replyToMessageId)
         // Legacy queue stays empty — chat messages don't fall through.
         fixture.invitationsRepository.bootstrap()
         assertTrue(fixture.invitationsRepository.invitations.value.isEmpty())
+    }
+
+    @Test
+    fun chatMessage_withReplyRef_persistsTargetId() = runTest {
+        val fixture = newFixture()
+        fixture.seedGroup(ownerIdentity, withSenderProfile = true)
+
+        val target = UUID.randomUUID()
+        val payload = chatPayload(UUID.randomUUID(), body = "agreed", replyToMessageId = target)
+        fixture.dispatch(ownerIdentity, payload, signer = senderSendingKey)
+
+        val stored = fixture.messageStore.listForGroup(ownerIdentity.value, groupIdHex).single()
+        assertEquals(
+            "an inbound reply must carry its target id onto the persisted message",
+            target,
+            stored.replyToMessageId,
+        )
     }
 
     // ─── trust-chain failures all drop without falling through ───
@@ -215,12 +233,14 @@ class IncomingMessageDispatcherChatMessageTest {
         id: UUID,
         body: String,
         sentAtMillis: Long = 1_700_000_000_000L,
+        replyToMessageId: UUID? = null,
     ) = ChatMessagePayload(
         version = 1,
         messageId = id,
         groupId = groupIdBytes,
         senderBlsPubkeyHex = senderBlsHex,
         sentAtMillis = sentAtMillis,
+        replyToMessageId = replyToMessageId,
         variant = ChatMessageVariant.Tyranny(body = body),
     )
 

--- a/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
+++ b/app/src/test/kotlin/app/onym/android/inbox/IncomingMessageDispatcherChatMessageTest.kt
@@ -2,8 +2,11 @@ package app.onym.android.inbox
 
 import app.onym.android.chain.SepGroupType
 import app.onym.android.chain.SepTier
+import app.onym.android.chats.ChatMessage
 import app.onym.android.chats.ChatMessagePayload
 import app.onym.android.chats.ChatMessageVariant
+import app.onym.android.chats.ChatReceiptPayload
+import app.onym.android.chats.ChatReceiptSending
 import app.onym.android.chats.MessageDirection
 import app.onym.android.chats.MessageRepository
 import app.onym.android.chats.MessageStatus
@@ -229,6 +232,71 @@ class IncomingMessageDispatcherChatMessageTest {
 
     // ─── helpers ──────────────────────────────────────────────────
 
+    // ─── receipts ─────────────────────────────────────────────────
+
+    @Test
+    fun incomingChatMessage_shipsDeliveredReceiptToSender() = runTest {
+        val fx = newFixture()
+        fx.seedGroup(owner = ownerIdentity, withSenderProfile = true)
+        val spy = SpyReceiptSender()
+        val id = UUID.randomUUID()
+        fx.dispatchChat(ownerIdentity, chatPayload(id, "hi"), senderSendingKey, spy)
+        assertEquals(1, spy.sends.size)
+        assertEquals(ChatReceiptPayload.Kind.DELIVERED, spy.sends[0].kind)
+        assertEquals(listOf(id), spy.sends[0].messageIds)
+        assertTrue(spy.sends[0].recipientInboxKey.contentEquals(senderInbox))
+    }
+
+    @Test
+    fun receipt_delivered_raisesOutgoingToDelivered() = runTest {
+        val fx = newFixture()
+        val id = UUID.randomUUID()
+        fx.messageRepository.append(outgoingMessage(id, MessageStatus.SENT))
+        fx.dispatchReceipt(ownerIdentity, receipt(ChatReceiptPayload.Kind.DELIVERED, listOf(id)))
+        assertEquals(MessageStatus.DELIVERED, fx.messageStore.findById(id)?.status)
+    }
+
+    @Test
+    fun receipt_read_honoredOnlyWhenEnabled() = runTest {
+        val fx = newFixture()
+        val id = UUID.randomUUID()
+        fx.messageRepository.append(outgoingMessage(id, MessageStatus.DELIVERED))
+
+        fx.dispatchReceipt(
+            ownerIdentity,
+            receipt(ChatReceiptPayload.Kind.READ, listOf(id)),
+            readReceiptsEnabled = { false },
+        )
+        assertEquals(MessageStatus.DELIVERED, fx.messageStore.findById(id)?.status)
+
+        fx.dispatchReceipt(
+            ownerIdentity,
+            receipt(ChatReceiptPayload.Kind.READ, listOf(id)),
+            readReceiptsEnabled = { true },
+        )
+        assertEquals(MessageStatus.READ, fx.messageStore.findById(id)?.status)
+    }
+
+    private fun receipt(kind: ChatReceiptPayload.Kind, ids: List<UUID>) = ChatReceiptPayload(
+        version = 1,
+        groupId = groupIdBytes,
+        senderBlsPubkeyHex = senderBlsHex,
+        kind = kind,
+        messageIds = ids,
+    )
+
+    private fun outgoingMessage(id: UUID, status: MessageStatus) = ChatMessage(
+        id = id,
+        groupId = groupIdHex,
+        ownerIdentityId = ownerIdentity.value,
+        senderBlsPubkeyHex = "ff".repeat(48),
+        body = "mine",
+        sentAtMillis = 1_700_000_000_000L,
+        direction = MessageDirection.OUTGOING,
+        status = status,
+        groupType = SepGroupType.TYRANNY,
+    )
+
     private fun chatPayload(
         id: UUID,
         body: String,
@@ -320,6 +388,43 @@ class IncomingMessageDispatcherChatMessageTest {
                 receivedAt = Instant.EPOCH,
             )
         }
+
+        suspend fun dispatchChat(
+            owner: IdentityId,
+            payload: ChatMessagePayload,
+            signer: ByteArray?,
+            receiptSender: ChatReceiptSending,
+            readReceiptsEnabled: () -> Boolean = { true },
+        ) {
+            val plaintext = jsonFormat
+                .encodeToString(ChatMessagePayload.serializer(), payload)
+                .toByteArray(Charsets.UTF_8)
+            IncomingMessageDispatcher(
+                envelopeDecrypter = StubDecrypterChat(plaintext, signer),
+                groupRepository = groupRepository,
+                invitationsRepository = invitationsRepository,
+                messageRepository = messageRepository,
+                receiptSender = receiptSender,
+                readReceiptsEnabled = readReceiptsEnabled,
+            ).dispatch("env-${payload.messageId}", owner, byteArrayOf(), Instant.EPOCH)
+        }
+
+        suspend fun dispatchReceipt(
+            owner: IdentityId,
+            receipt: ChatReceiptPayload,
+            readReceiptsEnabled: () -> Boolean = { true },
+        ) {
+            val plaintext = jsonFormat
+                .encodeToString(ChatReceiptPayload.serializer(), receipt)
+                .toByteArray(Charsets.UTF_8)
+            IncomingMessageDispatcher(
+                envelopeDecrypter = StubDecrypterChat(plaintext, senderSendingKey),
+                groupRepository = groupRepository,
+                invitationsRepository = invitationsRepository,
+                messageRepository = messageRepository,
+                readReceiptsEnabled = readReceiptsEnabled,
+            ).dispatch("env-receipt", owner, byteArrayOf(), Instant.EPOCH)
+        }
     }
 
     private fun makeGroup(
@@ -345,6 +450,26 @@ class IncomingMessageDispatcherChatMessageTest {
 
     private companion object {
         private val jsonFormat = Json { encodeDefaults = true }
+    }
+}
+
+private class SpyReceiptSender : ChatReceiptSending {
+    data class Sent(
+        val kind: ChatReceiptPayload.Kind,
+        val messageIds: List<UUID>,
+        val groupId: ByteArray,
+        val recipientInboxKey: ByteArray,
+    )
+
+    val sends = mutableListOf<Sent>()
+
+    override suspend fun send(
+        kind: ChatReceiptPayload.Kind,
+        messageIds: List<UUID>,
+        groupId: ByteArray,
+        recipientInboxKey: ByteArray,
+    ) {
+        sends.add(Sent(kind, messageIds, groupId, recipientInboxKey))
     }
 }
 


### PR DESCRIPTION
Telegram-style replies in chat, wire-compatible with iOS (#173–#175). Swipe a message to reply; a banner shows what you're replying to; the sent message renders an inset quote (sender + snippet) above its text; tapping the quote jumps to the original.

## Wire contract (matches iOS exactly)
The chat payload gains one optional field: `reply_to_message_id` (snake_case) — the target message's UUID string, or absent/null for non-replies.

- **Additive + optional, so `version` stays `1`.** An older sender omits the key (decodes to null); an older receiver ignores it.
- Only the target id travels. The quoted sender/body are **not** snapshotted — the receiver resolves the quote live from its own local store at render time.
- No new trust gate on receive: a dangling/forged ref just renders "Message unavailable" (rendering only resolves locally-known messages).
- Replies ride the existing Tyranny-only chat path; other governance types stay unsupported.

## Changes

**Data layer** (iOS #173)
- `ChatMessagePayload` — optional `reply_to_message_id` (uppercase canonical UUID, same encoding as `message_id`).
- `ChatMessage` / `PersistedMessage` — plain (non-encrypted) reply pointer; it's just a row reference, left queryable.
- `MessageDatabase` v1 → v2 with a non-destructive `ALTER TABLE … ADD COLUMN` migration (wired ahead of the existing destructive fallback, so existing messages survive).
- `SendMessageInteractor.send` takes the ref (default null) → payload + optimistic row; `retry` reconstructs it from the stored row. `IncomingMessageDispatcher` maps the ref onto the inbound message.

**Render** (iOS #174)
- `ChatReplyQuote` + live resolution from the loaded list: found → quote with the target sender's name + accent + one-line snippet; missing → muted "Message unavailable", not tappable.
- Quote renders above the bubble body; tapping it scrolls to and briefly flashes the original.

**Compose** (iOS #175)
- Drag-to-reply on the bubble: it follows the finger leftward (clamped), a reply glyph grows in, a one-shot haptic fires at the threshold, and it springs back; releasing past the threshold arms the reply. Leftward-only so vertical scroll and the back-swipe are untouched.
- "Replying to {name}" banner above the composer with a cancel button; arming focuses the composer. The target threads through the VM's send and clears on send / cancel.

Strings ("Replying to {name}", "Message", "Message unavailable", "Cancel reply") are plain literals, matching the existing chat UI and the iOS choice.

## Tests
Payload round-trip + back-compat decode (missing / explicit-null key → null) + snake_case pin; store round-trip; inbound mapping carries the ref; send carries it on payload + persisted row and retry preserves it; quote resolution (found / missing / non-reply / fingerprint fallback); and VM arm / cancel / send-forwards-and-clears. Full `:app:testDebugUnitTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)